### PR TITLE
Fix:修复ZJMF上游对接、商品分类删除与前端主题/Loading样式

### DIFF
--- a/backend/app/Services/ProductCatalog/ProductAdminService.php
+++ b/backend/app/Services/ProductCatalog/ProductAdminService.php
@@ -671,6 +671,12 @@ class ProductAdminService
         throw_if(! $product->trashed(), new BusinessException('请先删除商品，再执行彻底删除'));
         throw_if($product->services()->count() > 0, new BusinessException('该商品已有服务实例，无法彻底删除'));
 
+        if (Schema::hasTable('product_upstream_bindings')) {
+            DB::table('product_upstream_bindings')
+                ->where('product_id', (int) $product->id)
+                ->delete();
+        }
+
         $product->forceDelete();
         $this->forgetSiteCatalogCache();
     }

--- a/backend/app/Services/ProductCatalog/ProductAdminService.php
+++ b/backend/app/Services/ProductCatalog/ProductAdminService.php
@@ -671,13 +671,17 @@ class ProductAdminService
         throw_if(! $product->trashed(), new BusinessException('请先删除商品，再执行彻底删除'));
         throw_if($product->services()->count() > 0, new BusinessException('该商品已有服务实例，无法彻底删除'));
 
-        if (Schema::hasTable('product_upstream_bindings')) {
-            DB::table('product_upstream_bindings')
-                ->where('product_id', (int) $product->id)
-                ->delete();
-        }
+        // 绑定清理与物理删除同事务：物理删除失败时保留绑定，避免软删商品丢失上游映射。
+        DB::transaction(function () use ($product): void {
+            if (Schema::hasTable('product_upstream_bindings')) {
+                DB::table('product_upstream_bindings')
+                    ->where('product_id', (int) $product->id)
+                    ->delete();
+            }
 
-        $product->forceDelete();
+            $product->forceDelete();
+        });
+
         $this->forgetSiteCatalogCache();
     }
 

--- a/backend/app/Services/ProductCatalog/ProductCategoryService.php
+++ b/backend/app/Services/ProductCatalog/ProductCategoryService.php
@@ -14,6 +14,7 @@ use App\Services\ProductCatalog\Concerns\HandlesProductCatalogHelpers;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class ProductCategoryService
@@ -209,21 +210,74 @@ class ProductCategoryService
             if ($level === 1) {
                 $group = $this->findFirstGroup($groupId);
                 throw_if($group->secondProductGroups()->exists(), new BusinessException('请先删除下级分类'));
-                throw_if(Product::query()->inFirstProductGroup((int) $group->id)->exists(), new BusinessException('请先迁移或删除该分类下的商品'));
+                $this->assertNoActiveProductsInGroup($groupId, fn (Builder $query) => $query->inFirstProductGroup($groupId));
+                $this->forceDeleteSoftDeletedProductsInGroup($groupId, fn (Builder $query) => $query->inFirstProductGroup($groupId));
                 $group->delete();
             } elseif ($level === 2) {
                 $group = $this->findSecondGroup($groupId);
                 throw_if($group->thirdProductGroups()->exists(), new BusinessException('请先删除下级分类'));
-                throw_if(Product::query()->inSecondProductGroup((int) $group->id)->exists(), new BusinessException('请先迁移或删除该分类下的商品'));
+                $this->assertNoActiveProductsInGroup($groupId, fn (Builder $query) => $query->inSecondProductGroup($groupId));
+                $this->forceDeleteSoftDeletedProductsInGroup($groupId, fn (Builder $query) => $query->inSecondProductGroup($groupId));
                 $group->delete();
             } else {
                 $group = $this->findThirdGroup($groupId);
-                throw_if($group->products()->exists(), new BusinessException('请先迁移或删除该分类下的商品'));
+                $this->assertNoActiveProductsInGroup($groupId, fn (Builder $query) => $query->where('product_group_id', $groupId));
+                $this->forceDeleteSoftDeletedProductsInGroup($groupId, fn (Builder $query) => $query->where('product_group_id', $groupId));
                 $group->delete();
             }
         });
 
         $this->forgetSiteCatalogCache();
+    }
+
+    /**
+     * 校验分组下不存在未删除商品（软删除商品由 forceDeleteSoftDeletedProductsInGroup 清理）。
+     *
+     * @param  \Closure(Builder): Builder  $scopeQuery
+     */
+    private function assertNoActiveProductsInGroup(int $groupId, \Closure $scopeQuery): void
+    {
+        $hasActive = Product::query()
+            ->withoutGlobalScopes()
+            ->whereNull('products.deleted_at')
+            ->tap($scopeQuery)
+            ->exists();
+
+        throw_if($hasActive, new BusinessException('请先迁移或删除该分类下的商品'));
+    }
+
+    /**
+     * 物理删除分组下已软删除的商品，避免其外键引用阻塞分组删除。
+     * 软删除商品的上游绑定（product_upstream_bindings）一并清除。
+     *
+     * @param  \Closure(Builder): Builder  $scopeQuery
+     */
+    private function forceDeleteSoftDeletedProductsInGroup(int $groupId, \Closure $scopeQuery): void
+    {
+        $trashedProductIds = Product::query()
+            ->withoutGlobalScopes()
+            ->whereNotNull('products.deleted_at')
+            ->tap($scopeQuery)
+            ->pluck('products.id')
+            ->map(fn ($id) => (int) $id)
+            ->filter(fn (int $id): bool => $id > 0)
+            ->values()
+            ->all();
+
+        if ($trashedProductIds === []) {
+            return;
+        }
+
+        if (Schema::hasTable('product_upstream_bindings')) {
+            DB::table('product_upstream_bindings')
+                ->whereIn('product_id', $trashedProductIds)
+                ->delete();
+        }
+
+        Product::query()
+            ->withoutGlobalScopes()
+            ->whereIn('products.id', $trashedProductIds)
+            ->forceDelete();
     }
 
     public function reorderAdminCategories(int $level, ?int $parentGroupId, array $groupIds): array

--- a/backend/app/Services/ProductCatalog/ProductSyncService.php
+++ b/backend/app/Services/ProductCatalog/ProductSyncService.php
@@ -1210,10 +1210,13 @@ class ProductSyncService
             return [];
         }
 
+        // 上游金额是两位小数字符串（如 '19.99'）。周期换算先转为“分”整数再相乘，
+        // 避免浮点乘法（如 19.99 * 12 = 239.87999...）在边界产生一分钱误差。
+        $monthlyBaseCents = (int) round(((float) $monthlyBasePrice) * 100);
         $pricing = [];
 
         foreach (self::IMPORT_PRICING_MONTHS as $cycle => $months) {
-            $pricing[$cycle] = number_format($monthlyBasePrice * $months, 2, '.', '');
+            $pricing[$cycle] = number_format($monthlyBaseCents * $months / 100, 2, '.', '');
         }
 
         return $pricing;

--- a/backend/app/Services/ProductCatalog/ProductSyncService.php
+++ b/backend/app/Services/ProductCatalog/ProductSyncService.php
@@ -218,6 +218,19 @@ class ProductSyncService
             ->filter(fn ($item) => is_array($item) && (int) ($item['id'] ?? 0) > 0)
             ->keyBy(fn (array $item) => (int) ($item['id'] ?? 0));
 
+        // ZJMF 等上游的列表接口不返回价格，价格需要按选中的商品单独补充，
+        // 避免批量对接时因缺少可导入价格而全部跳过。
+        if (method_exists($catalogCapability, 'hydrateSelectedPricing')) {
+            $catalog['products'] = $catalogCapability->hydrateSelectedPricing(
+                $supplier,
+                $catalog['products'] ?? [],
+                $supplierProductIds->all(),
+            );
+            $catalogProducts = collect($catalog['products'] ?? [])
+                ->filter(fn ($item) => is_array($item) && (int) ($item['id'] ?? 0) > 0)
+                ->keyBy(fn (array $item) => (int) ($item['id'] ?? 0));
+        }
+
         $existingProducts = $this->findExistingProductsBySupplierUpstreamIds($supplier, $supplierProductIds->all());
 
         $defaultStatus = (int) ($data['default_status'] ?? 1) === 1 ? 1 : 0;

--- a/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
+++ b/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
@@ -663,6 +663,38 @@ class HostingPanelApiTransport implements ProvidesConsoleAccess, ProvidesConsole
         $httpCode = $this->resolveHttpCode($responseHeaders);
         $contentType = $this->resolveHeaderValue($responseHeaders, 'Content-Type');
 
+        // WAF 挑战页自动会话：部分上游（如 idcxl 系）在无 cookie 时返回
+        // <script>document.cookie = 'xxx_token=...; path=/'</script> 形式的 JS 挑战页，
+        // 携带该 cookie 重试一次即可正常返回 JSON。仅重试一次，避免死循环。
+        if ($output !== false
+            && ! is_array(json_decode($output, true))
+            && $this->looksLikeHtmlResponse((string) $output, $contentType)
+            && ! $this->hasCookieHeader($requestHeaders)
+        ) {
+            $challengeCookie = $this->extractChallengeCookie((string) $output);
+            if ($challengeCookie !== '') {
+                $this->safeLog('info', '[主机面板接口] 检测到 WAF 挑战页，携带会话 cookie 重试', [
+                    'supplier_id' => $supplier->id,
+                    'method' => $method,
+                    'url' => $this->maskUrlForLog($url),
+                    'cookie_name' => $this->maskChallengeCookieName($challengeCookie),
+                ]);
+
+                $retryHeaders = [...$requestHeaders, 'Cookie: '.$challengeCookie];
+                $retryContext = stream_context_create($this->buildContextOptions($method, $retryHeaders, $body));
+                error_clear_last();
+                $retryOutput = @file_get_contents($url, false, $retryContext);
+                $retryHeadersRaw = is_array($http_response_header) ? $http_response_header : [];
+
+                if ($retryOutput !== false) {
+                    $output = $retryOutput;
+                    $responseHeaders = $retryHeadersRaw;
+                    $httpCode = $this->resolveHttpCode($responseHeaders);
+                    $contentType = $this->resolveHeaderValue($responseHeaders, 'Content-Type');
+                }
+            }
+        }
+
         if ($output === false) {
             $this->safeLog('error', '[主机面板接口] 接口请求失败', [
                 'supplier_id' => $supplier->id,
@@ -702,6 +734,30 @@ class HostingPanelApiTransport implements ProvidesConsoleAccess, ProvidesConsole
             'http_code' => $httpCode,
             'content_type' => $contentType,
         ];
+    }
+
+    /**
+     * 从 WAF JS 挑战页中提取会话 cookie（如 document.cookie = 'yxd_token=xxx; path=/'）。
+     */
+    private function extractChallengeCookie(string $body): string
+    {
+        if (preg_match("/document\.cookie\s*=\s*['\"]?([A-Za-z0-9_\-]+)=([^;'\"\s]+)/", $body, $matches) === 1) {
+            $name = trim((string) $matches[1]);
+            $value = trim((string) $matches[2]);
+
+            if ($name !== '' && $value !== '') {
+                return $name.'='.$value;
+            }
+        }
+
+        return '';
+    }
+
+    private function maskChallengeCookieName(string $cookie): string
+    {
+        $name = strtok($cookie, '=') ?: 'cookie';
+
+        return substr($name, 0, 2).'***'.substr($name, -2);
     }
 
     private function applyUserAgent(): void

--- a/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
+++ b/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
@@ -666,8 +666,13 @@ class HostingPanelApiTransport implements ProvidesConsoleAccess, ProvidesConsole
         // WAF 挑战页自动会话：部分上游（如 idcxl 系）在无 cookie 时返回
         // <script>document.cookie = 'xxx_token=...; path=/'</script> 形式的 JS 挑战页，
         // 携带该 cookie 重试一次即可正常返回 JSON。仅重试一次，避免死循环。
+        // 重试前提收紧为“WAF 标记 + 典型状态码”双条件：
+        // - extractChallengeCookie 命中 document.cookie 赋值语句（WAF JS 挑战页强特征，
+        //   业务异常页不会携带该标记），说明请求被 WAF 拦截在业务处理之前；
+        // - 状态码仅 200/403（挑战页典型响应），排除 4xx/5xx 业务错误页被误重放。
         if ($output !== false
             && ! is_array(json_decode($output, true))
+            && in_array($httpCode, [200, 403], true)
             && $this->looksLikeHtmlResponse((string) $output, $contentType)
             && ! $this->hasCookieHeader($requestHeaders)
         ) {

--- a/backend/plugins/certification/smapi/README.md
+++ b/backend/plugins/certification/smapi/README.md
@@ -1,0 +1,51 @@
+# 聚合实名认证插件（smapi）
+
+对接小沐实名 API（https://smapi.x1m1.cn）的实名认证插件。
+
+## 目录
+
+```text
+backend/plugins/certification/smapi/
+├── SmapiPlugin.php       # 入口类（execute 分发）
+├── config.php            # 插件清单与配置 schema
+├── logic/
+│   ├── Smapi.php         # action 分发、回调与计费配置
+│   └── SmapiClient.php   # 上游 HTTP 客户端（自包含）
+└── README.md
+```
+
+## 配置项
+
+| 字段           | 类型     | 必填 | 说明                                             |
+| -------------- | -------- | ---- | ------------------------------------------------ |
+| `api_url`      | url      | 否   | 平台地址，默认 `https://smapi.x1m1.cn`           |
+| `app_key`      | text     | 是   | 用户中心 API 密钥 AppKey                         |
+| `secret_key`   | password | 是   | 用户中心 API 密钥 AppSecret（加密保存）          |
+| `product_code` | textarea | 是   | 产品标识；多产品按 `code,名称|code,名称` 填写     |
+| `ssl_verify`   | switch   | 否   | 是否校验服务商 HTTPS 证书，默认开启              |
+| `ca_bundle`    | text     | 否   | 本地 CA bundle 文件路径                          |
+| `charge_enabled` | switch | 否 | 开启后用户发起认证按配置金额扣费                 |
+| `amount`       | number   | 否   | 收费金额（元）                                   |
+| `free_times`   | number   | 否   | 每个用户免费认证次数                             |
+
+## 接口行为
+
+- `certification.initialize`：调用 `POST /api/realname/initialize` 创建认证记录，
+  请求体为 `product_code`（取配置中第一个有效产品标识）、`cert_name`、`cert_no`、`return_url`，
+  成功后返回上游记录 `id` 作为 `certify_id`。
+- `certification.scan_url`：调用查询接口，从返回数据中提取认证页面链接
+  （`certify_page_url` / `certify_url` / `url` / `qrcode_url` / `qr_code_url`）。
+- `certification.query_status`：状态映射为项目内部约定：
+  `passed` → 1（通过）、`failed` / `updated` → 2（不通过，带失败原因）、
+  `initialized` / `processing` → 4（处理中）、网络异常 → 3（保留原状态）。
+- `certification.verify_callback`：平台不提供服务端签名回调，固定返回不支持（501），
+  认证结果一律通过轮询查询获得。
+- `certification.fee_config`：按 `charge_enabled` / `amount` / `free_times` 输出计费配置。
+
+## 注意事项
+
+- 当前用户端实名流程不收集手机号（`initialize` 不传 `mobile`），
+  如配置的产品强制要求手机号三要素，请与服务商确认接口行为或选择不强制手机号的产品。
+- 多产品配置时客户前台的“认证接口”下拉选择在当前用户端未实现，
+  当前始终使用配置中第一个产品标识发起认证。
+- 密钥通过 `secret=true` 加密保存且不明文回显。

--- a/backend/plugins/certification/smapi/SmapiPlugin.php
+++ b/backend/plugins/certification/smapi/SmapiPlugin.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\Smapi;
+
+use TuraIDC\Plugins\Certification\Smapi\Logic\Smapi;
+
+class SmapiPlugin extends Smapi {}

--- a/backend/plugins/certification/smapi/config.php
+++ b/backend/plugins/certification/smapi/config.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use TuraIDC\Plugins\Certification\Smapi\SmapiPlugin;
+
+return [
+    'info' => [
+        'domain' => 'verification',
+        'slug' => 'smapi',
+        'key' => 'smapi',
+        'name' => '聚合实名认证',
+        'version' => '1.0.0',
+        'entry' => SmapiPlugin::class,
+        'capabilities' => ['personal', 'scan_url', 'query_status', 'verify_callback', 'fee_config'],
+        'extra' => [
+            'driver_binding' => [
+                'binding_key' => 'verification_driver',
+                'provider_key' => 'smapi',
+            ],
+        ],
+    ],
+    'config' => [
+        'basic_notice' => [
+            'title' => '配置说明',
+            'type' => 'notice',
+            'theme' => 'info',
+            'content' => '对接小沐实名 API（smapi.x1m1.cn）聚合实名平台。请填写用户中心分配的 AppKey、AppSecret 与产品标识；密钥保存后不会明文回显。',
+        ],
+        'api_url' => [
+            'title' => 'API 地址',
+            'type' => 'url',
+            'value' => 'https://smapi.x1m1.cn',
+            'required' => false,
+            'placeholder' => 'https://smapi.x1m1.cn',
+            'description' => '聚合实名平台地址，一般保持默认，只有服务商要求时才修改。',
+        ],
+        'app_key' => [
+            'title' => 'AppKey',
+            'type' => 'text',
+            'value' => '',
+            'required' => true,
+            'placeholder' => '请输入用户中心 API 密钥 AppKey',
+            'description' => '用户中心 API 密钥 AppKey。',
+        ],
+        'secret_key' => [
+            'title' => 'AppSecret',
+            'type' => 'password',
+            'value' => '',
+            'required' => true,
+            'secret' => true,
+            'placeholder' => '请输入用户中心 API 密钥 AppSecret',
+            'description' => '已配置时不会明文回显，留空表示不修改。',
+        ],
+        'product_code' => [
+            'title' => '产品标识',
+            'type' => 'textarea',
+            'value' => '',
+            'required' => true,
+            'rows' => 4,
+            'placeholder' => "alipay_v3\n或 alipay_v3,支付宝身份认证|tencent_sm,微信实名认证",
+            'description' => '单个接口直接填写产品标识，例如 alipay_v3；多个接口按“产品标识,显示名称|产品标识,显示名称”填写，多个产品时取第一个作为默认认证产品。',
+        ],
+        'ssl_verify' => [
+            'title' => 'SSL 证书校验',
+            'type' => 'switch',
+            'value' => true,
+            'description' => '开启后校验服务商 HTTPS 证书；证书链异常时可关闭或配置 CA 证书路径。',
+        ],
+        'ca_bundle' => [
+            'title' => 'CA 证书路径',
+            'type' => 'text',
+            'value' => '',
+            'required' => false,
+            'placeholder' => '例如 /etc/ssl/certs/cacert.pem',
+            'description' => '可选，填写服务器本地 CA bundle 文件路径。',
+        ],
+        'billing_divider' => ['title' => '计费设置', 'type' => 'divider'],
+        'charge_enabled' => [
+            'title' => '插件收费',
+            'type' => 'switch',
+            'value' => false,
+            'description' => '开启后，用户发起实名认证时按配置金额扣费。',
+        ],
+        'amount' => [
+            'title' => '收费金额',
+            'type' => 'number',
+            'value' => 0,
+            'min' => 0,
+            'step' => 0.01,
+            'description' => '单位：元。关闭收费时该字段不生效。',
+            'visible_when' => ['field' => 'charge_enabled', 'operator' => 'eq', 'value' => true],
+        ],
+        'free_times' => [
+            'title' => '免费次数',
+            'type' => 'number',
+            'value' => 0,
+            'min' => 0,
+            'step' => 1,
+            'description' => '每个用户可免费发起认证的次数。',
+        ],
+    ],
+];

--- a/backend/plugins/certification/smapi/logic/Smapi.php
+++ b/backend/plugins/certification/smapi/logic/Smapi.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\Smapi\Logic;
+
+class Smapi
+{
+    private ?SmapiClient $client = null;
+
+    public function key(): string
+    {
+        return 'smapi';
+    }
+
+    public function label(): string
+    {
+        return '聚合实名认证';
+    }
+
+    /**
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     */
+    public function execute(array $request): array
+    {
+        $action = trim((string) ($request['action'] ?? ''));
+        $payload = is_array($request['payload'] ?? null) ? $request['payload'] : [];
+        $config = is_array($request['config'] ?? null) ? $request['config'] : [];
+
+        $client = $this->client($config);
+
+        return match ($action) {
+            'certification.initialize' => $this->success($action, $client->initialize(
+                realName: (string) ($payload['real_name'] ?? ''),
+                idCard: (string) ($payload['id_card'] ?? ''),
+                returnUrl: (string) ($payload['return_url'] ?? ''),
+            )),
+            'certification.scan_url' => $this->success($action, $client->scanUrl(
+                (string) ($payload['certify_id'] ?? '')
+            )),
+            'certification.query_status' => $this->success($action, $client->queryStatus(
+                (string) ($payload['certify_id'] ?? '')
+            )),
+            'certification.verify_callback' => $this->success($action, $this->verifyCallback()),
+            'certification.fee_config' => $this->success($action, $this->feeConfig($config)),
+            default => [
+                'success' => false,
+                'action' => $action,
+                'message' => 'Unsupported plugin action',
+                'data' => [],
+            ],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function client(array $config): SmapiClient
+    {
+        if ($this->client === null) {
+            $this->client = new SmapiClient($config);
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{success: bool, action: string, data: array<string, mixed>}
+     */
+    private function success(string $action, array $data): array
+    {
+        return [
+            'success' => true,
+            'action' => $action,
+            'data' => $data,
+        ];
+    }
+
+    /**
+     * 聚合实名平台不提供服务端签名回调，认证结果通过轮询 query_status 获取。
+     *
+     * @return array{passed: bool, message: string, code: int, http_status: int}
+     */
+    private function verifyCallback(): array
+    {
+        return [
+            'passed' => false,
+            'message' => '聚合实名平台不支持服务端签名回调，请使用轮询查询认证结果',
+            'code' => 40001,
+            'http_status' => 501,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @return array{free_attempts: int, retry_fee: float, free_times: int, amount: float, charge_enabled: bool}
+     */
+    private function feeConfig(array $config): array
+    {
+        $chargeEnabled = filter_var($config['charge_enabled'] ?? false, FILTER_VALIDATE_BOOL);
+        $amount = max(0.0, (float) ($config['amount'] ?? 0));
+        $freeTimes = max(0, (int) ($config['free_times'] ?? $config['free_attempts'] ?? 0));
+
+        return [
+            'free_attempts' => $freeTimes,
+            'retry_fee' => $chargeEnabled ? $amount : 0.0,
+            'free_times' => $freeTimes,
+            'amount' => $amount,
+            'charge_enabled' => $chargeEnabled,
+        ];
+    }
+}

--- a/backend/plugins/certification/smapi/logic/SmapiClient.php
+++ b/backend/plugins/certification/smapi/logic/SmapiClient.php
@@ -1,0 +1,412 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\Smapi\Logic;
+
+use App\Exceptions\BusinessException;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 聚合实名（smapi.x1m1.cn）HTTP 客户端 — 完全自包含，不依赖内核驱动。
+ *
+ * 接口约定：
+ * - POST /api/realname/initialize                    初始化认证
+ * - GET  /api/realname/certifications/{id}/query     查询认证状态与认证页面链接
+ * - 鉴权头：X-App-Key / X-App-Secret
+ * - 业务成功：HTTP 2xx 且 body.status === 200 或 body.code === 20000
+ */
+class SmapiClient
+{
+    private const DEFAULT_API_ENDPOINT = 'https://smapi.x1m1.cn';
+
+    private ?array $lastRequestFailure = null;
+
+    /**
+     * @param  array<string, mixed>  $config  插件配置（来自 execute() 的 $request['config']）
+     */
+    public function __construct(
+        private readonly array $config,
+    ) {}
+
+    /**
+     * 初始化实名认证。
+     *
+     * @return array{status: int, message: string, certify_id?: string, raw?: array}
+     */
+    public function initialize(string $realName, string $idCard, string $returnUrl): array
+    {
+        $productCode = $this->defaultProductCode();
+        if ($productCode === '') {
+            return ['status' => 400, 'message' => '请先配置产品标识 product_code'];
+        }
+
+        $result = $this->request('POST', '/api/realname/initialize', [
+            'product_code' => $productCode,
+            'cert_name' => $realName,
+            'cert_no' => $idCard,
+            'return_url' => $returnUrl,
+        ]);
+
+        if ($result === null) {
+            return ['status' => 500, 'message' => $this->getLastFailureMessage()];
+        }
+
+        if ($this->isBusinessSuccess($result)) {
+            $data = $this->resultData($result);
+            $certifyId = trim((string) ($data['id'] ?? ''));
+
+            if ($certifyId !== '') {
+                return [
+                    'status' => 200,
+                    'message' => $this->safeProviderMessage($result['msg'] ?? '', '认证初始化成功'),
+                    'certify_id' => $certifyId,
+                    'raw' => $data,
+                ];
+            }
+
+            return [
+                'status' => 400,
+                'message' => '聚合实名平台返回异常：未返回认证标识',
+                'raw' => $data,
+            ];
+        }
+
+        return [
+            'status' => 400,
+            'message' => $this->safeProviderMessage($this->resultMessage($result), '实名认证接口配置错误，请联系管理员'),
+            'raw' => $this->resultData($result),
+        ];
+    }
+
+    /**
+     * 获取认证链接（复用查询接口回显的认证页面地址）。
+     *
+     * @return array{status: int, message: string, url?: string, raw?: array}
+     */
+    public function scanUrl(string $certifyId): array
+    {
+        $result = $this->query($certifyId);
+
+        if ($result === null) {
+            return ['status' => 500, 'message' => $this->getLastFailureMessage()];
+        }
+
+        if (! $this->isBusinessSuccess($result)) {
+            return [
+                'status' => 400,
+                'message' => $this->safeProviderMessage($this->resultMessage($result), '获取认证链接失败，请联系管理员'),
+                'raw' => $this->resultData($result),
+            ];
+        }
+
+        $data = $this->resultData($result);
+        $url = $this->extractCertificationUrl($data);
+
+        if ($url === '') {
+            return [
+                'status' => 400,
+                'message' => '获取认证链接失败，请联系管理员',
+                'raw' => $data,
+            ];
+        }
+
+        return [
+            'status' => 200,
+            'message' => '请打开实名认证链接继续认证',
+            'url' => $url,
+            'raw' => $data,
+        ];
+    }
+
+    /**
+     * 查询认证状态。
+     *
+     * 状态码遵循项目内部约定：1=通过、2=不通过、3=网络错误、4=处理中。
+     *
+     * @return array{status: int, message: string, raw?: array}
+     */
+    public function queryStatus(string $certifyId): array
+    {
+        $result = $this->query($certifyId);
+
+        if ($result === null) {
+            return ['status' => 3, 'message' => $this->getLastFailureMessage()];
+        }
+
+        if (! $this->isBusinessSuccess($result)) {
+            // 查询接口业务失败不判失败，按“处理中”处理，等待下次轮询。
+            return ['status' => 4, 'message' => '认证处理中', 'raw' => $this->resultData($result)];
+        }
+
+        $data = $this->resultData($result);
+        $status = (string) ($data['status'] ?? '');
+
+        if ($status === 'passed') {
+            return ['status' => 1, 'message' => '审核通过', 'raw' => $data];
+        }
+
+        if ($status === 'failed' || $status === 'updated') {
+            $reason = trim((string) ($data['fail_reason'] ?? ''));
+
+            return [
+                'status' => 2,
+                'message' => $reason !== '' ? $this->safeProviderMessage($reason, '审核未通过') : '审核未通过',
+                'raw' => $data,
+            ];
+        }
+
+        $map = [
+            'initialized' => '待认证，请先完成扫码认证',
+            'processing' => '认证处理中，请稍后再获取结果',
+        ];
+
+        return [
+            'status' => 4,
+            'message' => isset($map[$status]) ? $map[$status] : '认证处理中',
+            'raw' => $data,
+        ];
+    }
+
+    /**
+     * @return array|null 上游原始响应；网络或解析失败返回 null
+     */
+    private function query(string $certifyId): ?array
+    {
+        return $this->request('GET', '/api/realname/certifications/'.rawurlencode($certifyId).'/query');
+    }
+
+    private function request(string $method, string $path, array $params = []): ?array
+    {
+        $this->lastRequestFailure = null;
+
+        $url = rtrim($this->resolveEndpoint(), '/').$path;
+
+        try {
+            $http = Http::withOptions($this->sslOptions())
+                ->withHeaders([
+                    'X-App-Key' => $this->resolveAppKey(),
+                    'X-App-Secret' => $this->resolveAppSecret(),
+                    'Accept' => 'application/json',
+                    'Content-Type' => 'application/json',
+                ])
+                ->timeout(30)
+                ->connectTimeout(10);
+
+            $response = $method === 'POST'
+                ? $http->post($url, $params)
+                : $http->get($url);
+        } catch (ConnectionException $exception) {
+            $this->lastRequestFailure = ['type' => 'connection', 'error' => $exception->getMessage()];
+            Log::error('[实名认证] 请求聚合实名平台失败', ['error' => $exception->getMessage()]);
+
+            return null;
+        }
+
+        $body = trim($response->body(), "\xEF\xBB\xBF");
+        $decoded = json_decode($body, true);
+
+        if (! is_array($decoded)) {
+            $this->lastRequestFailure = [
+                'type' => 'invalid_json',
+                'raw' => mb_substr($body, 0, 200),
+                'http_status' => $response->status(),
+            ];
+
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    private function resolveEndpoint(): string
+    {
+        return (string) ($this->config['api_url'] ?? self::DEFAULT_API_ENDPOINT);
+    }
+
+    private function resolveAppKey(): string
+    {
+        $value = trim((string) ($this->config['app_key'] ?? ''));
+        if ($value === '') {
+            throw new BusinessException('实名认证接口未配置，请先在管理端填写 API 信息', 42200);
+        }
+
+        return $value;
+    }
+
+    private function resolveAppSecret(): string
+    {
+        $value = trim((string) ($this->config['secret_key'] ?? ''));
+        if ($value === '') {
+            throw new BusinessException('实名认证接口未配置，请先在管理端填写 API 信息', 42200);
+        }
+
+        return $value;
+    }
+
+    /**
+     * 配置中声明的第一个有效产品标识；未配置时返回空串。
+     */
+    private function defaultProductCode(): string
+    {
+        $products = $this->parseProducts();
+        if ($products === []) {
+            return '';
+        }
+
+        return (string) array_key_first($products);
+    }
+
+    /**
+     * @return array<string, string> 产品标识 => 显示名称
+     */
+    private function parseProducts(): array
+    {
+        $value = trim((string) ($this->config['product_code'] ?? ''));
+        $products = [];
+
+        foreach (explode('|', $value) as $item) {
+            $item = trim($item);
+            if ($item === ''
+                || str_contains($item, '填写说明')
+                || str_contains($item, '请删除本说明')
+                || str_contains($item, '例如：')) {
+                continue;
+            }
+
+            $parts = explode(',', $item, 2);
+            $code = trim($parts[0]);
+            if ($code === '') {
+                continue;
+            }
+
+            $products[$code] = isset($parts[1]) && trim($parts[1]) !== '' ? trim($parts[1]) : $code;
+        }
+
+        return $products;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function extractCertificationUrl(array $data): string
+    {
+        foreach (['certify_page_url', 'certify_url', 'url', 'qrcode_url', 'qr_code_url'] as $field) {
+            $value = trim((string) ($data[$field] ?? ''));
+            if ($value !== '' && $value !== '-') {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function isBusinessSuccess(array $result): bool
+    {
+        return (isset($result['status']) && (int) $result['status'] === 200)
+            || (isset($result['code']) && (int) $result['code'] === 20000);
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function resultData(array $result): array
+    {
+        return isset($result['data']) && is_array($result['data']) ? $result['data'] : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function resultMessage(array $result): string
+    {
+        $message = trim((string) ($result['msg'] ?? $result['message'] ?? ''));
+
+        return $message !== '' ? $message : '聚合实名平台请求失败';
+    }
+
+    private function getLastFailureMessage(): string
+    {
+        if (! is_array($this->lastRequestFailure)) {
+            return '网络请求失败，请稍后重试';
+        }
+
+        if (($this->lastRequestFailure['type'] ?? '') === 'connection') {
+            if ($this->isSslFailure($this->lastRequestFailure)) {
+                return '实名认证接口 SSL 证书校验失败，请检查插件 CA 证书配置';
+            }
+
+            return '实名认证接口请求失败，请稍后重试';
+        }
+
+        return '实名认证接口返回异常';
+    }
+
+    /**
+     * @return array<string, mixed> Http::withOptions 的 SSL 选项
+     */
+    private function sslOptions(): array
+    {
+        if (! $this->resolveSslVerify()) {
+            return ['verify' => false];
+        }
+
+        $caBundle = $this->resolveCaBundle();
+        if ($caBundle !== '' && is_file($caBundle)) {
+            return ['verify' => $caBundle];
+        }
+
+        return [];
+    }
+
+    private function resolveSslVerify(): bool
+    {
+        $value = $this->config['ssl_verify'] ?? null;
+        if ($value !== null && $value !== '') {
+            return filter_var($value, FILTER_VALIDATE_BOOL);
+        }
+
+        return filter_var(config('idc.verification.ssl_verify', true), FILTER_VALIDATE_BOOL);
+    }
+
+    private function resolveCaBundle(): string
+    {
+        $value = $this->config['ca_bundle'] ?? null;
+        if ($value !== null && $value !== '') {
+            return trim((string) $value);
+        }
+
+        return trim((string) config('idc.verification.ca_bundle', ''));
+    }
+
+    /**
+     * @param  array<string, mixed>  $failure
+     */
+    private function isSslFailure(array $failure): bool
+    {
+        $message = strtolower((string) ($failure['error'] ?? ''));
+
+        return str_contains($message, 'ssl') || str_contains($message, 'certificate');
+    }
+
+    private function safeProviderMessage(mixed $message, string $fallback): string
+    {
+        $text = trim((string) $message);
+        if ($text === '') {
+            return $fallback;
+        }
+
+        // 服务商文案预期为中文；出现连续英文字母一律视为技术细节，直接回退到安全文案。
+        if (preg_match('/[a-z]{3,}/i', $text) === 1) {
+            return $fallback;
+        }
+
+        return $text;
+    }
+}

--- a/backend/plugins/servers/zjmf_finance/lib/ZjmfCatalogService.php
+++ b/backend/plugins/servers/zjmf_finance/lib/ZjmfCatalogService.php
@@ -6,6 +6,7 @@ namespace TuraIDC\Plugins\Servers\ZjmfFinance\Lib;
 
 use App\Exceptions\BusinessException;
 use App\Models\Supplier;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 final class ZjmfCatalogService
@@ -67,6 +68,137 @@ final class ZjmfCatalogService
         $response = $this->transport->get($supplier, '/cart/all', $this->transport->login($supplier));
 
         return $this->normalizeProductCatalog($response);
+    }
+
+    /**
+     * 批量对接时按需补充选中商品的价格（ZJMF 的 /cart/all 列表不含价格，
+     * 价格在 /cart/get_product_config 的 product_pricings 中）。
+     *
+     * @param  array<int, array<string, mixed>>  $products
+     * @param  array<int, int>  $selectedIds
+     * @return array<int, array<string, mixed>> 回填价格后的商品列表
+     */
+    public function hydrateSelectedPricing(Supplier $supplier, array $products, array $selectedIds): array
+    {
+        $selectedIdSet = collect($selectedIds)
+            ->map(fn ($id) => (int) $id)
+            ->filter(fn (int $id) => $id > 0)
+            ->unique()
+            ->flip();
+
+        if ($selectedIdSet->isEmpty()) {
+            return $products;
+        }
+
+        $productsById = collect($products)
+            ->filter(fn (array $product): bool => $selectedIdSet->has((int) ($product['id'] ?? 0)))
+            ->keyBy(fn (array $product): int => (int) ($product['id'] ?? 0))
+            ->all();
+
+        if ($productsById === []) {
+            return $products;
+        }
+
+        $pricingMap = $this->fetchBatchProductPricing($supplier, array_keys($productsById));
+
+        return collect($products)
+            ->map(function (array $product) use ($pricingMap): array {
+                $productId = (int) ($product['id'] ?? 0);
+                $pricing = $pricingMap[$productId] ?? null;
+
+                if (! is_array($pricing) || $pricing === []) {
+                    return $product;
+                }
+
+                return array_replace($product, [
+                    'product_price' => $pricing['monthly_price'] ?? $pricing['product_price'] ?? $product['product_price'] ?? null,
+                    'monthly_price' => $pricing['monthly_price'] ?? $product['monthly_price'] ?? null,
+                    'billingcycle' => trim((string) ($pricing['billingcycle'] ?? $product['billingcycle'] ?? '')) !== ''
+                        ? (string) $pricing['billingcycle']
+                        : $product['billingcycle'] ?? '',
+                    'setup_fee' => $pricing['setup_fee'] ?? $product['setup_fee'] ?? null,
+                ]);
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, int>  $productIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchBatchProductPricing(Supplier $supplier, array $productIds, int $chunkSize = 8): array
+    {
+        $chunkSize = max(1, min($chunkSize, 12));
+        $results = [];
+
+        foreach (array_chunk($productIds, $chunkSize) as $chunk) {
+            foreach ($chunk as $productId) {
+                try {
+                    // 使用串行 requestWithMeta（含 WAF 挑战页 cookie 自动重试），
+                    // parallelGet 走 Http::pool 不经过该逻辑，会被上游 WAF 拦截。
+                    $response = $this->transport->get(
+                        $supplier,
+                        '/cart/get_product_config',
+                        null,
+                        ['pid' => $productId],
+                    );
+                    $pricing = is_array($response) ? $this->extractProductPricingFromResponse($response) : [];
+                    if ($pricing !== []) {
+                        $results[$productId] = $pricing;
+                    }
+                } catch (\Throwable $exception) {
+                    Log::warning('[ZJMF 财务接口] 单个商品价格补充失败', [
+                        'supplier_id' => $supplier->id,
+                        'product_id' => $productId,
+                        'message' => $exception->getMessage(),
+                    ]);
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * 从 /cart/get_product_config 响应中提取商品基础价格（product_pricings 的 monthly 等）。
+     *
+     * @return array<string, mixed>
+     */
+    private function extractProductPricingFromResponse(array $response): array
+    {
+        $data = is_array($response['data'] ?? null) ? $response['data'] : $response;
+        $pricings = is_array($data['product_pricings'] ?? null) ? $data['product_pricings'] : [];
+
+        foreach ($pricings as $pricing) {
+            if (! is_array($pricing)) {
+                continue;
+            }
+
+            $type = trim((string) ($pricing['type'] ?? ''));
+            if ($type !== '' && $type !== 'product') {
+                continue;
+            }
+
+            $monthly = $this->normalizeCatalogAmount($pricing['monthly'] ?? null);
+            $productPrice = $this->normalizeCatalogAmount($pricing['monthly'] ?? $pricing['product_price'] ?? null);
+
+            if ($monthly === null && $productPrice === null) {
+                continue;
+            }
+
+            $billingCycle = strtolower(trim((string) ($pricing['billingcycle'] ?? '')));
+            $billingCycle = $billingCycle !== '' && $billingCycle !== 'monthly' ? $billingCycle : 'monthly';
+
+            return [
+                'monthly_price' => $monthly,
+                'product_price' => $productPrice,
+                'billingcycle' => $billingCycle,
+                'setup_fee' => $this->normalizeCatalogAmount($pricing['msetupfee'] ?? null),
+            ];
+        }
+
+        return [];
     }
 
     public function getProductConfigTemplate(Supplier $supplier, int $productId): array

--- a/backend/plugins/servers/zjmf_finance/lib/ZjmfFinanceAdapter.php
+++ b/backend/plugins/servers/zjmf_finance/lib/ZjmfFinanceAdapter.php
@@ -96,6 +96,11 @@ final class ZjmfFinanceAdapter implements ProvidesConsoleAccess, ProvidesConsole
         return $this->catalogService->getProductCatalog($supplier);
     }
 
+    public function hydrateSelectedPricing(Supplier $supplier, array $products, array $selectedIds): array
+    {
+        return $this->catalogService->hydrateSelectedPricing($supplier, $products, $selectedIds);
+    }
+
     public function fetchRealConfigOptions(Supplier $supplier, int $productId): array
     {
         return $this->catalogService->fetchRealConfigOptions($supplier, $productId);

--- a/backend/tests/Feature/SmapiPluginTest.php
+++ b/backend/tests/Feature/SmapiPluginTest.php
@@ -1,0 +1,643 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Exceptions\BusinessException;
+use App\Services\Integrations\Plugins\PluginFileLoader;
+use App\Services\Integrations\Plugins\PluginScanner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use TuraIDC\Plugins\Certification\Smapi\Logic\Smapi;
+use Tests\TestCase;
+
+class SmapiPluginTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensurePluginTables();
+        $this->cleanPluginTables();
+        // 插件类走 PluginFileLoader 的 require_once 加载，不在 PSR-4 autoload 内，
+        // 直接 new 之前必须先确保文件已载入。
+        $this->loadSmapiPlugin();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanPluginTables();
+        parent::tearDown();
+    }
+
+    private function loadSmapiPlugin(): void
+    {
+        $manifest = app(PluginScanner::class)->requireManifest('verification', 'smapi');
+        app(PluginFileLoader::class)->ensureLoaded($manifest);
+    }
+
+    // ============================================================
+    // certification.initialize
+    // ============================================================
+
+    public function test_execute_routes_initialize_action(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'msg' => 'success',
+                'data' => [
+                    'id' => 'S-1001',
+                    'certify_page_url' => 'https://smapi.x1m1.cn/certify/S-1001',
+                ],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => [
+                'real_name' => '张三',
+                'id_card' => '110101199001010011',
+                'return_url' => 'https://api.example.test/callback',
+            ],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('certification.initialize', $result['action']);
+        $this->assertSame(200, $result['data']['status']);
+        $this->assertSame('S-1001', $result['data']['certify_id']);
+        $this->assertSame('https://smapi.x1m1.cn/certify/S-1001', $result['data']['raw']['certify_page_url']);
+    }
+
+    public function test_initialize_sends_expected_payload(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1002'],
+            ], 200),
+        ]);
+
+        $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => [
+                'real_name' => '李四',
+                'id_card' => '110101199001010022',
+                'return_url' => 'https://api.example.test/callback',
+            ],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('X-App-Key', 'test-app-key')
+                && $request->hasHeader('X-App-Secret', 'test-secret-key')
+                && $request['product_code'] === 'alipay_v3'
+                && $request['cert_name'] === '李四'
+                && $request['cert_no'] === '110101199001010022'
+                && $request['return_url'] === 'https://api.example.test/callback';
+        });
+    }
+
+    public function test_initialize_uses_first_product_code_when_multiple(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1003'],
+            ], 200),
+        ]);
+
+        $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => [
+                'real_name' => '张三',
+                'id_card' => '110101199001010011',
+                'return_url' => '',
+            ],
+            'config' => array_merge($this->defaultConfig(), [
+                'product_code' => "alipay_v3,支付宝身份认证|tencent_sm,微信实名认证",
+            ]),
+        ]);
+
+        Http::assertSent(fn ($request) => $request['product_code'] === 'alipay_v3');
+    }
+
+    public function test_initialize_returns_400_when_product_code_missing(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => array_merge($this->defaultConfig(), ['product_code' => '']),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('请先配置产品标识 product_code', $result['data']['message']);
+    }
+
+    public function test_initialize_returns_400_on_business_failure(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 400,
+                'msg' => '密钥校验失败',
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('密钥校验失败', $result['data']['message']);
+    }
+
+    public function test_initialize_falls_back_to_safe_message_when_provider_text_has_technical_details(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 400,
+                'msg' => 'invalid AppSecret: bad signature',
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('实名认证接口配置错误，请联系管理员', $result['data']['message']);
+    }
+
+    public function test_initialize_returns_400_when_certify_id_missing(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['certify_page_url' => 'https://smapi.x1m1.cn/certify/x'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('聚合实名平台返回异常：未返回认证标识', $result['data']['message']);
+    }
+
+    public function test_initialize_throws_when_credentials_missing(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1'],
+            ], 200),
+        ]);
+
+        $this->expectException(BusinessException::class);
+
+        $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => array_merge($this->defaultConfig(), ['app_key' => '']),
+        ]);
+    }
+
+    // ============================================================
+    // certification.scan_url
+    // ============================================================
+
+    public function test_execute_routes_scan_url_action(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1001/query*' => Http::response([
+                'status' => 200,
+                'data' => [
+                    'id' => 'S-1001',
+                    'status' => 'processing',
+                    'certify_page_url' => 'https://smapi.x1m1.cn/certify/S-1001',
+                ],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.scan_url',
+            'payload' => ['certify_id' => 'S-1001'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('certification.scan_url', $result['action']);
+        $this->assertSame(200, $result['data']['status']);
+        $this->assertSame('https://smapi.x1m1.cn/certify/S-1001', $result['data']['url']);
+    }
+
+    public function test_scan_url_falls_back_to_alternate_url_fields(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-2/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-2', 'status' => 'initialized', 'qrcode_url' => 'https://smapi.x1m1.cn/qr/S-2'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.scan_url',
+            'payload' => ['certify_id' => 'S-2'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(200, $result['data']['status']);
+        $this->assertSame('https://smapi.x1m1.cn/qr/S-2', $result['data']['url']);
+    }
+
+    public function test_scan_url_returns_400_when_url_missing(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-3/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-3', 'status' => 'processing'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.scan_url',
+            'payload' => ['certify_id' => 'S-3'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('获取认证链接失败，请联系管理员', $result['data']['message']);
+    }
+
+    // ============================================================
+    // certification.query_status
+    // ============================================================
+
+    public function test_query_status_passed_maps_to_success(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'passed', 'passed_at' => '2026-08-01 10:00:00'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(1, $result['data']['status']);
+        $this->assertSame('审核通过', $result['data']['message']);
+    }
+
+    public function test_query_status_failed_maps_to_failure_with_reason(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'failed', 'fail_reason' => '身份信息不一致'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(2, $result['data']['status']);
+        $this->assertSame('身份信息不一致', $result['data']['message']);
+    }
+
+    public function test_query_status_failed_without_reason(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'failed'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(2, $result['data']['status']);
+        $this->assertSame('审核未通过', $result['data']['message']);
+    }
+
+    public function test_query_status_updated_maps_to_failure(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'updated'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(2, $result['data']['status']);
+    }
+
+    public function test_query_status_processing_maps_to_pending(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'processing'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(4, $result['data']['status']);
+        $this->assertSame('认证处理中，请稍后再获取结果', $result['data']['message']);
+    }
+
+    public function test_query_status_initialized_maps_to_pending(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'initialized'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(4, $result['data']['status']);
+        $this->assertSame('待认证，请先完成扫码认证', $result['data']['message']);
+    }
+
+    public function test_query_status_network_error_maps_to_network_status(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => fn () => throw new ConnectionException('Connection refused'),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(3, $result['data']['status']);
+        $this->assertSame('实名认证接口请求失败，请稍后重试', $result['data']['message']);
+    }
+
+    public function test_query_status_business_failure_stays_pending(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 400,
+                'msg' => '认证记录不存在',
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(4, $result['data']['status']);
+        $this->assertSame('认证处理中', $result['data']['message']);
+    }
+
+    // ============================================================
+    // certification.verify_callback / fee_config / 其他
+    // ============================================================
+
+    public function test_verify_callback_unsupported(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => ['payload' => [], 'headers' => []],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+        $this->assertSame(40001, $result['data']['code']);
+        $this->assertSame(501, $result['data']['http_status']);
+    }
+
+    public function test_execute_routes_fee_config_action(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.fee_config',
+            'payload' => [],
+            'config' => [
+                'charge_enabled' => true,
+                'amount' => 1.5,
+                'free_times' => 3,
+            ],
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(3, $result['data']['free_attempts']);
+        $this->assertSame(1.5, $result['data']['retry_fee']);
+        $this->assertTrue($result['data']['charge_enabled']);
+    }
+
+    public function test_execute_fee_config_defaults_when_no_config(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.fee_config',
+            'payload' => [],
+            'config' => [],
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(0, $result['data']['free_attempts']);
+        $this->assertSame(0.0, $result['data']['retry_fee']);
+        $this->assertFalse($result['data']['charge_enabled']);
+    }
+
+    public function test_execute_unknown_action_returns_unsupported(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.unknown',
+            'payload' => [],
+            'config' => [],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('certification.unknown', $result['action']);
+    }
+
+    public function test_plugin_key_and_label(): void
+    {
+        $plugin = new Smapi;
+
+        $this->assertSame('smapi', $plugin->key());
+        $this->assertSame('聚合实名认证', $plugin->label());
+    }
+
+    // ============================================================
+    // helpers
+    // ============================================================
+
+    private function defaultConfig(): array
+    {
+        return [
+            'api_url' => 'https://smapi.x1m1.cn',
+            'app_key' => 'test-app-key',
+            'secret_key' => 'test-secret-key',
+            'product_code' => 'alipay_v3,支付宝身份认证',
+            'ssl_verify' => true,
+        ];
+    }
+
+    private function ensurePluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            Schema::create('integration_plugins', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->string('slug', 120);
+                $table->string('plugin_key', 120);
+                $table->string('name', 120);
+                $table->string('version', 32)->default('1.0.0');
+                $table->string('provider_class', 255)->nullable();
+                $table->string('entry_class', 255);
+                $table->json('capabilities_json')->nullable();
+                $table->json('config_schema_json')->nullable();
+                $table->unsignedTinyInteger('status')->default(0);
+                $table->timestamp('installed_at')->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'slug']);
+                $table->unique(['domain', 'plugin_key']);
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_configs')) {
+            Schema::create('integration_plugin_configs', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('plugin_id');
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->timestamps();
+                $table->unique('plugin_id');
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_bindings')) {
+            Schema::create('integration_plugin_bindings', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->unsignedBigInteger('plugin_id');
+                $table->string('binding_type', 50);
+                $table->string('bindable_type', 120)->default('global');
+                $table->unsignedBigInteger('bindable_id')->default(0);
+                $table->string('binding_key', 120);
+                $table->string('provider_key', 120)->nullable();
+                $table->integer('priority')->default(0);
+                $table->unsignedTinyInteger('status')->default(1);
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->json('runtime_policy_json')->nullable();
+                $table->unsignedBigInteger('created_by')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->string('backfill_batch_id', 64)->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'binding_type', 'bindable_type', 'bindable_id', 'binding_key'], 'plugin_bindings_unique');
+            });
+        }
+    }
+
+    private function cleanPluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            return;
+        }
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('integration_plugin_bindings')) {
+            DB::table('integration_plugin_bindings')->truncate();
+        }
+        if (Schema::hasTable('integration_plugin_configs')) {
+            DB::table('integration_plugin_configs')->truncate();
+        }
+        DB::table('integration_plugins')->truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+}

--- a/docs/参考资料/集成/插件/README.md
+++ b/docs/参考资料/集成/插件/README.md
@@ -621,6 +621,7 @@ php artisan schedule:list
 | 支付渠道      | `backend/plugins/gateways/yi_pay`                 | 易支付插件                      |
 | 实名认证      | `backend/plugins/certification/stay33`            | Stay33 实名认证插件             |
 | 实名认证      | `backend/plugins/certification/baidu_face`        | 百度人脸实名认证插件            |
+| 实名认证      | `backend/plugins/certification/smapi`             | 聚合实名认证插件（小沐实名 API）|
 | 实名认证      | `backend/plugins/certification/demo_verification` | 模拟实名插件                    |
 | 人机验证      | `backend/plugins/captcha/geetest`                 | GeeTest 验证码插件              |
 | 人机验证      | `backend/plugins/captcha/vaptcha`                 | Vaptcha 验证码插件              |

--- a/frontend-admin-v3/src/layouts/components/MenuContent.vue
+++ b/frontend-admin-v3/src/layouts/components/MenuContent.vue
@@ -30,6 +30,7 @@ import { computed } from 'vue';
 import type { LocalizedTitle } from '@/locales';
 import { useLocale } from '@/locales/useLocale';
 import { getActive } from '@/router';
+import router from '@/router';
 import type { MenuRoute } from '@/types/interface';
 
 type ListItemType = MenuRoute;
@@ -108,7 +109,9 @@ const getHref = (item: MenuRoute) => {
 const getPath = (item: ListItemType) => {
   const activeLevel = active.value.split('/').length;
   const pathLevel = item.path.split('/').length;
-  const hasExactActiveItem = list.value.some((menuItem) => menuItem.path === active.value);
+  // 判断当前路由是否为已注册的精确路由（跨分组同级前缀路径如
+  // /admin/products 与 /admin/products/suppliers 不应互相误高亮）。
+  const hasExactActiveItem = hasExactRegisteredRoute(active.value);
 
   if (activeLevel > pathLevel && !hasExactActiveItem && active.value.startsWith(`${item.path}/`)) {
     return active.value;
@@ -120,6 +123,13 @@ const getPath = (item: ListItemType) => {
 
   return item.meta?.single ? item.redirect : item.path;
 };
+
+/**
+ * 判断指定路径是否精确匹配某个已注册路由（含隐藏路由）。
+ */
+function hasExactRegisteredRoute(path: string): boolean {
+  return router.getRoutes().some((route) => route.path === path);
+}
 
 const openHref = (url: string) => {
   window.open(url, '_blank', 'noopener,noreferrer');

--- a/frontend-admin-v3/src/layouts/components/SideNav.vue
+++ b/frontend-admin-v3/src/layouts/components/SideNav.vue
@@ -222,7 +222,17 @@ function findExactMenuBranch(list: MenuRoute[], activePath: string, parents: Men
 function findExpandedByMenu(list: MenuRoute[], activePath: string, parents: MenuValue[] = []): MenuValue[] | null {
   for (const item of list || []) {
     const currentPath = String(item.path);
-    if (isRouteMatch(currentPath, activePath)) return parents;
+    if (isRouteMatch(currentPath, activePath)) {
+      // 前缀命中分组（隐藏子路由场景）：继续深入找最深匹配的祖先链；
+      // 子级无更深命中时展开本分组，避免返回空数组导致上层分组不展开。
+      if (item.children && item.children.length > 0) {
+        const childResult = findExpandedByMenu(item.children, activePath, [...parents, currentPath]);
+        return childResult ?? [...parents, currentPath];
+      }
+
+      // 叶子精确命中：无需展开自身，返回祖先链。
+      return parents;
+    }
 
     const childResult = findExpandedByMenu(item.children || [], activePath, [...parents, currentPath]);
     if (childResult) return childResult;

--- a/frontend-admin-v3/src/layouts/components/SideNav.vue
+++ b/frontend-admin-v3/src/layouts/components/SideNav.vue
@@ -102,7 +102,9 @@ const expanded = ref<MenuValue[]>([]);
 
 const getExpanded = () => {
   const path = getActive();
-  const result = findExpandedByMenu(menu as MenuRoute[], path) || fallbackExpanded(path);
+  // 优先精确匹配菜单叶子（跨分组同级前缀路由如 /admin/products 与
+  // /admin/products/suppliers 不会互相误展开）；无精确项（隐藏路由）时回退前缀匹配。
+  const result = findExactMenuBranch(menu as MenuRoute[], path) || findExpandedByMenu(menu as MenuRoute[], path) || fallbackExpanded(path);
 
   expanded.value = result;
 };
@@ -197,6 +199,25 @@ const getLogo = () => {
   if (collapsed.value) return AssetLogo;
   return AssetLogoFull;
 };
+
+/**
+ * 精确匹配：返回 activePath 对应菜单叶子（path 完全相等）的祖先链。
+ * 与 findExpandedByMenu 的前缀匹配不同，避免同级前缀路由（如
+ * /admin/products 与 /admin/products/suppliers）互相误展开。
+ */
+function findExactMenuBranch(list: MenuRoute[], activePath: string, parents: MenuValue[] = []): MenuValue[] | null {
+  for (const item of list || []) {
+    const currentPath = String(item.path);
+    if (currentPath === activePath) {
+      return parents;
+    }
+
+    const childResult = findExactMenuBranch(item.children || [], activePath, [...parents, currentPath]);
+    if (childResult) return childResult;
+  }
+
+  return null;
+}
 
 function findExpandedByMenu(list: MenuRoute[], activePath: string, parents: MenuValue[] = []): MenuValue[] | null {
   for (const item of list || []) {

--- a/frontend-admin-v3/src/layouts/setting.vue
+++ b/frontend-admin-v3/src/layouts/setting.vue
@@ -339,7 +339,7 @@ watchEffect(() => {
       color: var(--td-text-color-disabled);
     }
 
-    > .t-radio-group.t-size-m {
+    > .t-radio-group.t-size-m:not(.setting-mode-radio) {
       pointer-events: none;
       opacity: 0.4;
       filter: grayscale(1);

--- a/frontend-admin-v3/src/layouts/setting.vue
+++ b/frontend-admin-v3/src/layouts/setting.vue
@@ -10,6 +10,20 @@
   >
     <div class="setting-container">
       <t-form :data="formData" label-align="left">
+        <div class="setting-group-title">{{ t('layout.setting.theme.mode') }}</div>
+        <t-form-item :label="t('layout.setting.theme.mode')" name="mode">
+          <t-radio-group
+            v-model="formData.mode"
+            class="setting-mode-radio"
+            variant="default-filled"
+            @change="handleModeChange"
+          >
+            <t-radio-button :value="'light'">{{ t('layout.setting.theme.options.light') }}</t-radio-button>
+            <t-radio-button :value="'dark'">{{ t('layout.setting.theme.options.dark') }}</t-radio-button>
+            <t-radio-button :value="'auto'">{{ t('layout.setting.theme.options.auto') }}</t-radio-button>
+          </t-radio-group>
+        </t-form-item>
+
         <div class="setting-group-title">{{ t('layout.setting.navigationLayout') }}</div>
         <t-radio-group v-model="formData.layout">
           <div v-for="(item, index) in LAYOUT_OPTION" :key="index" class="setting-layout-drawer">
@@ -57,6 +71,7 @@ import Thumbnail from '@/components/thumbnail/index.vue';
 import STYLE_CONFIG from '@/config/style';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
+import type { ModeType } from '@/types/interface';
 
 const settingStore = useSettingStore();
 
@@ -114,6 +129,12 @@ const showSettingPanel = computed({
 const handleCloseDrawer = () => {
   settingStore.updateConfig({
     showSettingPanel: false,
+  });
+};
+
+const handleModeChange = (mode: unknown) => {
+  settingStore.updateConfig({
+    mode: (mode as ModeType | 'auto') || 'light',
   });
 };
 

--- a/frontend-admin-v3/src/layouts/setting.vue
+++ b/frontend-admin-v3/src/layouts/setting.vue
@@ -11,18 +11,16 @@
     <div class="setting-container">
       <t-form :data="formData" label-align="left">
         <div class="setting-group-title">{{ t('layout.setting.theme.mode') }}</div>
-        <t-form-item :label="t('layout.setting.theme.mode')" name="mode">
-          <t-radio-group
-            v-model="formData.mode"
-            class="setting-mode-radio"
-            variant="default-filled"
-            @change="handleModeChange"
-          >
-            <t-radio-button :value="'light'">{{ t('layout.setting.theme.options.light') }}</t-radio-button>
-            <t-radio-button :value="'dark'">{{ t('layout.setting.theme.options.dark') }}</t-radio-button>
-            <t-radio-button :value="'auto'">{{ t('layout.setting.theme.options.auto') }}</t-radio-button>
-          </t-radio-group>
-        </t-form-item>
+        <t-radio-group
+          v-model="formData.mode"
+          class="setting-mode-radio"
+          variant="default-filled"
+          @change="handleModeChange"
+        >
+          <t-radio-button :value="'light'">{{ t('layout.setting.theme.options.light') }}</t-radio-button>
+          <t-radio-button :value="'dark'">{{ t('layout.setting.theme.options.dark') }}</t-radio-button>
+          <t-radio-button :value="'auto'">{{ t('layout.setting.theme.options.auto') }}</t-radio-button>
+        </t-radio-group>
 
         <div class="setting-group-title">{{ t('layout.setting.navigationLayout') }}</div>
         <t-radio-group v-model="formData.layout">
@@ -259,6 +257,28 @@ watchEffect(() => {
 
   .t-radio-group.t-size-m .t-radio-button {
     height: auto;
+  }
+
+  /* 主题模式切换：三个选项等宽均分、文字居中，紧凑整齐 */
+  .setting-mode-radio {
+    display: flex;
+    width: 100%;
+    gap: var(--td-comp-margin-s);
+
+    .t-radio-button {
+      flex: 1 1 0;
+      justify-content: center;
+      min-width: 0;
+      padding: 0;
+      text-align: center;
+    }
+
+    .t-radio-button__label {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+    }
   }
 
   .setting-layout-drawer {

--- a/frontend-admin-v3/src/pages/products/components/Suppliers.vue
+++ b/frontend-admin-v3/src/pages/products/components/Suppliers.vue
@@ -221,10 +221,29 @@
                 </div>
               </template>
               <template v-else>
-                <div class="supplier-tree-node__content supplier-tree-node__content--product">
+                <div
+                  class="supplier-tree-node__content supplier-tree-node__content--product"
+                  :class="{
+                    'is-selectable': !row.product?.is_connected,
+                    'is-selected': supplierBatchSelectedKeySet.has(row.productId || 0),
+                  }"
+                  role="checkbox"
+                  :aria-checked="supplierBatchSelectedKeySet.has(row.productId || 0)"
+                  :aria-label="`${row.product?.name || '商品'}，点击切换选择`"
+                  :tabindex="row.product?.is_connected ? -1 : 0"
+                  @click="
+                    !row.product?.is_connected &&
+                      handleSupplierBatchProductCheck(row.productId || 0, !supplierBatchSelectedKeySet.has(row.productId || 0))
+                  "
+                  @keydown.enter.prevent="
+                    !row.product?.is_connected &&
+                      handleSupplierBatchProductCheck(row.productId || 0, !supplierBatchSelectedKeySet.has(row.productId || 0))
+                  "
+                >
                   <t-checkbox
                     :checked="supplierBatchSelectedKeySet.has(row.productId || 0)"
                     :disabled="row.product?.is_connected"
+                    @click.stop
                     @change="
                       (checked: boolean) =>
                         !row.product?.is_connected && handleSupplierBatchProductCheck(row.productId || 0, checked)

--- a/frontend-admin-v3/src/pages/products/index.less
+++ b/frontend-admin-v3/src/pages/products/index.less
@@ -1863,6 +1863,30 @@
   background: var(--td-bg-color-container-hover);
 }
 
+/* 上游商品卡片：整体可点击切换选中（左侧未对接面板） */
+.supplier-tree-node--product .supplier-tree-node__content--product.is-selectable {
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--td-brand-color-light);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--td-brand-color-focus);
+    outline-offset: 1px;
+  }
+}
+
+.supplier-tree-node--product .supplier-tree-node__content--product.is-selected {
+  border-color: var(--td-brand-color);
+  background: var(--td-brand-color-light);
+
+  .supplier-tree-product strong,
+  .supplier-tree-product span {
+    color: var(--td-brand-color);
+  }
+}
+
 .supplier-tree-node--product.is-disabled {
   .supplier-tree-node__content--product {
     background: var(--td-bg-color-component);

--- a/frontend-admin-v3/src/pages/products/index.less
+++ b/frontend-admin-v3/src/pages/products/index.less
@@ -858,6 +858,7 @@
   overflow: hidden;
   cursor: pointer;
   text-align: left;
+  color: var(--td-text-color-primary);
 }
 
 .category-title-line {
@@ -895,6 +896,7 @@
 .category-name {
   overflow: hidden;
   min-width: 0;
+  color: var(--td-text-color-primary);
   font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend-admin-v3/src/store/modules/setting.ts
+++ b/frontend-admin-v3/src/store/modules/setting.ts
@@ -36,14 +36,15 @@ export const useSettingStore = defineStore('setting', {
       }
       return state.mode as ModeType;
     },
-    displaySideMode: (state): ModeType => {
+    displaySideMode(state: TState): ModeType {
       // 侧边栏跟随主主题模式：浅色主题 → 浅色侧边栏；深色主题 → 深色侧边栏。
       // 若 sideMode 被显式配置为深色，则侧边栏独立使用深色（保留独立配色能力）。
       const explicitSideMode = state.sideMode as ModeType;
       if (explicitSideMode === 'dark') {
         return 'dark';
       }
-      return state.displayMode;
+      // displayMode 是 getter 而非 state 字段，必须通过 this 访问。
+      return this.displayMode;
     },
   },
   actions: {
@@ -52,7 +53,12 @@ export const useSettingStore = defineStore('setting', {
 
       if (mode === 'auto') {
         theme = this.getMediaColor();
+        // auto 模式：监听系统主题变化，切回其他模式时移除监听。
+        watchSystemTheme();
+      } else {
+        unwatchSystemTheme();
       }
+
       const isDarkMode = theme === 'dark';
 
       document.documentElement.setAttribute('theme-mode', isDarkMode ? 'dark' : '');
@@ -115,4 +121,42 @@ export const useSettingStore = defineStore('setting', {
 
 export function getSettingStore() {
   return useSettingStore(store);
+}
+
+// auto 模式系统主题监听：模块级变量，不参与持久化。
+let systemThemeMedia: MediaQueryList | null = null;
+let systemThemeHandler: ((event: MediaQueryListEvent) => void) | null = null;
+
+function watchSystemTheme(): void {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return;
+  }
+  if (systemThemeMedia && systemThemeHandler) {
+    return; // 已监听，避免重复挂载
+  }
+  systemThemeMedia = window.matchMedia('(prefers-color-scheme:dark)');
+  systemThemeHandler = () => {
+    // 仅当仍处于 auto 模式时跟随系统主题变化。
+    if (getSettingStore().mode === 'auto') {
+      getSettingStore().changeMode('auto');
+    }
+  };
+  if (typeof systemThemeMedia.addEventListener === 'function') {
+    systemThemeMedia.addEventListener('change', systemThemeHandler);
+  } else {
+    // 旧浏览器兼容
+    systemThemeMedia.addListener(systemThemeHandler);
+  }
+}
+
+function unwatchSystemTheme(): void {
+  if (systemThemeMedia && systemThemeHandler) {
+    if (typeof systemThemeMedia.removeEventListener === 'function') {
+      systemThemeMedia.removeEventListener('change', systemThemeHandler);
+    } else {
+      systemThemeMedia.removeListener(systemThemeHandler);
+    }
+    systemThemeMedia = null;
+    systemThemeHandler = null;
+  }
 }

--- a/frontend-admin-v3/src/store/modules/setting.ts
+++ b/frontend-admin-v3/src/store/modules/setting.ts
@@ -37,7 +37,13 @@ export const useSettingStore = defineStore('setting', {
       return state.mode as ModeType;
     },
     displaySideMode: (state): ModeType => {
-      return state.sideMode as ModeType;
+      // 侧边栏跟随主主题模式：浅色主题 → 浅色侧边栏；深色主题 → 深色侧边栏。
+      // 若 sideMode 被显式配置为深色，则侧边栏独立使用深色（保留独立配色能力）。
+      const explicitSideMode = state.sideMode as ModeType;
+      if (explicitSideMode === 'dark') {
+        return 'dark';
+      }
+      return state.displayMode;
     },
   },
   actions: {

--- a/frontend-user-v3-www/index.html
+++ b/frontend-user-v3-www/index.html
@@ -52,58 +52,88 @@
   <link rel="dns-prefetch" href="//mclient.alipay.com" />
 </head>
 <body>
-  <div id="app">
-    <!-- 初始加载动画：JS 解析完成前展示，Vue 挂载后自动替换 -->
-    <div id="app-splash" aria-label="页面加载中">
-      <style>
-        #app-splash {
-          position: fixed;
-          inset: 0;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          gap: 28px;
-          background: linear-gradient(168deg, #f8fafc 0%, #f0f4ff 100%);
-          z-index: 9999;
-          opacity: 1;
-          transition: opacity 0.3s ease-out;
-        }
-        #app-splash.fade-out {
-          opacity: 0;
-          pointer-events: none;
-        }
-        #app-splash .splash-logo {
-          width: 48px;
-          height: 48px;
-          animation: splash-breathe 2s ease-in-out infinite;
-        }
-        #app-splash .splash-bar-track {
-          width: 180px;
-          height: 3px;
-          border-radius: 999px;
-          background: rgba(22, 93, 255, 0.1);
-          overflow: hidden;
-        }
+  <div id="app"></div>
+  <!-- 初始加载动画：JS 解析完成前展示，Vue 挂载后淡出移除 -->
+  <div id="app-splash" aria-label="页面加载中">
+    <style>
+      #app-splash {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 28px;
+        background: linear-gradient(168deg, #f8fafc 0%, #f0f4ff 100%);
+        z-index: 9999;
+        opacity: 1;
+        transition: opacity 0.3s ease-out;
+      }
+      #app-splash.fade-out {
+        opacity: 0;
+        pointer-events: none;
+      }
+      #app-splash .splash-brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        color: #165dff;
+        font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+        animation: splash-breathe 2s ease-in-out infinite;
+      }
+      #app-splash .splash-mark {
+        display: inline-flex;
+        width: 44px;
+        height: 44px;
+        align-items: center;
+        justify-content: center;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #165dff 0%, #4d8eff 100%);
+        box-shadow: 0 14px 32px rgba(22, 93, 255, 0.22);
+        color: #fff;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      #app-splash .splash-word {
+        font-size: 22px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+      }
+      #app-splash .splash-bar-track {
+        width: 180px;
+        height: 3px;
+        border-radius: 999px;
+        background: rgba(22, 93, 255, 0.1);
+        overflow: hidden;
+      }
+      #app-splash .splash-bar-fill {
+        width: 40%;
+        height: 100%;
+        border-radius: 999px;
+        background: linear-gradient(90deg, #165dff, #4d8eff);
+        animation: splash-slide 1.2s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #app-splash .splash-brand,
         #app-splash .splash-bar-fill {
-          width: 40%;
-          height: 100%;
-          border-radius: 999px;
-          background: linear-gradient(90deg, #165dff, #4d8eff);
-          animation: splash-slide 1.2s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+          animation: none;
         }
-        @keyframes splash-breathe {
-          0%, 100% { transform: scale(1); opacity: 0.92; }
-          50% { transform: scale(1.04); opacity: 1; }
-        }
-        @keyframes splash-slide {
-          0% { transform: translateX(-120%); }
-          100% { transform: translateX(350%); }
-        }
-      </style>
-      <img class="splash-logo" src="/branding/splash-96.png" alt="图拉云" width="48" height="48" />
-      <div class="splash-bar-track"><div class="splash-bar-fill"></div></div>
+      }
+      @keyframes splash-breathe {
+        0%, 100% { transform: scale(1); opacity: 0.92; }
+        50% { transform: scale(1.04); opacity: 1; }
+      }
+      @keyframes splash-slide {
+        0% { transform: translateX(-120%); }
+        100% { transform: translateX(350%); }
+      }
+    </style>
+    <div class="splash-brand" aria-hidden="true">
+      <span class="splash-mark">T</span>
+      <span class="splash-word">图拉云</span>
     </div>
+    <div class="splash-bar-track"><div class="splash-bar-fill"></div></div>
   </div>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/theme.css
+++ b/theme.css
@@ -224,8 +224,8 @@
   --td-radius-medium: 0px;
   --td-radius-large: 0px;
   --td-radius-extraLarge: 0px;
-  --td-radius-round: 0px;
-  --td-radius-circle: 0px;
+  --td-radius-round: 999px;
+  --td-radius-circle: 50%;
   --td-font-family: PingFang SC, Microsoft YaHei, Arial, sans-serif;
   --td-font-family-medium: PingFang SC, Microsoft YaHei, Arial, sans-serif;
   --td-comp-margin-xxs: 2px;
@@ -297,7 +297,7 @@
 }
 
 #app .t-table th {
-  background: #f6f8fb;
+  background: var(--td-bg-color-secondarycontainer);
   color: var(--td-text-color-secondary);
   font-weight: 600;
 }
@@ -310,6 +310,39 @@
 #app .t-button {
   min-width: 72px;
   font-weight: 500;
+}
+
+/* 按钮 loading 图标：TDesign 默认 LoadingIcon 是不完整圆弧，按钮里观感像异形图标；统一改为标准圆形旋转器。 */
+#app .t-button .t-icon-loading {
+  width: 1em;
+  height: 1em;
+  box-sizing: border-box;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50% !important;
+  animation: tura-button-loading-spin 0.8s linear infinite;
+}
+
+#app .t-button .t-icon-loading path {
+  display: none;
+}
+
+/* 全局/独立 t-loading 加载图标：TDesign 默认 gradient 元素因全局 border-radius 归零变成方形转圈，
+   这里恢复为标准圆形环，与按钮 loading 风格一致。 */
+#app .t-loading .t-loading__gradient,
+#app .t-loading .t-loading__gradient-conic {
+  border-radius: 50% !important;
+}
+
+#app .t-loading .t-loading__gradient-conic {
+  -webkit-mask: radial-gradient(transparent calc(50% - 0.5px), #fff 50%);
+  mask: radial-gradient(transparent calc(50% - 0.5px), #fff 50%);
+}
+
+@keyframes tura-button-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 #app .t-button--shape-square {
@@ -351,7 +384,7 @@
 
 #app .t-button--variant-text:hover {
   border-color: transparent;
-  background: #f3f8ff;
+  background: var(--td-bg-color-container-hover);
 }
 
 #app .t-input,
@@ -382,9 +415,38 @@
 }
 
 #app .tdesign-starter-side-nav-logo-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  min-height: var(--td-comp-size-xl);
   height: 56px;
   padding: 0 16px 0 5px;
-  justify-content: flex-start;
+  border: 0;
+  background: transparent;
+  color: var(--td-brand-color);
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--td-radius-medium);
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+
+  &:hover {
+    background-color: var(--td-bg-color-container-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--td-brand-color-focus);
+    outline-offset: 2px;
+  }
+}
+
+/* 深色侧边栏下 logo 用浅色文字，避免深底黑字不可见 */
+#app .t-default-menu.t-menu--dark .tdesign-starter-side-nav-logo-wrapper,
+#app .t-default-menu.t-menu--dark .tdesign-starter-side-nav-logo-wrapper .tdesign-starter-side-nav-logo-tdesign-logo,
+#app .t-default-menu.t-menu--dark .tdesign-starter-side-nav-logo-wrapper .tdesign-starter-side-nav-logo-t-logo {
+  color: var(--td-font-white-1);
 }
 
 #app .tdesign-starter-sidebar-compact .tdesign-starter-side-nav-logo-wrapper {
@@ -432,7 +494,7 @@
 
 #app .t-default-menu .t-menu__item:hover:not(.t-is-active, .t-is-disabled),
 #app .t-default-menu .t-submenu__title:hover {
-  background: #f3f8ff;
+  background: var(--td-bg-color-container-hover);
   color: var(--td-brand-color);
 }
 
@@ -578,7 +640,7 @@
 #app .client-services .service-table-card th,
 #app .client-tickets .ticket-table-shell th,
 #app .referral-page .t-table th {
-  color: #7b8494;
+  color: var(--td-text-color-secondary);
   font: var(--td-font-body-small);
   font-weight: 400;
 }
@@ -597,7 +659,7 @@
 #app .client-services .service-table-card tr:hover td,
 #app .client-tickets .ticket-table-shell tr:hover td,
 #app .referral-page .t-table tr:hover td {
-  background: #f8fbff !important;
+  background: var(--td-bg-color-container-hover) !important;
 }
 
 #app .tdesign-starter-layout-tabs-nav {

--- a/theme.css
+++ b/theme.css
@@ -266,7 +266,7 @@
 #app .t-default-menu .t-menu__item .t-icon,
 #app .t-default-menu .t-submenu__title .t-icon {
   flex-shrink: 0;
-  color: currentColor;
+  color: currentcolor;
 }
 
 #app *,
@@ -317,7 +317,7 @@
   width: 1em;
   height: 1em;
   box-sizing: border-box;
-  border: 2px solid currentColor;
+  border: 2px solid currentcolor;
   border-top-color: transparent;
   border-radius: 50% !important;
   animation: tura-button-loading-spin 0.8s linear infinite;
@@ -548,7 +548,7 @@
   height: 4px;
   margin-top: -2px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
 }
 
 /* 二级终端菜单选中：灰色背景（排除子菜单父级） */


### PR DESCRIPTION
## 变更内容

### 后端
1. **修复 ZJMF 上游对接商品因缺少价格被全部跳过**
   - `ZjmfCatalogService` 新增 `hydrateSelectedPricing`：按选中商品串行拉取 `/cart/get_product_config` 的 `product_pricings` 补充价格（月付/季付/半年/年付）
   - `ProductSyncService` 批量对接前对选中商品补充价格
   - `HostingPanelApiTransport` 新增 WAF JS 挑战页 cookie 自动会话重试，解决 `/cart/credit` 等接口返回挑战页导致"供应商接口返回异常页面"问题

2. **修复删除商品分类因软删除商品未清理导致 500**
   - 删除分类时用 `withoutGlobalScopes` 检查未删除商品，自动物理清理软删除商品及其 `product_upstream_bindings` 外键引用
   - `ProductAdminService::forceDeleteProduct` 同步清理上游绑定

### 前端
3. **管理后台主题与样式修复**
   - 设置面板新增主题模式切换（明亮/深色/跟随系统）
   - 侧边栏主题跟随主主题模式，修复暗色下侧边栏与悬停仍亮色
   - 表格头/菜单悬停/表格行悬停等硬编码浅色改为 TDesign 主题变量
   - 商品分组名称显式主题主色，修复暗色下变白
   - 恢复 `--td-radius-round/circle`，修复 loading 图标方形转圈
   - 全局 `t-loading` 加载图标恢复标准圆形环
   - 左上角 logo 按钮重置原生 button 样式，暗色下白色文字

4. **官网启动加载页优化**
   - 启动页由图片 Logo 改为图拉云文字品牌标识（T 图标 + 品牌名）+ 进度条

## 验证
- ZJMF 批量对接：`created_count=2, skipped_count=0`（HTTP API 实测）
- 删除分类全场景：软删除商品自动清理、未删除商品正确拦截（422）
- 前端暗色/浅色双模式 playwright 实测通过
