### PR TITLE
style(user-console): 横向nav品牌名改为breadcrumb；样式微调

### DIFF
--- a/frontend-user-v4-console/src/layouts/components/Header.vue
+++ b/frontend-user-v4-console/src/layouts/components/Header.vue
@@ -10,7 +10,11 @@
           <t-button theme="default" shape="square" variant="text" :title="sidebarButtonTitle" @click="changeCollapsed">
             <t-icon class="collapsed-icon" name="view-list" />
           </t-button>
-          <span class="header-page-brand">{{ siteBranding.siteName }}</span>
+          <t-breadcrumb class="header-breadcrumb">
+            <t-breadcrumbItem v-for="item in breadcrumbs" :key="item.to" :to="item.to">
+              {{ item.title }}
+            </t-breadcrumbItem>
+          </t-breadcrumb>
         </div>
       </template>
       <template v-if="layout !== 'side'" #default>
@@ -101,13 +105,15 @@ import { ChevronDownIcon, NotificationIcon, PoweroffIcon, UserCircleIcon, Wallet
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next';
 import type { PropType } from 'vue';
 import { computed, onMounted, ref } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 import { useSiteBrandingStore } from '@/app/stores/siteBranding';
 import { useDeviceLayout } from '@/composables/useDeviceLayout';
 import { prefix } from '@/config/global';
 import type { InboxItem } from '@/domains/content/useInbox';
 import { useInbox } from '@/domains/content/useInbox';
+import type { LocalizedTitle } from '@/locales';
+import { useLocale } from '@/locales/useLocale';
 import { getActive } from '@/router';
 import { useSettingStore, useUserStore } from '@/store';
 import type { MenuRoute, ModeType } from '@/types/interface';
@@ -146,6 +152,8 @@ const { theme, layout, showLogo, menu, isFixed, isCompact } = defineProps({
 });
 
 const router = useRouter();
+const route = useRoute();
+const { locale } = useLocale();
 const settingStore = useSettingStore();
 const user = useUserStore();
 const siteBranding = useSiteBrandingStore();
@@ -161,6 +169,21 @@ const {
 const { isMobile } = useDeviceLayout();
 
 const active = computed(() => getActive());
+const breadcrumbs = computed(() => {
+  return route.matched.reduce<Array<{ to: string; title: string }>>((breadcrumbArray, matchedRoute) => {
+    const { meta, path } = matchedRoute;
+    if (path === '/client' || meta?.hiddenBreadcrumb) {
+      return breadcrumbArray;
+    }
+
+    const title = meta?.title as LocalizedTitle | undefined;
+    const renderedTitle = title?.[locale.value as keyof LocalizedTitle] || '';
+    if (renderedTitle) {
+      breadcrumbArray.push({ to: path, title: renderedTitle });
+    }
+    return breadcrumbArray;
+  }, []);
+});
 const accountName = computed(() => user.userInfo.name || '图拉云用户');
 const userInitials = computed(() => {
   const name = accountName.value.trim();
@@ -370,10 +393,12 @@ onMounted(() => {
   gap: var(--td-comp-margin-m);
 }
 
-.header-page-brand {
-  color: var(--td-text-color-primary);
-  font: var(--td-font-body-medium);
-  line-height: var(--td-line-height-body-medium);
+.header-breadcrumb {
+  margin: 0;
+
+  :deep(.t-breadcrumb__item) {
+    max-width: 150px;
+  }
 }
 
 .header-logo-container {
@@ -456,7 +481,7 @@ onMounted(() => {
 }
 
 @media (max-width: @screen-sm-max) {
-  .header-page-brand,
+  .header-breadcrumb,
   .header-user-balance {
     display: none;
   }

--- a/frontend-user-v4-console/src/layouts/components/Header.vue
+++ b/frontend-user-v4-console/src/layouts/components/Header.vue
@@ -11,7 +11,7 @@
             <t-icon class="collapsed-icon" name="view-list" />
           </t-button>
           <t-breadcrumb class="header-breadcrumb">
-            <t-breadcrumbItem v-for="item in breadcrumbs" :key="item.to" :to="item.to">
+            <t-breadcrumbItem v-for="item in breadcrumbs" :key="item.key" :to="item.to">
               {{ item.title }}
             </t-breadcrumbItem>
           </t-breadcrumb>
@@ -106,6 +106,7 @@ import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next';
 import type { PropType } from 'vue';
 import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+import type { RouteLocationRaw } from 'vue-router';
 
 import { useSiteBrandingStore } from '@/app/stores/siteBranding';
 import { useDeviceLayout } from '@/composables/useDeviceLayout';
@@ -170,7 +171,7 @@ const { isMobile } = useDeviceLayout();
 
 const active = computed(() => getActive());
 const breadcrumbs = computed(() => {
-  return route.matched.reduce<Array<{ to: string; title: string }>>((breadcrumbArray, matchedRoute) => {
+  return route.matched.reduce<Array<{ key: string; to: RouteLocationRaw; title: string }>>((breadcrumbArray, matchedRoute) => {
     const { meta, path } = matchedRoute;
     if (path === '/client' || meta?.hiddenBreadcrumb) {
       return breadcrumbArray;
@@ -179,7 +180,10 @@ const breadcrumbs = computed(() => {
     const title = meta?.title as LocalizedTitle | undefined;
     const renderedTitle = title?.[locale.value as keyof LocalizedTitle] || '';
     if (renderedTitle) {
-      breadcrumbArray.push({ to: path, title: renderedTitle });
+      const to: RouteLocationRaw = matchedRoute.name
+        ? { name: matchedRoute.name, params: route.params }
+        : path;
+      breadcrumbArray.push({ key: matchedRoute.name?.toString() || path, to, title: renderedTitle });
     }
     return breadcrumbArray;
   }, []);

--- a/frontend-user-v4-console/src/pages/client/dashboard/index.vue
+++ b/frontend-user-v4-console/src/pages/client/dashboard/index.vue
@@ -4,7 +4,7 @@
       <div class="summary-grid">
         <t-card class="account-card dashboard-card" :bordered="false">
           <div class="account-card__user">
-            <t-avatar :image="avatarUrl || undefined" size="large">{{ avatarText }}</t-avatar>
+            <t-avatar style="margin-top:5px" :image="avatarUrl || undefined" size="large">{{ avatarText }}</t-avatar>
             <div class="account-card__main">
               <h2>{{ greetingText }}，{{ displayName }}</h2>
               <p>{{ todayDateText }}</p>
@@ -457,7 +457,7 @@ const greetingText = computed(() => {
 const todayDateText = computed(() => {
   const now = new Date();
   const weekDays = ['日', '一', '二', '三', '四', '五', '六'];
-  return `${now.getFullYear()}年 ${now.getMonth() + 1}月 ${now.getDate()}日 星期${weekDays[now.getDay()]}`;
+  return `${now.getFullYear()}年${now.getMonth() + 1}月${now.getDate()}日 星期${weekDays[now.getDay()]}`;
 });
 
 const productCards = computed<ProductCard[]>(() => {


### PR DESCRIPTION
## 变更内容

均集中在用户控制台。前端改了几个小瑕疵，如下：
* menu中集中出现多次的品牌名称，header的改为breadcrumb指示当前位置，取自路由。
* 日期格式调整：删除空格
* 头像偏移与greeting对齐：这个有点乱来了其实，直接加了个margin，原来更加偏上。两列直接flex的我也没啥好办法去处理 我第一个想到的是table（

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 重构/性能优化
- [x] 其他（请说明）

## 检查清单

- [x] 已阅读 [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] 已运行相关 lint 与静态检查（`composer format:check` / `npm run lint:frontends` 等）
- [x] 数据库变更通过新增 migration 实现，未改动 `database/schema/mysql-schema.sql` 基线
- [x] 未提交任何敏感信息（密钥、`.env`、真实域名等）

* lint似乎本来就过不去