### PR TITLE
Feat:smapi聚合认证插件、控制台暗色模式与邮件/短信配置完善

### DIFF
--- a/backend/app/Console/Commands/DatabaseNormalizeCoreRelationsCommand.php
+++ b/backend/app/Console/Commands/DatabaseNormalizeCoreRelationsCommand.php
@@ -10,13 +10,15 @@ use Illuminate\Console\Command;
 class DatabaseNormalizeCoreRelationsCommand extends Command
 {
     protected $signature = 'db:normalize-core-relations
+        {--execute : 实际写入；未指定时默认 dry-run，仅报告影响范围}
         {--json : 以 JSON 输出结果}';
 
-    protected $description = '清理核心关系伪引用、孤儿记录，并回填核心表 trace_id';
+    protected $description = '预览或执行核心关系伪引用规范化，并报告孤儿记录与 trace_id 缺口';
 
     public function handle(DatabaseEngineeringService $service): int
     {
-        $summary = $service->normalizeCoreRelations();
+        $execute = (bool) $this->option('execute');
+        $summary = $service->normalizeCoreRelations($execute);
 
         if ((bool) $this->option('json')) {
             $this->line(json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
@@ -24,7 +26,10 @@ class DatabaseNormalizeCoreRelationsCommand extends Command
             return self::SUCCESS;
         }
 
-        $this->info('核心关系规范化完成');
+        $this->info($execute ? '核心关系规范化执行完成' : '核心关系规范化 dry-run 完成');
+        if (! $execute) {
+            $this->warn('当前为 dry-run，未写入数据库、未删除任何记录；确认影响范围后追加 --execute 执行可逆字段修复。');
+        }
         foreach ($summary as $key => $value) {
             $this->line("- {$key}: {$value}");
         }

--- a/backend/app/Http/Controllers/Admin/V2/SupplierController.php
+++ b/backend/app/Http/Controllers/Admin/V2/SupplierController.php
@@ -142,7 +142,12 @@ class SupplierController extends Controller
 
     public function runTask(RunSupplierTaskRequest $request, Supplier $supplier)
     {
-        $result = $this->queryService->runSupplierTask($supplier, $request->taskType(), $request->payload());
+        $result = $this->queryService->runSupplierTask(
+            $supplier,
+            $request->taskType(),
+            $request->payload(),
+            $request->user()
+        );
 
         return $this->success(AdminActionResultResource::make($result)->resolve(), (string) $result['message']);
     }

--- a/backend/app/Http/Controllers/Client/V2/TicketController.php
+++ b/backend/app/Http/Controllers/Client/V2/TicketController.php
@@ -9,7 +9,6 @@ use App\Http\Requests\Client\V2\Ticket\ListTicketRepliesRequest;
 use App\Http\Requests\Client\V2\Ticket\ShowTicketRequest;
 use App\Http\Resources\Ticket\V2\TicketDetailResource;
 use App\Http\Resources\Ticket\V2\TicketReplyResource;
-use App\Models\Ticket;
 use App\Services\Ticket\TicketService;
 use Illuminate\Http\JsonResponse;
 
@@ -34,10 +33,8 @@ class TicketController extends Controller
         );
     }
 
-    private function findUserTicket(ShowTicketRequest|ListTicketRepliesRequest $request, int $ticket): Ticket
+    private function findUserTicket(ShowTicketRequest|ListTicketRepliesRequest $request, int $ticket)
     {
-        return Ticket::query()
-            ->where('user_id', (int) $request->user()->id)
-            ->findOrFail($ticket);
+        return $this->tickets->clientTicket((int) $request->user()->id, $ticket);
     }
 }

--- a/backend/app/Http/Controllers/Client/V2/TicketWorkflowController.php
+++ b/backend/app/Http/Controllers/Client/V2/TicketWorkflowController.php
@@ -3,14 +3,14 @@
 namespace App\Http\Controllers\Client\V2;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Client\V2\Action\ClientActionRequest;
+use App\Http\Requests\Client\V2\Ticket\ListTicketsRequest;
 use App\Http\Requests\Client\V2\Ticket\ReplyRequest;
 use App\Http\Requests\Client\V2\Ticket\ServiceOptionsRequest;
 use App\Http\Requests\Client\V2\Ticket\StoreRequest;
 use App\Http\Requests\Client\V2\Ticket\UploadImageRequest;
-use App\Models\Ticket;
 use App\Services\Ticket\TicketService;
 use App\Traits\ApiResponse;
-use Illuminate\Http\Request;
 
 class TicketWorkflowController extends Controller
 {
@@ -18,11 +18,13 @@ class TicketWorkflowController extends Controller
 
     public function __construct(private TicketService $ticketService) {}
 
-    public function index(Request $request)
+    public function index(ListTicketsRequest $request)
     {
-        $filters = $request->only(['keyword', 'status']);
-        $perPage = max(1, min((int) $request->input('page_size', 15), 50));
-        $paginator = $this->ticketService->clientList($request->user()->id, $filters, $perPage);
+        $paginator = $this->ticketService->clientList(
+            (int) $request->user()->id,
+            $request->filters(),
+            $request->perPage()
+        );
 
         return $this->paginate($paginator);
     }
@@ -58,20 +60,13 @@ class TicketWorkflowController extends Controller
         return $this->success($image, '图片上传成功');
     }
 
-    public function show(Request $request, int $id)
-    {
-        $ticket = Ticket::where('user_id', $request->user()->id)->findOrFail($id);
-
-        return $this->success($this->ticketService->detail($ticket));
-    }
-
     public function reply(ReplyRequest $request, int $id)
     {
-        $ticket = Ticket::where('user_id', $request->user()->id)->findOrFail($id);
+        $ticket = $this->ticketService->clientTicket((int) $request->user()->id, $id);
         $data = $request->validated();
         $reply = $this->ticketService->clientReply(
             $ticket,
-            $request->user()->id,
+            (int) $request->user()->id,
             $data['content'] ?? null,
             $data['attachments'] ?? [],
             $data['quote_reply_id'] ?? null,
@@ -80,25 +75,17 @@ class TicketWorkflowController extends Controller
         return $this->success($reply, '回复成功');
     }
 
-    public function recall(Request $request, int $id, int $replyId)
+    public function close(ClientActionRequest $request, int $id)
     {
-        $ticket = Ticket::where('user_id', $request->user()->id)->findOrFail($id);
-        $this->ticketService->recallReply($ticket, $replyId, $request->user()->id);
-
-        return $this->success(null, '消息已撤回');
-    }
-
-    public function close(Request $request, int $id)
-    {
-        $ticket = Ticket::where('user_id', $request->user()->id)->findOrFail($id);
-        $this->ticketService->clientClose($ticket, $request->user()->id);
+        $ticket = $this->ticketService->clientTicket((int) $request->user()->id, $id);
+        $this->ticketService->clientClose($ticket, (int) $request->user()->id);
 
         return $this->success(null, '工单已关闭');
     }
 
-    public function reopen(Request $request, int $id)
+    public function reopen(ClientActionRequest $request, int $id)
     {
-        $ticket = Ticket::where('user_id', $request->user()->id)->findOrFail($id);
+        $ticket = $this->ticketService->clientTicket((int) $request->user()->id, $id);
         $updated = $this->ticketService->reopen($ticket, [
             'operator_type' => 'client',
             'operator_id' => (int) $request->user()->id,

--- a/backend/app/Http/Requests/Client/V2/Service/CreateNatForwardingRequest.php
+++ b/backend/app/Http/Requests/Client/V2/Service/CreateNatForwardingRequest.php
@@ -14,7 +14,7 @@ class CreateNatForwardingRequest extends ClientFormRequest
             'name' => ['required', 'string', 'max:255'],
             'ext_port' => ['nullable', 'integer', 'between:1,65535'],
             'int_port' => ['required', 'integer', 'between:1,65535'],
-            'protocol' => ['required', 'string', 'in:1,2,3'],
+            'protocol' => ['required', 'string', 'regex:/\A[A-Za-z0-9_.-]+\z/', 'max:50'],
         ];
     }
 }

--- a/backend/app/Http/Requests/Client/V2/Ticket/ListTicketsRequest.php
+++ b/backend/app/Http/Requests/Client/V2/Ticket/ListTicketsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Client\V2\Ticket;
+
+use App\Http\Requests\Client\V2\Common\ClientFormRequest;
+use Illuminate\Validation\Rule;
+
+class ListTicketsRequest extends ClientFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'keyword' => ['nullable', 'string', 'max:100'],
+            'status' => ['nullable', Rule::in([0, 1, 2, 3, '0', '1', '2', '3'])],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'page_size' => ['nullable', 'integer', 'min:1', 'max:50'],
+            'pageSize' => ['prohibited'],
+            'per_page' => ['prohibited'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function filters(): array
+    {
+        return $this->safe()->only(['keyword', 'status']);
+    }
+
+    public function perPage(int $default = 15): int
+    {
+        return max(1, min((int) $this->integer('page_size', $default), 50));
+    }
+}

--- a/backend/app/Http/Resources/Client/V2/ClientInvoiceDetailResource.php
+++ b/backend/app/Http/Resources/Client/V2/ClientInvoiceDetailResource.php
@@ -75,6 +75,11 @@ class ClientInvoiceDetailResource extends AdminInvoiceSummaryResource
         ];
     }
 
+    protected function isSensitiveKey(string $key): bool
+    {
+        return parent::isSensitiveKey($key) || str_contains($key, 'trade_no');
+    }
+
     private function productWithOptions(mixed $product): ?array
     {
         if (! is_array($product)) {

--- a/backend/app/Services/Admin/V2/AdminConfigurationV2QueryService.php
+++ b/backend/app/Services/Admin/V2/AdminConfigurationV2QueryService.php
@@ -26,6 +26,7 @@ use App\Services\Upstream\Contracts\ProvidesConsoleCatalog;
 use App\Services\Upstream\Contracts\ProvidesRenewal;
 use App\Services\Upstream\ProviderRegistry;
 use App\Services\Upstream\ProviderResolver;
+use App\Support\AdminPermissions;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -438,8 +439,10 @@ class AdminConfigurationV2QueryService
      * @param  array<string, mixed>  $payload
      * @return array<string, mixed>
      */
-    public function runSupplierTask(Supplier $supplier, string $type, array $payload): array
+    public function runSupplierTask(Supplier $supplier, string $type, array $payload, ?AdminUser $operator = null): array
     {
+        $this->assertSupplierTaskPermission($type, $operator);
+
         $binding = app(PluginBindingResolver::class)->supplierBindingProjection($supplier, includeSecrets: true);
         $providerKey = trim((string) ($binding['provider_key'] ?? ''));
         if ($providerKey === '') {
@@ -497,6 +500,27 @@ class AdminConfigurationV2QueryService
             'type' => $type,
             'result' => $this->compactSupplierTaskResult($data),
         ]);
+    }
+
+    private function assertSupplierTaskPermission(string $type, ?AdminUser $operator): void
+    {
+        $requiredPermission = $this->requiredPermissionForSupplierTask($type);
+        if ($requiredPermission === null) {
+            throw new BusinessException('不支持的供应商插件动作', 42200);
+        }
+
+        if (! $operator?->hasPermission($requiredPermission)) {
+            throw new BusinessException('当前账号无权执行该供应商插件动作', 40300, 403);
+        }
+    }
+
+    private function requiredPermissionForSupplierTask(string $type): ?string
+    {
+        return match ($type) {
+            'server.supplier.refresh_card' => AdminPermissions::SUPPLIER_SYNC,
+            'server.supplier.bulk_connect' => AdminPermissions::PRODUCT_SYNC,
+            default => null,
+        };
     }
 
     /**

--- a/backend/app/Services/ClientServiceConsole/ServiceNatService.php
+++ b/backend/app/Services/ClientServiceConsole/ServiceNatService.php
@@ -101,12 +101,14 @@ class ServiceNatService
         ]);
 
         [$runtime, $supplier, $hostId, $jwt, $natContext] = $this->resolveNatAclContext($service, true);
+        $protocol = trim((string) ($data['protocol'] ?? ''));
+        $this->assertNatProtocolAllowed((array) ($natContext['protocols'] ?? []), $protocol);
         $payload = [
             'func' => 'addNatAcl',
             'name' => trim((string) ($data['name'] ?? '')),
             'ext_port' => trim((string) ($data['ext_port'] ?? '')),
             'int_port' => trim((string) ($data['int_port'] ?? '')),
-            'select-protocol' => trim((string) ($data['protocol'] ?? '')),
+            'select-protocol' => $protocol,
         ];
         $response = is_callable([$runtime, 'submitCustomModuleAction'])
             ? $runtime->submitCustomModuleAction($supplier, $natContext['endpoint'], $payload, $jwt)
@@ -128,8 +130,8 @@ class ServiceNatService
             'forwarding_name' => trim((string) ($data['name'] ?? '')),
             'external_port' => trim((string) ($data['ext_port'] ?? '')),
             'internal_port' => trim((string) ($data['int_port'] ?? '')),
-            'protocol' => trim((string) ($data['protocol'] ?? '')),
-            'protocol_label' => $this->transformService->resolveSelectOptionLabel((array) ($natContext['protocols'] ?? []), trim((string) ($data['protocol'] ?? ''))),
+            'protocol' => $protocol,
+            'protocol_label' => $this->transformService->resolveSelectOptionLabel((array) ($natContext['protocols'] ?? []), $protocol),
             'message' => $message,
         ], $context);
 
@@ -227,6 +229,27 @@ class ServiceNatService
         }
 
         Cache::forget($this->buildNatAclContextCacheKey($service));
+    }
+
+    private function assertNatProtocolAllowed(array $options, string $protocol): void
+    {
+        throw_if($protocol === '', new BusinessException('请选择 NAT 转发协议', 42200));
+
+        if ($options === []) {
+            throw new BusinessException('当前上游未返回可用 NAT 协议选项，请刷新后重试', 42200);
+        }
+
+        $allowed = collect($options)
+            ->filter(fn ($item): bool => is_array($item))
+            ->map(fn (array $item): string => trim((string) ($item['value'] ?? '')))
+            ->filter(fn (string $item): bool => $item !== '')
+            ->values()
+            ->all();
+
+        throw_if(
+            $allowed === [] || ! in_array($protocol, $allowed, true),
+            new BusinessException('NAT 转发协议不在当前上游允许范围内', 42200)
+        );
     }
 
     // ── NAT ACL HTML parsing ───────────────────────────────────────────────

--- a/backend/app/Services/ClientServiceConsole/ServiceSecurityGroupService.php
+++ b/backend/app/Services/ClientServiceConsole/ServiceSecurityGroupService.php
@@ -258,17 +258,24 @@ class ServiceSecurityGroupService
         ]);
 
         $securityGroupContext = $this->assertSecurityGroupVisibleToCurrentHost($service, $groupId);
+        $direction = trim((string) ($data['direction'] ?? ''));
+        $protocol = trim((string) ($data['protocol'] ?? ''));
+        $port = trim((string) ($data['port'] ?? ''));
+        $ip = trim((string) ($data['ip'] ?? ''));
+        $description = trim((string) ($data['description'] ?? ''));
+
+        $this->assertSecurityRulePayload($securityGroupContext, $direction, $protocol, $port, $ip);
 
         $result = $this->callSecurityGroupAction(
             $service,
             'createSecurityRule',
             [
                 'id' => $groupId,
-                'direction' => trim((string) ($data['direction'] ?? '')),
-                'protocol' => trim((string) ($data['protocol'] ?? '')),
-                'port' => trim((string) ($data['port'] ?? '')),
-                'ip' => trim((string) ($data['ip'] ?? '')),
-                'description' => trim((string) ($data['description'] ?? '')),
+                'direction' => $direction,
+                'protocol' => $protocol,
+                'port' => $port,
+                'ip' => $ip,
+                'description' => $description,
             ],
             '创建安全组规则',
             $securityGroupContext
@@ -282,13 +289,13 @@ class ServiceSecurityGroupService
             'host_id' => (int) ($result['context']['host_id'] ?? 0),
             'group_id' => $groupId,
             'group_name' => $this->resolveSecurityGroupName((array) ($result['context']['groups'] ?? []), $groupId),
-            'direction' => trim((string) ($data['direction'] ?? '')),
-            'direction_label' => $this->transformService->resolveSelectOptionLabel((array) ($result['context']['directions'] ?? []), trim((string) ($data['direction'] ?? ''))),
-            'protocol' => trim((string) ($data['protocol'] ?? '')),
-            'protocol_label' => $this->transformService->resolveSelectOptionLabel((array) ($result['context']['protocols'] ?? []), trim((string) ($data['protocol'] ?? ''))),
-            'port' => trim((string) ($data['port'] ?? '')),
-            'ip' => trim((string) ($data['ip'] ?? '')),
-            'description' => trim((string) ($data['description'] ?? '')),
+            'direction' => $direction,
+            'direction_label' => $this->transformService->resolveSelectOptionLabel((array) ($result['context']['directions'] ?? []), $direction),
+            'protocol' => $protocol,
+            'protocol_label' => $this->transformService->resolveSelectOptionLabel((array) ($result['context']['protocols'] ?? []), $protocol),
+            'port' => $port,
+            'ip' => $ip,
+            'description' => $description,
             'message' => $message,
         ], $context);
 
@@ -467,6 +474,99 @@ class ServiceSecurityGroupService
         $this->detailService->assertSuccess($response, $action);
 
         return ['context' => $context, 'response' => $response];
+    }
+
+    private function assertSecurityRulePayload(array $context, string $direction, string $protocol, string $port, string $ip): void
+    {
+        $this->assertSecurityOptionAllowed((array) ($context['directions'] ?? []), $direction, '方向');
+        $this->assertSecurityOptionAllowed((array) ($context['protocols'] ?? []), $protocol, '协议');
+        $this->assertSecurityPortExpression($port);
+        $this->assertSecurityIpExpression($ip);
+    }
+
+    private function assertSecurityOptionAllowed(array $options, string $value, string $label): void
+    {
+        if ($value === '') {
+            throw new BusinessException('请选择安全组规则'.$label, 42200);
+        }
+
+        if ($options === []) {
+            return;
+        }
+
+        $allowed = collect($options)
+            ->filter(fn ($item): bool => is_array($item))
+            ->map(fn (array $item): string => trim((string) ($item['value'] ?? '')))
+            ->filter(fn (string $item): bool => $item !== '')
+            ->values()
+            ->all();
+
+        throw_if(
+            $allowed !== [] && ! in_array($value, $allowed, true),
+            new BusinessException('安全组规则'.$label.'不在当前上游允许范围内', 42200)
+        );
+    }
+
+    private function assertSecurityPortExpression(string $value): void
+    {
+        throw_if($value === '', new BusinessException('请填写安全组规则端口', 42200));
+
+        $segments = preg_split('/\s*,\s*/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        throw_if($segments === [], new BusinessException('请填写安全组规则端口', 42200));
+
+        foreach ($segments as $segment) {
+            $segment = trim($segment);
+            if ($segment === '*') {
+                continue;
+            }
+
+            if (preg_match('/^\d{1,5}$/', $segment) === 1) {
+                $port = (int) $segment;
+                throw_if($port < 1 || $port > 65535, new BusinessException('端口必须在 1-65535 之间', 42200));
+                continue;
+            }
+
+            if (preg_match('/^(\d{1,5})-(\d{1,5})$/', $segment, $matches) === 1) {
+                $start = (int) $matches[1];
+                $end = (int) $matches[2];
+                throw_if($start < 1 || $start > 65535 || $end < 1 || $end > 65535 || $start > $end, new BusinessException('端口范围必须在 1-65535 之间且起始端口不能大于结束端口', 42200));
+                continue;
+            }
+
+            throw new BusinessException('端口格式不正确，仅支持单端口、端口范围或英文逗号分隔列表', 42200);
+        }
+    }
+
+    private function assertSecurityIpExpression(string $value): void
+    {
+        throw_if($value === '', new BusinessException('请填写安全组规则授权地址', 42200));
+
+        $segments = preg_split('/\s*,\s*/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        throw_if($segments === [], new BusinessException('请填写安全组规则授权地址', 42200));
+
+        foreach ($segments as $segment) {
+            $segment = trim($segment);
+            if ($segment === '*') {
+                continue;
+            }
+
+            if (filter_var($segment, FILTER_VALIDATE_IP) !== false) {
+                continue;
+            }
+
+            if (preg_match('/^([^\/]+)\/(\d{1,3})$/', $segment, $matches) === 1) {
+                $ip = trim((string) $matches[1]);
+                $prefix = (int) $matches[2];
+                $isV4 = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+                $isV6 = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+                throw_if(! $isV4 && ! $isV6, new BusinessException('授权地址必须是合法 IP 或 CIDR', 42200));
+                throw_if($isV4 && ($prefix < 0 || $prefix > 32), new BusinessException('IPv4 CIDR 前缀必须在 0-32 之间', 42200));
+                throw_if($isV6 && ($prefix < 0 || $prefix > 128), new BusinessException('IPv6 CIDR 前缀必须在 0-128 之间', 42200));
+                continue;
+            }
+
+            throw new BusinessException('授权地址必须是合法 IP、CIDR 或英文逗号分隔列表', 42200);
+        }
     }
 
     private function isNativeSecurityGroupContext(array $context): bool

--- a/backend/app/Services/ProductCatalog/ProductAdminService.php
+++ b/backend/app/Services/ProductCatalog/ProductAdminService.php
@@ -671,13 +671,17 @@ class ProductAdminService
         throw_if(! $product->trashed(), new BusinessException('请先删除商品，再执行彻底删除'));
         throw_if($product->services()->count() > 0, new BusinessException('该商品已有服务实例，无法彻底删除'));
 
-        if (Schema::hasTable('product_upstream_bindings')) {
-            DB::table('product_upstream_bindings')
-                ->where('product_id', (int) $product->id)
-                ->delete();
-        }
+        // 绑定清理与物理删除同事务：物理删除失败时保留绑定，避免软删商品丢失上游映射。
+        DB::transaction(function () use ($product): void {
+            if (Schema::hasTable('product_upstream_bindings')) {
+                DB::table('product_upstream_bindings')
+                    ->where('product_id', (int) $product->id)
+                    ->delete();
+            }
 
-        $product->forceDelete();
+            $product->forceDelete();
+        });
+
         $this->forgetSiteCatalogCache();
     }
 

--- a/backend/app/Services/ProductCatalog/ProductSyncService.php
+++ b/backend/app/Services/ProductCatalog/ProductSyncService.php
@@ -1210,10 +1210,13 @@ class ProductSyncService
             return [];
         }
 
+        // 上游金额是两位小数字符串（如 '19.99'）。周期换算先转为“分”整数再相乘，
+        // 避免浮点乘法（如 19.99 * 12 = 239.87999...）在边界产生一分钱误差。
+        $monthlyBaseCents = (int) round(((float) $monthlyBasePrice) * 100);
         $pricing = [];
 
         foreach (self::IMPORT_PRICING_MONTHS as $cycle => $months) {
-            $pricing[$cycle] = number_format($monthlyBasePrice * $months, 2, '.', '');
+            $pricing[$cycle] = number_format($monthlyBaseCents * $months / 100, 2, '.', '');
         }
 
         return $pricing;

--- a/backend/app/Services/System/DatabaseEngineeringService.php
+++ b/backend/app/Services/System/DatabaseEngineeringService.php
@@ -224,8 +224,13 @@ class DatabaseEngineeringService
             'trace_ids_backfilled' => 0,
         ];
 
-        DB::transaction(function () use (&$summary, $execute): void {
+        // 结构调整（ALTER）只允许在执行模式发生，dry-run 绝不改库：
+        // MySQL DDL 会隐式提交并锁定表，与 dry-run 只读承诺冲突。
+        if ($execute) {
             $this->ensureNullableUnsignedBigInt('services', 'order_id');
+        }
+
+        DB::transaction(function () use (&$summary, $execute): void {
             $summary['services_order_id_zero_to_null'] = $execute
                 ? $this->normalizeZeroReference('services', 'order_id')
                 : $this->countZeroReference('services', 'order_id');

--- a/backend/app/Services/System/DatabaseEngineeringService.php
+++ b/backend/app/Services/System/DatabaseEngineeringService.php
@@ -197,9 +197,10 @@ class DatabaseEngineeringService
     /**
      * @return array<string, int>
      */
-    public function normalizeCoreRelations(): array
+    public function normalizeCoreRelations(bool $execute = false): array
     {
         $summary = [
+            'mode' => $execute ? 'execute' : 'dry_run',
             'services_order_id_zero_to_null' => 0,
             'services_invoice_id_zero_to_null' => 0,
             'payments_order_id_zero_to_null' => 0,
@@ -213,71 +214,84 @@ class DatabaseEngineeringService
             'services_cleared_orphan_invoice_id' => 0,
             'invoices_cleared_orphan_order_id' => 0,
             'invoices_deleted_orphan_user_or_product' => 0,
+            'invoice_items_orphan_reported' => 0,
+            'payment_callbacks_orphan_reported' => 0,
+            'user_accounts_orphan_reported' => 0,
+            'ticket_replies_orphan_reported' => 0,
+            'services_orphan_user_or_product_reported' => 0,
+            'invoices_orphan_user_or_product_reported' => 0,
             'payments_orphan_user_or_invoice_reported' => 0,
             'trace_ids_backfilled' => 0,
         ];
 
-        DB::transaction(function () use (&$summary): void {
+        DB::transaction(function () use (&$summary, $execute): void {
             $this->ensureNullableUnsignedBigInt('services', 'order_id');
-            $summary['services_order_id_zero_to_null'] = $this->normalizeZeroReference('services', 'order_id');
-            $summary['services_invoice_id_zero_to_null'] = $this->normalizeZeroReference('services', 'invoice_id');
-            $summary['payments_order_id_zero_to_null'] = $this->normalizeZeroReference('payments', 'order_id');
-            $summary['payments_invoice_id_zero_to_null'] = $this->normalizeZeroReference('payments', 'invoice_id');
-            $summary['invoices_order_id_zero_to_null'] = $this->normalizeZeroReference('invoices', 'order_id');
+            $summary['services_order_id_zero_to_null'] = $execute
+                ? $this->normalizeZeroReference('services', 'order_id')
+                : $this->countZeroReference('services', 'order_id');
+            $summary['services_invoice_id_zero_to_null'] = $execute
+                ? $this->normalizeZeroReference('services', 'invoice_id')
+                : $this->countZeroReference('services', 'invoice_id');
+            $summary['payments_order_id_zero_to_null'] = $execute
+                ? $this->normalizeZeroReference('payments', 'order_id')
+                : $this->countZeroReference('payments', 'order_id');
+            $summary['payments_invoice_id_zero_to_null'] = $execute
+                ? $this->normalizeZeroReference('payments', 'invoice_id')
+                : $this->countZeroReference('payments', 'invoice_id');
+            $summary['invoices_order_id_zero_to_null'] = $execute
+                ? $this->normalizeZeroReference('invoices', 'order_id')
+                : $this->countZeroReference('invoices', 'order_id');
 
-            $summary['invoice_items_deleted_orphans'] = $this->deleteOrphans(
+            $summary['invoice_items_orphan_reported'] = $this->countOrphans(
                 'invoice_items',
                 'invoice_id',
                 'invoices',
                 'id'
             );
-            $summary['payment_callbacks_deleted_orphans'] = $this->deleteOrphans(
+            $summary['payment_callbacks_orphan_reported'] = $this->countOrphans(
                 'payment_callbacks',
                 'payment_id',
                 'payments',
                 'id'
             );
-            $summary['user_accounts_deleted_orphans'] = $this->deleteOrphans(
+            $summary['user_accounts_orphan_reported'] = $this->countOrphans(
                 'user_accounts',
                 'user_id',
                 'users',
-                'id',
-                'user_id'
+                'id'
             );
-            $summary['ticket_replies_deleted_orphans'] = $this->deleteOrphans(
+            $summary['ticket_replies_orphan_reported'] = $this->countOrphans(
                 'ticket_replies',
                 'ticket_id',
                 'tickets',
                 'id'
             );
 
-            $summary['services_deleted_orphan_user_or_product'] =
-                $this->deleteOrphans('services', 'user_id', 'users', 'id')
-                + $this->deleteOrphans('services', 'product_id', 'products', 'id');
-            $summary['services_cleared_orphan_invoice_id'] = $this->clearOrphansToNull(
-                'services',
-                'invoice_id',
-                'invoices',
-                'id'
-            );
-            $summary['invoices_cleared_orphan_order_id'] = $this->clearOrphansToNull(
-                'invoices',
-                'order_id',
-                'orders',
-                'id'
-            );
-            $summary['invoices_deleted_orphan_user_or_product'] =
-                $this->deleteOrphans('invoices', 'user_id', 'users', 'id')
-                + $this->deleteOrphans('invoices', 'product_id', 'products', 'id');
+            $summary['services_orphan_user_or_product_reported'] =
+                $this->countOrphans('services', 'user_id', 'users', 'id')
+                + $this->countOrphans('services', 'product_id', 'products', 'id');
+            $summary['services_cleared_orphan_invoice_id'] = $execute
+                ? $this->clearOrphansToNull('services', 'invoice_id', 'invoices', 'id')
+                : $this->countOrphans('services', 'invoice_id', 'invoices', 'id');
+            $summary['invoices_cleared_orphan_order_id'] = $execute
+                ? $this->clearOrphansToNull('invoices', 'order_id', 'orders', 'id')
+                : $this->countOrphans('invoices', 'order_id', 'orders', 'id');
+            $summary['invoices_orphan_user_or_product_reported'] =
+                $this->countOrphans('invoices', 'user_id', 'users', 'id')
+                + $this->countOrphans('invoices', 'product_id', 'products', 'id');
             $summary['payments_orphan_user_or_invoice_reported'] =
                 $this->countOrphans('payments', 'user_id', 'users', 'id')
                 + $this->countOrphans('payments', 'invoice_id', 'invoices', 'id');
 
-            $summary['trace_ids_backfilled'] =
-                $this->backfillTraceIds('invoices') +
-                $this->backfillTraceIds('payments') +
-                $this->backfillTraceIds('services') +
-                $this->backfillTraceIds('account_transactions');
+            $summary['trace_ids_backfilled'] = $execute
+                ? $this->backfillTraceIds('invoices')
+                    + $this->backfillTraceIds('payments')
+                    + $this->backfillTraceIds('services')
+                    + $this->backfillTraceIds('account_transactions')
+                : $this->countMissingTraceId('invoices')
+                    + $this->countMissingTraceId('payments')
+                    + $this->countMissingTraceId('services')
+                    + $this->countMissingTraceId('account_transactions');
         });
 
         return $summary;
@@ -597,6 +611,15 @@ class DatabaseEngineeringService
         }
 
         return DB::table($table)->where($column, 0)->update([$column => null]);
+    }
+
+    private function countZeroReference(string $table, string $column): int
+    {
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, $column)) {
+            return 0;
+        }
+
+        return DB::table($table)->where($column, 0)->count();
     }
 
     private function deleteOrphans(string $table, string $column, string $parentTable, string $parentColumn, string $primaryColumn = 'id'): int

--- a/backend/app/Services/Ticket/TicketService.php
+++ b/backend/app/Services/Ticket/TicketService.php
@@ -342,6 +342,13 @@ class TicketService
         return $ticket->fresh();
     }
 
+    public function clientTicket(int $userId, int $ticketId): Ticket
+    {
+        return Ticket::query()
+            ->where('user_id', $userId)
+            ->findOrFail($ticketId);
+    }
+
     /**
      * 客户端列表
      */

--- a/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
+++ b/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
@@ -666,8 +666,13 @@ class HostingPanelApiTransport implements ProvidesConsoleAccess, ProvidesConsole
         // WAF 挑战页自动会话：部分上游（如 idcxl 系）在无 cookie 时返回
         // <script>document.cookie = 'xxx_token=...; path=/'</script> 形式的 JS 挑战页，
         // 携带该 cookie 重试一次即可正常返回 JSON。仅重试一次，避免死循环。
+        // 重试前提收紧为“WAF 标记 + 典型状态码”双条件：
+        // - extractChallengeCookie 命中 document.cookie 赋值语句（WAF JS 挑战页强特征，
+        //   业务异常页不会携带该标记），说明请求被 WAF 拦截在业务处理之前；
+        // - 状态码仅 200/403（挑战页典型响应），排除 4xx/5xx 业务错误页被误重放。
         if ($output !== false
             && ! is_array(json_decode($output, true))
+            && in_array($httpCode, [200, 403], true)
             && $this->looksLikeHtmlResponse((string) $output, $contentType)
             && ! $this->hasCookieHeader($requestHeaders)
         ) {

--- a/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
+++ b/backend/app/Services/Upstream/Drivers/HostingPanelApi/HostingPanelApiTransport.php
@@ -666,15 +666,21 @@ class HostingPanelApiTransport implements ProvidesConsoleAccess, ProvidesConsole
         // WAF 挑战页自动会话：部分上游（如 idcxl 系）在无 cookie 时返回
         // <script>document.cookie = 'xxx_token=...; path=/'</script> 形式的 JS 挑战页，
         // 携带该 cookie 重试一次即可正常返回 JSON。仅重试一次，避免死循环。
-        // 重试前提收紧为“WAF 标记 + 典型状态码”双条件：
+        // 重试前提收紧为“WAF 标记 + 典型状态码 + 幂等性”三重条件：
         // - extractChallengeCookie 命中 document.cookie 赋值语句（WAF JS 挑战页强特征，
         //   业务异常页不会携带该标记），说明请求被 WAF 拦截在业务处理之前；
-        // - 状态码仅 200/403（挑战页典型响应），排除 4xx/5xx 业务错误页被误重放。
+        // - 状态码仅 200/403（挑战页典型响应），排除 4xx/5xx 业务错误页被误重放；
+        // - 仅幂等方法（GET/HEAD/OPTIONS）可自动重试；POST/PUT/DELETE 等非幂等请求
+        //   只在登录端点（如 /passport/login，重复登录幂等）且仍无会话时重试，
+        //   避免续费/结算/流量包购买等写操作被重放造成重复扣款。
+        $isIdempotentMethod = in_array($method, ['GET', 'HEAD', 'OPTIONS'], true);
+        $retryAllowed = $isIdempotentMethod || $this->isLoginEndpoint($uri);
         if ($output !== false
             && ! is_array(json_decode($output, true))
             && in_array($httpCode, [200, 403], true)
             && $this->looksLikeHtmlResponse((string) $output, $contentType)
             && ! $this->hasCookieHeader($requestHeaders)
+            && $retryAllowed
         ) {
             $challengeCookie = $this->extractChallengeCookie((string) $output);
             if ($challengeCookie !== '') {

--- a/backend/app/Support/SmsNotificationTemplateDefaults.php
+++ b/backend/app/Support/SmsNotificationTemplateDefaults.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * 短信通知默认模板内容（channel=sms）。
+ *
+ * 说明：
+ * - 只内置「验证码短信」100001 的最小必需内容，供非阿里云类短信驱动
+ *   在 sendTemplateSms 路径渲染正文；阿里云验证码走驱动自身的
+ *   verifyCodeTemplate + 云商模板 ID，不依赖本地 content。
+ * - 其余业务短信模板（登录提醒等）的 content / provider_template_id
+ *   由后台在「通知与接口 → 短信模板」按服务商要求维护。
+ */
+final class SmsNotificationTemplateDefaults
+{
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public static function templates(): array
+    {
+        return [
+            [
+                'code' => SmsTemplateCatalog::TEMPLATE_VERIFY_CODE,
+                'name' => '验证码短信',
+                'description' => '用户获取短信验证码时发送。',
+                'content' => '您的验证码为{{code}}，请在{{expire_minutes}}分钟内填写，请勿向他人泄露。',
+                'variables' => ['code', 'min', 'expire_minutes'],
+                'audience' => 'user',
+            ],
+        ];
+    }
+}

--- a/backend/database/seeders/SettingsSeeder.php
+++ b/backend/database/seeders/SettingsSeeder.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Database\Seeders;
 
 use App\Models\Setting;
+use App\Support\EmailNotificationTemplateDefaults;
+use App\Support\SmsNotificationTemplateDefaults;
 use App\Support\SmsTemplateCatalog;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class SettingsSeeder
 {
@@ -119,6 +122,63 @@ class SettingsSeeder
         static::seedGroup('content', [
             'published_cache_version' => '1',
         ]);
+
+        // 通知模板默认数据（email 全量 + sms 验证码）：幂等种入，
+        // 修复 schema baseline 只含表结构不含模板数据的部署缺口。
+        static::seedNotificationTemplates();
+    }
+
+    /**
+     * 幂等种入通知模板默认数据：按 channel+code 跳过已存在的模板，
+     * 不会覆盖管理员在后台的个性化内容。
+     */
+    private static function seedNotificationTemplates(): void
+    {
+        if (! Schema::hasTable('notification_templates')) {
+            return;
+        }
+
+        $definitions = [
+            'email' => EmailNotificationTemplateDefaults::templates(),
+            'sms' => SmsNotificationTemplateDefaults::templates(),
+        ];
+
+        foreach ($definitions as $channel => $templates) {
+            foreach ($templates as $definition) {
+                $code = trim((string) ($definition['code'] ?? ''));
+                if ($code === '') {
+                    continue;
+                }
+
+                $exists = DB::table('notification_templates')
+                    ->where('channel', $channel)
+                    ->where('code', $code)
+                    ->exists();
+                if ($exists) {
+                    continue;
+                }
+
+                DB::table('notification_templates')->insert([
+                    'channel' => $channel,
+                    'code' => $code,
+                    'name' => (string) ($definition['name'] ?? $code),
+                    'description' => (string) ($definition['description'] ?? ''),
+                    'audience' => (string) ($definition['audience'] ?? 'user'),
+                    'subject' => isset($definition['subject']) && trim((string) $definition['subject']) !== ''
+                        ? (string) $definition['subject']
+                        : null,
+                    'content' => (string) ($definition['content'] ?? ''),
+                    'variables_json' => json_encode(array_values((array) ($definition['variables'] ?? []))),
+                    'provider_variables_json' => '[]',
+                    'provider_template_id' => null,
+                    'is_enabled' => 1,
+                    'is_custom' => 0,
+                    'sort_order' => 0,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
     }
 
     private static function seedGroup(string $group, array $values): void

--- a/backend/database/seeders/SettingsSeeder.php
+++ b/backend/database/seeders/SettingsSeeder.php
@@ -150,15 +150,9 @@ class SettingsSeeder
                     continue;
                 }
 
-                $exists = DB::table('notification_templates')
-                    ->where('channel', $channel)
-                    ->where('code', $code)
-                    ->exists();
-                if ($exists) {
-                    continue;
-                }
-
-                DB::table('notification_templates')->insert([
+                // insertOrIgnore 依赖 (channel, code) 唯一约束原子跳过已存在模板，
+                // 避免 exists() + insert() 之间的并发窗口造成重复键异常；不覆盖后台个性化内容。
+                DB::table('notification_templates')->insertOrIgnore([
                     'channel' => $channel,
                     'code' => $code,
                     'name' => (string) ($definition['name'] ?? $code),

--- a/backend/plugins/certification/smapi/README.md
+++ b/backend/plugins/certification/smapi/README.md
@@ -21,7 +21,7 @@ backend/plugins/certification/smapi/
 | `api_url`      | url      | 否   | 平台地址，默认 `https://smapi.x1m1.cn`           |
 | `app_key`      | text     | 是   | 用户中心 API 密钥 AppKey                         |
 | `secret_key`   | password | 是   | 用户中心 API 密钥 AppSecret（加密保存）          |
-| `product_code` | textarea | 是   | 产品标识；多产品按 `code,名称|code,名称` 填写     |
+| `product_code` | textarea | 是   | 产品标识；多产品按 `code,名称\|code,名称` 填写     |
 | `ssl_verify`   | switch   | 否   | 是否校验服务商 HTTPS 证书，默认开启              |
 | `ca_bundle`    | text     | 否   | 本地 CA bundle 文件路径                          |
 | `charge_enabled` | switch | 否 | 开启后用户发起认证按配置金额扣费                 |

--- a/backend/plugins/certification/smapi/README.md
+++ b/backend/plugins/certification/smapi/README.md
@@ -1,0 +1,51 @@
+# 聚合实名认证插件（smapi）
+
+对接小沐实名 API（https://smapi.x1m1.cn）的实名认证插件。
+
+## 目录
+
+```text
+backend/plugins/certification/smapi/
+├── SmapiPlugin.php       # 入口类（execute 分发）
+├── config.php            # 插件清单与配置 schema
+├── logic/
+│   ├── Smapi.php         # action 分发、回调与计费配置
+│   └── SmapiClient.php   # 上游 HTTP 客户端（自包含）
+└── README.md
+```
+
+## 配置项
+
+| 字段           | 类型     | 必填 | 说明                                             |
+| -------------- | -------- | ---- | ------------------------------------------------ |
+| `api_url`      | url      | 否   | 平台地址，默认 `https://smapi.x1m1.cn`           |
+| `app_key`      | text     | 是   | 用户中心 API 密钥 AppKey                         |
+| `secret_key`   | password | 是   | 用户中心 API 密钥 AppSecret（加密保存）          |
+| `product_code` | textarea | 是   | 产品标识；多产品按 `code,名称|code,名称` 填写     |
+| `ssl_verify`   | switch   | 否   | 是否校验服务商 HTTPS 证书，默认开启              |
+| `ca_bundle`    | text     | 否   | 本地 CA bundle 文件路径                          |
+| `charge_enabled` | switch | 否 | 开启后用户发起认证按配置金额扣费                 |
+| `amount`       | number   | 否   | 收费金额（元）                                   |
+| `free_times`   | number   | 否   | 每个用户免费认证次数                             |
+
+## 接口行为
+
+- `certification.initialize`：调用 `POST /api/realname/initialize` 创建认证记录，
+  请求体为 `product_code`（取配置中第一个有效产品标识）、`cert_name`、`cert_no`、`return_url`，
+  成功后返回上游记录 `id` 作为 `certify_id`。
+- `certification.scan_url`：调用查询接口，从返回数据中提取认证页面链接
+  （`certify_page_url` / `certify_url` / `url` / `qrcode_url` / `qr_code_url`）。
+- `certification.query_status`：状态映射为项目内部约定：
+  `passed` → 1（通过）、`failed` / `updated` → 2（不通过，带失败原因）、
+  `initialized` / `processing` → 4（处理中）、网络异常 → 3（保留原状态）。
+- `certification.verify_callback`：平台不提供服务端签名回调，固定返回不支持（501），
+  认证结果一律通过轮询查询获得。
+- `certification.fee_config`：按 `charge_enabled` / `amount` / `free_times` 输出计费配置。
+
+## 注意事项
+
+- 当前用户端实名流程不收集手机号（`initialize` 不传 `mobile`），
+  如配置的产品强制要求手机号三要素，请与服务商确认接口行为或选择不强制手机号的产品。
+- 多产品配置时客户前台的“认证接口”下拉选择在当前用户端未实现，
+  当前始终使用配置中第一个产品标识发起认证。
+- 密钥通过 `secret=true` 加密保存且不明文回显。

--- a/backend/plugins/certification/smapi/SmapiPlugin.php
+++ b/backend/plugins/certification/smapi/SmapiPlugin.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\Smapi;
+
+use TuraIDC\Plugins\Certification\Smapi\Logic\Smapi;
+
+class SmapiPlugin extends Smapi {}

--- a/backend/plugins/certification/smapi/config.php
+++ b/backend/plugins/certification/smapi/config.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use TuraIDC\Plugins\Certification\Smapi\SmapiPlugin;
+
+return [
+    'info' => [
+        'domain' => 'verification',
+        'slug' => 'smapi',
+        'key' => 'smapi',
+        'name' => '聚合实名认证',
+        'version' => '1.0.0',
+        'entry' => SmapiPlugin::class,
+        'capabilities' => ['personal', 'scan_url', 'query_status', 'verify_callback', 'fee_config'],
+        'extra' => [
+            'driver_binding' => [
+                'binding_key' => 'verification_driver',
+                'provider_key' => 'smapi',
+            ],
+        ],
+    ],
+    'config' => [
+        'basic_notice' => [
+            'title' => '配置说明',
+            'type' => 'notice',
+            'theme' => 'info',
+            'content' => '对接小沐实名 API（smapi.x1m1.cn）聚合实名平台。请填写用户中心分配的 AppKey、AppSecret 与产品标识；密钥保存后不会明文回显。',
+        ],
+        'api_url' => [
+            'title' => 'API 地址',
+            'type' => 'url',
+            'value' => 'https://smapi.x1m1.cn',
+            'required' => false,
+            'placeholder' => 'https://smapi.x1m1.cn',
+            'description' => '聚合实名平台地址，一般保持默认，只有服务商要求时才修改。',
+        ],
+        'app_key' => [
+            'title' => 'AppKey',
+            'type' => 'text',
+            'value' => '',
+            'required' => true,
+            'placeholder' => '请输入用户中心 API 密钥 AppKey',
+            'description' => '用户中心 API 密钥 AppKey。',
+        ],
+        'secret_key' => [
+            'title' => 'AppSecret',
+            'type' => 'password',
+            'value' => '',
+            'required' => true,
+            'secret' => true,
+            'placeholder' => '请输入用户中心 API 密钥 AppSecret',
+            'description' => '已配置时不会明文回显，留空表示不修改。',
+        ],
+        'product_code' => [
+            'title' => '产品标识',
+            'type' => 'textarea',
+            'value' => '',
+            'required' => true,
+            'rows' => 4,
+            'placeholder' => "alipay_v3\n或 alipay_v3,支付宝身份认证|tencent_sm,微信实名认证",
+            'description' => '单个接口直接填写产品标识，例如 alipay_v3；多个接口按“产品标识,显示名称|产品标识,显示名称”填写，多个产品时取第一个作为默认认证产品。',
+        ],
+        'ssl_verify' => [
+            'title' => 'SSL 证书校验',
+            'type' => 'switch',
+            'value' => true,
+            'description' => '开启后校验服务商 HTTPS 证书；证书链异常时可关闭或配置 CA 证书路径。',
+        ],
+        'ca_bundle' => [
+            'title' => 'CA 证书路径',
+            'type' => 'text',
+            'value' => '',
+            'required' => false,
+            'placeholder' => '例如 /etc/ssl/certs/cacert.pem',
+            'description' => '可选，填写服务器本地 CA bundle 文件路径。',
+        ],
+        'billing_divider' => ['title' => '计费设置', 'type' => 'divider'],
+        'charge_enabled' => [
+            'title' => '插件收费',
+            'type' => 'switch',
+            'value' => false,
+            'description' => '开启后，用户发起实名认证时按配置金额扣费。',
+        ],
+        'amount' => [
+            'title' => '收费金额',
+            'type' => 'number',
+            'value' => 0,
+            'min' => 0,
+            'step' => 0.01,
+            'description' => '单位：元。关闭收费时该字段不生效。',
+            'visible_when' => ['field' => 'charge_enabled', 'operator' => 'eq', 'value' => true],
+        ],
+        'free_times' => [
+            'title' => '免费次数',
+            'type' => 'number',
+            'value' => 0,
+            'min' => 0,
+            'step' => 1,
+            'description' => '每个用户可免费发起认证的次数。',
+        ],
+    ],
+];

--- a/backend/plugins/certification/smapi/logic/Smapi.php
+++ b/backend/plugins/certification/smapi/logic/Smapi.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\Smapi\Logic;
+
+class Smapi
+{
+    private ?SmapiClient $client = null;
+
+    public function key(): string
+    {
+        return 'smapi';
+    }
+
+    public function label(): string
+    {
+        return '聚合实名认证';
+    }
+
+    /**
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     */
+    public function execute(array $request): array
+    {
+        $action = trim((string) ($request['action'] ?? ''));
+        $payload = is_array($request['payload'] ?? null) ? $request['payload'] : [];
+        $config = is_array($request['config'] ?? null) ? $request['config'] : [];
+
+        $client = $this->client($config);
+
+        return match ($action) {
+            'certification.initialize' => $this->success($action, $client->initialize(
+                realName: (string) ($payload['real_name'] ?? ''),
+                idCard: (string) ($payload['id_card'] ?? ''),
+                returnUrl: (string) ($payload['return_url'] ?? ''),
+            )),
+            'certification.scan_url' => $this->success($action, $client->scanUrl(
+                (string) ($payload['certify_id'] ?? '')
+            )),
+            'certification.query_status' => $this->success($action, $client->queryStatus(
+                (string) ($payload['certify_id'] ?? '')
+            )),
+            'certification.verify_callback' => $this->success($action, $this->verifyCallback()),
+            'certification.fee_config' => $this->success($action, $this->feeConfig($config)),
+            default => [
+                'success' => false,
+                'action' => $action,
+                'message' => 'Unsupported plugin action',
+                'data' => [],
+            ],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function client(array $config): SmapiClient
+    {
+        if ($this->client === null) {
+            $this->client = new SmapiClient($config);
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{success: bool, action: string, data: array<string, mixed>}
+     */
+    private function success(string $action, array $data): array
+    {
+        return [
+            'success' => true,
+            'action' => $action,
+            'data' => $data,
+        ];
+    }
+
+    /**
+     * 聚合实名平台不提供服务端签名回调，认证结果通过轮询 query_status 获取。
+     *
+     * @return array{passed: bool, message: string, code: int, http_status: int}
+     */
+    private function verifyCallback(): array
+    {
+        return [
+            'passed' => false,
+            'message' => '聚合实名平台不支持服务端签名回调，请使用轮询查询认证结果',
+            'code' => 40001,
+            'http_status' => 501,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @return array{free_attempts: int, retry_fee: float, free_times: int, amount: float, charge_enabled: bool}
+     */
+    private function feeConfig(array $config): array
+    {
+        $chargeEnabled = filter_var($config['charge_enabled'] ?? false, FILTER_VALIDATE_BOOL);
+        $amount = max(0.0, (float) ($config['amount'] ?? 0));
+        $freeTimes = max(0, (int) ($config['free_times'] ?? $config['free_attempts'] ?? 0));
+
+        return [
+            'free_attempts' => $freeTimes,
+            'retry_fee' => $chargeEnabled ? $amount : 0.0,
+            'free_times' => $freeTimes,
+            'amount' => $amount,
+            'charge_enabled' => $chargeEnabled,
+        ];
+    }
+}

--- a/backend/plugins/certification/smapi/logic/SmapiClient.php
+++ b/backend/plugins/certification/smapi/logic/SmapiClient.php
@@ -223,7 +223,10 @@ class SmapiClient
 
     private function resolveEndpoint(): string
     {
-        return (string) ($this->config['api_url'] ?? self::DEFAULT_API_ENDPOINT);
+        // 用空值判断而非 ??：管理员清空 api_url 后回退到默认地址，避免拼出相对 URL。
+        $endpoint = trim((string) ($this->config['api_url'] ?? ''));
+
+        return $endpoint !== '' ? $endpoint : self::DEFAULT_API_ENDPOINT;
     }
 
     private function resolveAppKey(): string

--- a/backend/plugins/certification/smapi/logic/SmapiClient.php
+++ b/backend/plugins/certification/smapi/logic/SmapiClient.php
@@ -1,0 +1,412 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\Smapi\Logic;
+
+use App\Exceptions\BusinessException;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 聚合实名（smapi.x1m1.cn）HTTP 客户端 — 完全自包含，不依赖内核驱动。
+ *
+ * 接口约定：
+ * - POST /api/realname/initialize                    初始化认证
+ * - GET  /api/realname/certifications/{id}/query     查询认证状态与认证页面链接
+ * - 鉴权头：X-App-Key / X-App-Secret
+ * - 业务成功：HTTP 2xx 且 body.status === 200 或 body.code === 20000
+ */
+class SmapiClient
+{
+    private const DEFAULT_API_ENDPOINT = 'https://smapi.x1m1.cn';
+
+    private ?array $lastRequestFailure = null;
+
+    /**
+     * @param  array<string, mixed>  $config  插件配置（来自 execute() 的 $request['config']）
+     */
+    public function __construct(
+        private readonly array $config,
+    ) {}
+
+    /**
+     * 初始化实名认证。
+     *
+     * @return array{status: int, message: string, certify_id?: string, raw?: array}
+     */
+    public function initialize(string $realName, string $idCard, string $returnUrl): array
+    {
+        $productCode = $this->defaultProductCode();
+        if ($productCode === '') {
+            return ['status' => 400, 'message' => '请先配置产品标识 product_code'];
+        }
+
+        $result = $this->request('POST', '/api/realname/initialize', [
+            'product_code' => $productCode,
+            'cert_name' => $realName,
+            'cert_no' => $idCard,
+            'return_url' => $returnUrl,
+        ]);
+
+        if ($result === null) {
+            return ['status' => 500, 'message' => $this->getLastFailureMessage()];
+        }
+
+        if ($this->isBusinessSuccess($result)) {
+            $data = $this->resultData($result);
+            $certifyId = trim((string) ($data['id'] ?? ''));
+
+            if ($certifyId !== '') {
+                return [
+                    'status' => 200,
+                    'message' => $this->safeProviderMessage($result['msg'] ?? '', '认证初始化成功'),
+                    'certify_id' => $certifyId,
+                    'raw' => $data,
+                ];
+            }
+
+            return [
+                'status' => 400,
+                'message' => '聚合实名平台返回异常：未返回认证标识',
+                'raw' => $data,
+            ];
+        }
+
+        return [
+            'status' => 400,
+            'message' => $this->safeProviderMessage($this->resultMessage($result), '实名认证接口配置错误，请联系管理员'),
+            'raw' => $this->resultData($result),
+        ];
+    }
+
+    /**
+     * 获取认证链接（复用查询接口回显的认证页面地址）。
+     *
+     * @return array{status: int, message: string, url?: string, raw?: array}
+     */
+    public function scanUrl(string $certifyId): array
+    {
+        $result = $this->query($certifyId);
+
+        if ($result === null) {
+            return ['status' => 500, 'message' => $this->getLastFailureMessage()];
+        }
+
+        if (! $this->isBusinessSuccess($result)) {
+            return [
+                'status' => 400,
+                'message' => $this->safeProviderMessage($this->resultMessage($result), '获取认证链接失败，请联系管理员'),
+                'raw' => $this->resultData($result),
+            ];
+        }
+
+        $data = $this->resultData($result);
+        $url = $this->extractCertificationUrl($data);
+
+        if ($url === '') {
+            return [
+                'status' => 400,
+                'message' => '获取认证链接失败，请联系管理员',
+                'raw' => $data,
+            ];
+        }
+
+        return [
+            'status' => 200,
+            'message' => '请打开实名认证链接继续认证',
+            'url' => $url,
+            'raw' => $data,
+        ];
+    }
+
+    /**
+     * 查询认证状态。
+     *
+     * 状态码遵循项目内部约定：1=通过、2=不通过、3=网络错误、4=处理中。
+     *
+     * @return array{status: int, message: string, raw?: array}
+     */
+    public function queryStatus(string $certifyId): array
+    {
+        $result = $this->query($certifyId);
+
+        if ($result === null) {
+            return ['status' => 3, 'message' => $this->getLastFailureMessage()];
+        }
+
+        if (! $this->isBusinessSuccess($result)) {
+            // 查询接口业务失败不判失败，按“处理中”处理，等待下次轮询。
+            return ['status' => 4, 'message' => '认证处理中', 'raw' => $this->resultData($result)];
+        }
+
+        $data = $this->resultData($result);
+        $status = (string) ($data['status'] ?? '');
+
+        if ($status === 'passed') {
+            return ['status' => 1, 'message' => '审核通过', 'raw' => $data];
+        }
+
+        if ($status === 'failed' || $status === 'updated') {
+            $reason = trim((string) ($data['fail_reason'] ?? ''));
+
+            return [
+                'status' => 2,
+                'message' => $reason !== '' ? $this->safeProviderMessage($reason, '审核未通过') : '审核未通过',
+                'raw' => $data,
+            ];
+        }
+
+        $map = [
+            'initialized' => '待认证，请先完成扫码认证',
+            'processing' => '认证处理中，请稍后再获取结果',
+        ];
+
+        return [
+            'status' => 4,
+            'message' => isset($map[$status]) ? $map[$status] : '认证处理中',
+            'raw' => $data,
+        ];
+    }
+
+    /**
+     * @return array|null 上游原始响应；网络或解析失败返回 null
+     */
+    private function query(string $certifyId): ?array
+    {
+        return $this->request('GET', '/api/realname/certifications/'.rawurlencode($certifyId).'/query');
+    }
+
+    private function request(string $method, string $path, array $params = []): ?array
+    {
+        $this->lastRequestFailure = null;
+
+        $url = rtrim($this->resolveEndpoint(), '/').$path;
+
+        try {
+            $http = Http::withOptions($this->sslOptions())
+                ->withHeaders([
+                    'X-App-Key' => $this->resolveAppKey(),
+                    'X-App-Secret' => $this->resolveAppSecret(),
+                    'Accept' => 'application/json',
+                    'Content-Type' => 'application/json',
+                ])
+                ->timeout(30)
+                ->connectTimeout(10);
+
+            $response = $method === 'POST'
+                ? $http->post($url, $params)
+                : $http->get($url);
+        } catch (ConnectionException $exception) {
+            $this->lastRequestFailure = ['type' => 'connection', 'error' => $exception->getMessage()];
+            Log::error('[实名认证] 请求聚合实名平台失败', ['error' => $exception->getMessage()]);
+
+            return null;
+        }
+
+        $body = trim($response->body(), "\xEF\xBB\xBF");
+        $decoded = json_decode($body, true);
+
+        if (! is_array($decoded)) {
+            $this->lastRequestFailure = [
+                'type' => 'invalid_json',
+                'raw' => mb_substr($body, 0, 200),
+                'http_status' => $response->status(),
+            ];
+
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    private function resolveEndpoint(): string
+    {
+        return (string) ($this->config['api_url'] ?? self::DEFAULT_API_ENDPOINT);
+    }
+
+    private function resolveAppKey(): string
+    {
+        $value = trim((string) ($this->config['app_key'] ?? ''));
+        if ($value === '') {
+            throw new BusinessException('实名认证接口未配置，请先在管理端填写 API 信息', 42200);
+        }
+
+        return $value;
+    }
+
+    private function resolveAppSecret(): string
+    {
+        $value = trim((string) ($this->config['secret_key'] ?? ''));
+        if ($value === '') {
+            throw new BusinessException('实名认证接口未配置，请先在管理端填写 API 信息', 42200);
+        }
+
+        return $value;
+    }
+
+    /**
+     * 配置中声明的第一个有效产品标识；未配置时返回空串。
+     */
+    private function defaultProductCode(): string
+    {
+        $products = $this->parseProducts();
+        if ($products === []) {
+            return '';
+        }
+
+        return (string) array_key_first($products);
+    }
+
+    /**
+     * @return array<string, string> 产品标识 => 显示名称
+     */
+    private function parseProducts(): array
+    {
+        $value = trim((string) ($this->config['product_code'] ?? ''));
+        $products = [];
+
+        foreach (explode('|', $value) as $item) {
+            $item = trim($item);
+            if ($item === ''
+                || str_contains($item, '填写说明')
+                || str_contains($item, '请删除本说明')
+                || str_contains($item, '例如：')) {
+                continue;
+            }
+
+            $parts = explode(',', $item, 2);
+            $code = trim($parts[0]);
+            if ($code === '') {
+                continue;
+            }
+
+            $products[$code] = isset($parts[1]) && trim($parts[1]) !== '' ? trim($parts[1]) : $code;
+        }
+
+        return $products;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function extractCertificationUrl(array $data): string
+    {
+        foreach (['certify_page_url', 'certify_url', 'url', 'qrcode_url', 'qr_code_url'] as $field) {
+            $value = trim((string) ($data[$field] ?? ''));
+            if ($value !== '' && $value !== '-') {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function isBusinessSuccess(array $result): bool
+    {
+        return (isset($result['status']) && (int) $result['status'] === 200)
+            || (isset($result['code']) && (int) $result['code'] === 20000);
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function resultData(array $result): array
+    {
+        return isset($result['data']) && is_array($result['data']) ? $result['data'] : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function resultMessage(array $result): string
+    {
+        $message = trim((string) ($result['msg'] ?? $result['message'] ?? ''));
+
+        return $message !== '' ? $message : '聚合实名平台请求失败';
+    }
+
+    private function getLastFailureMessage(): string
+    {
+        if (! is_array($this->lastRequestFailure)) {
+            return '网络请求失败，请稍后重试';
+        }
+
+        if (($this->lastRequestFailure['type'] ?? '') === 'connection') {
+            if ($this->isSslFailure($this->lastRequestFailure)) {
+                return '实名认证接口 SSL 证书校验失败，请检查插件 CA 证书配置';
+            }
+
+            return '实名认证接口请求失败，请稍后重试';
+        }
+
+        return '实名认证接口返回异常';
+    }
+
+    /**
+     * @return array<string, mixed> Http::withOptions 的 SSL 选项
+     */
+    private function sslOptions(): array
+    {
+        if (! $this->resolveSslVerify()) {
+            return ['verify' => false];
+        }
+
+        $caBundle = $this->resolveCaBundle();
+        if ($caBundle !== '' && is_file($caBundle)) {
+            return ['verify' => $caBundle];
+        }
+
+        return [];
+    }
+
+    private function resolveSslVerify(): bool
+    {
+        $value = $this->config['ssl_verify'] ?? null;
+        if ($value !== null && $value !== '') {
+            return filter_var($value, FILTER_VALIDATE_BOOL);
+        }
+
+        return filter_var(config('idc.verification.ssl_verify', true), FILTER_VALIDATE_BOOL);
+    }
+
+    private function resolveCaBundle(): string
+    {
+        $value = $this->config['ca_bundle'] ?? null;
+        if ($value !== null && $value !== '') {
+            return trim((string) $value);
+        }
+
+        return trim((string) config('idc.verification.ca_bundle', ''));
+    }
+
+    /**
+     * @param  array<string, mixed>  $failure
+     */
+    private function isSslFailure(array $failure): bool
+    {
+        $message = strtolower((string) ($failure['error'] ?? ''));
+
+        return str_contains($message, 'ssl') || str_contains($message, 'certificate');
+    }
+
+    private function safeProviderMessage(mixed $message, string $fallback): string
+    {
+        $text = trim((string) $message);
+        if ($text === '') {
+            return $fallback;
+        }
+
+        // 服务商文案预期为中文；出现连续英文字母一律视为技术细节，直接回退到安全文案。
+        if (preg_match('/[a-z]{3,}/i', $text) === 1) {
+            return $fallback;
+        }
+
+        return $text;
+    }
+}

--- a/backend/plugins/servers/zjmf_finance/lib/ZjmfBillingRestoreService.php
+++ b/backend/plugins/servers/zjmf_finance/lib/ZjmfBillingRestoreService.php
@@ -139,8 +139,8 @@ class ZjmfBillingRestoreService
         usort($invoicePayload, fn (array $a, array $b) => $a['id'] <=> $b['id']);
         usort($balanceLogPayload, fn (array $a, array $b) => $a['id'] <=> $b['id']);
 
-        // 空库强制审计：先统计目标表既有数据供 dry-run 预检展示；非 dry-run 且目标表
-        // 非空时必须显式 --force 才允许物理删除重插，防止误把 dump 快照后的新财务数据抹掉。
+        // 仅允许恢复到空财务表：invoices/balance_logs 属于审计链路，禁止用 dump 覆盖
+        // 当前库中已产生的账单/余额日志。--force 保留为兼容旧脚本的无效参数，不再触发删除。
         $existingInvoices = Schema::hasTable('invoices') ? (int) DB::table('invoices')->count() : 0;
         $existingBalanceLogs = Schema::hasTable('balance_logs') ? (int) DB::table('balance_logs')->count() : 0;
         $summary['existing_invoices'] = $existingInvoices;
@@ -150,20 +150,18 @@ class ZjmfBillingRestoreService
             return $summary;
         }
 
-        if (($existingInvoices > 0 || $existingBalanceLogs > 0) && ! $forceOverwrite) {
+        if ($existingInvoices > 0 || $existingBalanceLogs > 0) {
             throw new RuntimeException(
                 '目标库 invoices/balance_logs 已有数据（invoices='.$existingInvoices.', balance_logs='.$existingBalanceLogs.'），'
-                .'恢复将物理删除并覆盖全部现有财务数据；如确认覆盖，请追加 --force'
+                .'为保护财务审计链路，禁止覆盖或物理删除既有账单/余额日志；请仅在空库或隔离库执行恢复'
             );
         }
 
-        $summary['overwrite_forced'] = true;
+        $summary['overwrite_forced'] = false;
 
         DB::transaction(function () use ($invoicePayload, $balanceLogPayload, $clientBalances): void {
             $now = now()->format('Y-m-d H:i:s');
 
-            DB::table('balance_logs')->delete();
-            DB::table('invoices')->delete();
             DB::table('users')->update([
                 'updated_at' => $now,
             ]);

--- a/backend/plugins/servers/zjmf_finance/lib/ZjmfBillingRestoreService.php
+++ b/backend/plugins/servers/zjmf_finance/lib/ZjmfBillingRestoreService.php
@@ -150,16 +150,21 @@ class ZjmfBillingRestoreService
             return $summary;
         }
 
-        if ($existingInvoices > 0 || $existingBalanceLogs > 0) {
-            throw new RuntimeException(
-                '目标库 invoices/balance_logs 已有数据（invoices='.$existingInvoices.', balance_logs='.$existingBalanceLogs.'），'
-                .'为保护财务审计链路，禁止覆盖或物理删除既有账单/余额日志；请仅在空库或隔离库执行恢复'
-            );
-        }
-
         $summary['overwrite_forced'] = false;
 
-        DB::transaction(function () use ($invoicePayload, $balanceLogPayload, $clientBalances): void {
+        DB::transaction(function () use ($invoicePayload, $balanceLogPayload, $clientBalances, &$summary): void {
+            // 非空检查与恢复写入放在同一事务内：事务外计数后线上仍可能写入新账单，
+            // 此处于写入前重新计数并立即拒绝，降低“计数后、写入前”并发窗口。
+            // （本工具按单实例停机式运维恢复使用，未引入 GET_LOCK 多实例互斥，如需并发恢复请另行加锁）
+            $guardInvoices = Schema::hasTable('invoices') ? (int) DB::table('invoices')->count() : 0;
+            $guardBalanceLogs = Schema::hasTable('balance_logs') ? (int) DB::table('balance_logs')->count() : 0;
+            if ($guardInvoices > 0 || $guardBalanceLogs > 0) {
+                throw new RuntimeException(
+                    '目标库 invoices/balance_logs 已有数据（invoices='.$guardInvoices.', balance_logs='.$guardBalanceLogs.'），'
+                    .'为保护财务审计链路，禁止覆盖或物理删除既有账单/余额日志；请仅在空库或隔离库执行恢复'
+                );
+            }
+
             $now = now()->format('Y-m-d H:i:s');
 
             DB::table('users')->update([

--- a/backend/plugins/servers/zjmf_finance/src/Commands/RestoreZjmfBillingCommand.php
+++ b/backend/plugins/servers/zjmf_finance/src/Commands/RestoreZjmfBillingCommand.php
@@ -12,7 +12,7 @@ class RestoreZjmfBillingCommand extends Command
     protected $signature = 'finance:restore-zjmf-billing
         {dump : 原始 ZJMF 账单 SQL 文件绝对路径}
         {--confirm= : 危险确认短语，默认必须为 RESTORE_ZJMF_BILLING}
-        {--force : 目标 invoices/balance_logs 表存在既有数据时，允许物理删除后覆盖重插}
+        {--force : 已废弃兼容参数；不再允许覆盖既有 invoices/balance_logs 财务审计数据}
         {--dry-run : 仅解析并输出统计，不写入数据库}';
 
     protected $description = '从历史 ZJMF SQL 备份恢复账单、支付流水与余额记录';
@@ -42,8 +42,8 @@ class RestoreZjmfBillingCommand extends Command
 
         $this->info($dryRun ? '账单恢复预检完成' : '账单恢复完成');
         $this->line('SQL 文件: '.$dumpPath);
-        $this->line('既有账单数（将被覆盖）: '.$summary['existing_invoices']);
-        $this->line('既有余额日志数（将被覆盖）: '.$summary['existing_balance_logs']);
+        $this->line('既有账单数（非空即拒绝恢复）: '.$summary['existing_invoices']);
+        $this->line('既有余额日志数（非空即拒绝恢复）: '.$summary['existing_balance_logs']);
         $this->line('账单数: '.$summary['invoices']);
         $this->line('余额日志数: '.$summary['balance_logs']);
         $this->line('同步余额用户数: '.$summary['user_balances']);

--- a/backend/scripts/install_db.py
+++ b/backend/scripts/install_db.py
@@ -87,7 +87,10 @@ if (Schema::hasTable('settings')) {
     SettingsSeeder::seed();
 }
 
-// 通知模板默认数据已包含在 schema baseline 中，无需额外迁移
+// SettingsSeeder 会幂等种入：
+// 1) 系统核心默认配置（settings 表，含 notification.email_enabled / sms_enabled / sms_template_code）；
+// 2) 通知模板默认数据（notification_templates 表）：email 全量模板 + sms 验证码模板。
+// schema baseline 仅导出表结构、不含模板数据，模板种子必须经此入口执行。
 """
 
 

--- a/backend/tests/Feature/BackendStructureBoundaryTest.php
+++ b/backend/tests/Feature/BackendStructureBoundaryTest.php
@@ -24,6 +24,8 @@ class BackendStructureBoundaryTest extends TestCase
             'Http/Controllers/Client/V2/OrderController.php',
             'Http/Controllers/Client/V2/PaymentController.php',
             'Http/Controllers/Client/V2/RechargeController.php',
+            'Http/Controllers/Client/V2/TicketController.php',
+            'Http/Controllers/Client/V2/TicketWorkflowController.php',
         ] as $path) {
             $source = $this->appSource($path);
 

--- a/backend/tests/Feature/ClientInvoiceInvoiceOnlyRegressionTest.php
+++ b/backend/tests/Feature/ClientInvoiceInvoiceOnlyRegressionTest.php
@@ -262,7 +262,8 @@ class ClientInvoiceInvoiceOnlyRegressionTest extends TestCase
             ->assertJsonPath('data.invoice.service.id', (int) $service->id)
             ->assertJsonPath('data.invoice.display.product_display_name', '客户端云主机 2核4G')
             ->assertJsonMissingPath('data.raw_status')
-            ->assertJsonPath('data.invoice.payment_chain.payments.0.trade_no', 'TRADE-CLIENT-VISIBLE-'.$suffix);
+            ->assertJsonMissingPath('data.invoice.payment_chain.payment_summary.trade_no')
+            ->assertJsonMissingPath('data.invoice.payment_chain.payments.0.trade_no');
 
         $this->getJson('/api/v2/client/invoices?keyword=TRADE-CLIENT-VISIBLE-'.$suffix.'&page_size=20')
             ->assertOk()

--- a/backend/tests/Feature/DatabaseEngineeringCommandTest.php
+++ b/backend/tests/Feature/DatabaseEngineeringCommandTest.php
@@ -204,6 +204,34 @@ class DatabaseEngineeringCommandTest extends TestCase
         }
     }
 
+    public function test_db_normalize_core_relations_dry_run_does_not_alter_column_nullability(): void
+    {
+        $schema = (string) config('database.connections.'.config('database.default').'.database');
+
+        $readNullable = function () use ($schema): string {
+            $row = DB::selectOne(
+                "SELECT IS_NULLABLE FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'services' AND COLUMN_NAME = 'order_id'",
+                [$schema]
+            );
+
+            return (string) ($row->IS_NULLABLE ?? 'NO');
+        };
+
+        $before = $readNullable();
+
+        // 不带 --execute 执行，应为纯 dry-run
+        Artisan::call('db:normalize-core-relations');
+
+        $after = $readNullable();
+
+        $this->assertSame(
+            $before,
+            $after,
+            'dry-run 不应修改 services.order_id 的可空性（避免 MySQL DDL 隐式提交与表锁定）'
+        );
+    }
+
     private function ensureUserId(): int
     {
         $id = (int) DB::table('users')->value('id');

--- a/backend/tests/Feature/DatabaseEngineeringCommandTest.php
+++ b/backend/tests/Feature/DatabaseEngineeringCommandTest.php
@@ -75,7 +75,7 @@ class DatabaseEngineeringCommandTest extends TestCase
             DB::statement('SET FOREIGN_KEY_CHECKS=1');
         }
 
-        Artisan::call('db:normalize-core-relations');
+        Artisan::call('db:normalize-core-relations', ['--execute' => true]);
 
         $this->assertDatabaseHas('services', [
             'id' => $serviceId,
@@ -150,7 +150,7 @@ class DatabaseEngineeringCommandTest extends TestCase
         }
 
         try {
-            Artisan::call('db:normalize-core-relations', ['--json' => true]);
+            Artisan::call('db:normalize-core-relations', ['--execute' => true, '--json' => true]);
 
             $payload = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
 
@@ -158,6 +158,46 @@ class DatabaseEngineeringCommandTest extends TestCase
             $this->assertDatabaseHas('invoices', [
                 'id' => $invoiceId,
                 'order_id' => null,
+            ]);
+        } finally {
+            DB::table('invoices')->where('id', $invoiceId)->delete();
+        }
+    }
+
+    public function test_db_normalize_core_relations_reports_but_does_not_delete_orphan_invoices(): void
+    {
+        $invoiceNo = 'norm-report-orphan-'.bin2hex(random_bytes(4));
+        $invoiceId = 0;
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        try {
+            $invoiceId = (int) DB::table('invoices')->insertGetId([
+                'invoice_no' => $invoiceNo,
+                'user_id' => 999999997,
+                'product_id' => 999999996,
+                'type' => 'normal',
+                'amount' => '1.00',
+                'discount' => '0.00',
+                'paid_amount' => '0.00',
+                'status' => 0,
+                'due_date' => now()->addDay()->toDateString(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } finally {
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+
+        try {
+            Artisan::call('db:normalize-core-relations', ['--execute' => true, '--json' => true]);
+
+            $payload = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+            $this->assertSame(0, (int) ($payload['invoices_deleted_orphan_user_or_product'] ?? -1));
+            $this->assertGreaterThanOrEqual(1, (int) ($payload['invoices_orphan_user_or_product_reported'] ?? 0));
+            $this->assertDatabaseHas('invoices', [
+                'id' => $invoiceId,
+                'invoice_no' => $invoiceNo,
             ]);
         } finally {
             DB::table('invoices')->where('id', $invoiceId)->delete();

--- a/backend/tests/Feature/SmapiPluginTest.php
+++ b/backend/tests/Feature/SmapiPluginTest.php
@@ -1,0 +1,643 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Exceptions\BusinessException;
+use App\Services\Integrations\Plugins\PluginFileLoader;
+use App\Services\Integrations\Plugins\PluginScanner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use TuraIDC\Plugins\Certification\Smapi\Logic\Smapi;
+use Tests\TestCase;
+
+class SmapiPluginTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensurePluginTables();
+        $this->cleanPluginTables();
+        // 插件类走 PluginFileLoader 的 require_once 加载，不在 PSR-4 autoload 内，
+        // 直接 new 之前必须先确保文件已载入。
+        $this->loadSmapiPlugin();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanPluginTables();
+        parent::tearDown();
+    }
+
+    private function loadSmapiPlugin(): void
+    {
+        $manifest = app(PluginScanner::class)->requireManifest('verification', 'smapi');
+        app(PluginFileLoader::class)->ensureLoaded($manifest);
+    }
+
+    // ============================================================
+    // certification.initialize
+    // ============================================================
+
+    public function test_execute_routes_initialize_action(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'msg' => 'success',
+                'data' => [
+                    'id' => 'S-1001',
+                    'certify_page_url' => 'https://smapi.x1m1.cn/certify/S-1001',
+                ],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => [
+                'real_name' => '张三',
+                'id_card' => '110101199001010011',
+                'return_url' => 'https://api.example.test/callback',
+            ],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('certification.initialize', $result['action']);
+        $this->assertSame(200, $result['data']['status']);
+        $this->assertSame('S-1001', $result['data']['certify_id']);
+        $this->assertSame('https://smapi.x1m1.cn/certify/S-1001', $result['data']['raw']['certify_page_url']);
+    }
+
+    public function test_initialize_sends_expected_payload(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1002'],
+            ], 200),
+        ]);
+
+        $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => [
+                'real_name' => '李四',
+                'id_card' => '110101199001010022',
+                'return_url' => 'https://api.example.test/callback',
+            ],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('X-App-Key', 'test-app-key')
+                && $request->hasHeader('X-App-Secret', 'test-secret-key')
+                && $request['product_code'] === 'alipay_v3'
+                && $request['cert_name'] === '李四'
+                && $request['cert_no'] === '110101199001010022'
+                && $request['return_url'] === 'https://api.example.test/callback';
+        });
+    }
+
+    public function test_initialize_uses_first_product_code_when_multiple(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1003'],
+            ], 200),
+        ]);
+
+        $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => [
+                'real_name' => '张三',
+                'id_card' => '110101199001010011',
+                'return_url' => '',
+            ],
+            'config' => array_merge($this->defaultConfig(), [
+                'product_code' => "alipay_v3,支付宝身份认证|tencent_sm,微信实名认证",
+            ]),
+        ]);
+
+        Http::assertSent(fn ($request) => $request['product_code'] === 'alipay_v3');
+    }
+
+    public function test_initialize_returns_400_when_product_code_missing(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => array_merge($this->defaultConfig(), ['product_code' => '']),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('请先配置产品标识 product_code', $result['data']['message']);
+    }
+
+    public function test_initialize_returns_400_on_business_failure(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 400,
+                'msg' => '密钥校验失败',
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('密钥校验失败', $result['data']['message']);
+    }
+
+    public function test_initialize_falls_back_to_safe_message_when_provider_text_has_technical_details(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 400,
+                'msg' => 'invalid AppSecret: bad signature',
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('实名认证接口配置错误，请联系管理员', $result['data']['message']);
+    }
+
+    public function test_initialize_returns_400_when_certify_id_missing(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['certify_page_url' => 'https://smapi.x1m1.cn/certify/x'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('聚合实名平台返回异常：未返回认证标识', $result['data']['message']);
+    }
+
+    public function test_initialize_throws_when_credentials_missing(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/initialize*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1'],
+            ], 200),
+        ]);
+
+        $this->expectException(BusinessException::class);
+
+        $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => ['real_name' => '张三', 'id_card' => '110101199001010011', 'return_url' => ''],
+            'config' => array_merge($this->defaultConfig(), ['app_key' => '']),
+        ]);
+    }
+
+    // ============================================================
+    // certification.scan_url
+    // ============================================================
+
+    public function test_execute_routes_scan_url_action(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1001/query*' => Http::response([
+                'status' => 200,
+                'data' => [
+                    'id' => 'S-1001',
+                    'status' => 'processing',
+                    'certify_page_url' => 'https://smapi.x1m1.cn/certify/S-1001',
+                ],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.scan_url',
+            'payload' => ['certify_id' => 'S-1001'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('certification.scan_url', $result['action']);
+        $this->assertSame(200, $result['data']['status']);
+        $this->assertSame('https://smapi.x1m1.cn/certify/S-1001', $result['data']['url']);
+    }
+
+    public function test_scan_url_falls_back_to_alternate_url_fields(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-2/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-2', 'status' => 'initialized', 'qrcode_url' => 'https://smapi.x1m1.cn/qr/S-2'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.scan_url',
+            'payload' => ['certify_id' => 'S-2'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(200, $result['data']['status']);
+        $this->assertSame('https://smapi.x1m1.cn/qr/S-2', $result['data']['url']);
+    }
+
+    public function test_scan_url_returns_400_when_url_missing(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-3/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-3', 'status' => 'processing'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.scan_url',
+            'payload' => ['certify_id' => 'S-3'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(400, $result['data']['status']);
+        $this->assertSame('获取认证链接失败，请联系管理员', $result['data']['message']);
+    }
+
+    // ============================================================
+    // certification.query_status
+    // ============================================================
+
+    public function test_query_status_passed_maps_to_success(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'passed', 'passed_at' => '2026-08-01 10:00:00'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(1, $result['data']['status']);
+        $this->assertSame('审核通过', $result['data']['message']);
+    }
+
+    public function test_query_status_failed_maps_to_failure_with_reason(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'failed', 'fail_reason' => '身份信息不一致'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(2, $result['data']['status']);
+        $this->assertSame('身份信息不一致', $result['data']['message']);
+    }
+
+    public function test_query_status_failed_without_reason(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'failed'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(2, $result['data']['status']);
+        $this->assertSame('审核未通过', $result['data']['message']);
+    }
+
+    public function test_query_status_updated_maps_to_failure(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'updated'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(2, $result['data']['status']);
+    }
+
+    public function test_query_status_processing_maps_to_pending(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'processing'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(4, $result['data']['status']);
+        $this->assertSame('认证处理中，请稍后再获取结果', $result['data']['message']);
+    }
+
+    public function test_query_status_initialized_maps_to_pending(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 200,
+                'data' => ['id' => 'S-1', 'status' => 'initialized'],
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(4, $result['data']['status']);
+        $this->assertSame('待认证，请先完成扫码认证', $result['data']['message']);
+    }
+
+    public function test_query_status_network_error_maps_to_network_status(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => fn () => throw new ConnectionException('Connection refused'),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(3, $result['data']['status']);
+        $this->assertSame('实名认证接口请求失败，请稍后重试', $result['data']['message']);
+    }
+
+    public function test_query_status_business_failure_stays_pending(): void
+    {
+        $plugin = new Smapi;
+
+        Http::fake([
+            'smapi.x1m1.cn/api/realname/certifications/S-1/query*' => Http::response([
+                'status' => 400,
+                'msg' => '认证记录不存在',
+            ], 200),
+        ]);
+
+        $result = $plugin->execute([
+            'action' => 'certification.query_status',
+            'payload' => ['certify_id' => 'S-1'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertSame(4, $result['data']['status']);
+        $this->assertSame('认证处理中', $result['data']['message']);
+    }
+
+    // ============================================================
+    // certification.verify_callback / fee_config / 其他
+    // ============================================================
+
+    public function test_verify_callback_unsupported(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => ['payload' => [], 'headers' => []],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+        $this->assertSame(40001, $result['data']['code']);
+        $this->assertSame(501, $result['data']['http_status']);
+    }
+
+    public function test_execute_routes_fee_config_action(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.fee_config',
+            'payload' => [],
+            'config' => [
+                'charge_enabled' => true,
+                'amount' => 1.5,
+                'free_times' => 3,
+            ],
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(3, $result['data']['free_attempts']);
+        $this->assertSame(1.5, $result['data']['retry_fee']);
+        $this->assertTrue($result['data']['charge_enabled']);
+    }
+
+    public function test_execute_fee_config_defaults_when_no_config(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.fee_config',
+            'payload' => [],
+            'config' => [],
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(0, $result['data']['free_attempts']);
+        $this->assertSame(0.0, $result['data']['retry_fee']);
+        $this->assertFalse($result['data']['charge_enabled']);
+    }
+
+    public function test_execute_unknown_action_returns_unsupported(): void
+    {
+        $plugin = new Smapi;
+
+        $result = $plugin->execute([
+            'action' => 'certification.unknown',
+            'payload' => [],
+            'config' => [],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('certification.unknown', $result['action']);
+    }
+
+    public function test_plugin_key_and_label(): void
+    {
+        $plugin = new Smapi;
+
+        $this->assertSame('smapi', $plugin->key());
+        $this->assertSame('聚合实名认证', $plugin->label());
+    }
+
+    // ============================================================
+    // helpers
+    // ============================================================
+
+    private function defaultConfig(): array
+    {
+        return [
+            'api_url' => 'https://smapi.x1m1.cn',
+            'app_key' => 'test-app-key',
+            'secret_key' => 'test-secret-key',
+            'product_code' => 'alipay_v3,支付宝身份认证',
+            'ssl_verify' => true,
+        ];
+    }
+
+    private function ensurePluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            Schema::create('integration_plugins', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->string('slug', 120);
+                $table->string('plugin_key', 120);
+                $table->string('name', 120);
+                $table->string('version', 32)->default('1.0.0');
+                $table->string('provider_class', 255)->nullable();
+                $table->string('entry_class', 255);
+                $table->json('capabilities_json')->nullable();
+                $table->json('config_schema_json')->nullable();
+                $table->unsignedTinyInteger('status')->default(0);
+                $table->timestamp('installed_at')->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'slug']);
+                $table->unique(['domain', 'plugin_key']);
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_configs')) {
+            Schema::create('integration_plugin_configs', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('plugin_id');
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->timestamps();
+                $table->unique('plugin_id');
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_bindings')) {
+            Schema::create('integration_plugin_bindings', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->unsignedBigInteger('plugin_id');
+                $table->string('binding_type', 50);
+                $table->string('bindable_type', 120)->default('global');
+                $table->unsignedBigInteger('bindable_id')->default(0);
+                $table->string('binding_key', 120);
+                $table->string('provider_key', 120)->nullable();
+                $table->integer('priority')->default(0);
+                $table->unsignedTinyInteger('status')->default(1);
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->json('runtime_policy_json')->nullable();
+                $table->unsignedBigInteger('created_by')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->string('backfill_batch_id', 64)->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'binding_type', 'bindable_type', 'bindable_id', 'binding_key'], 'plugin_bindings_unique');
+            });
+        }
+    }
+
+    private function cleanPluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            return;
+        }
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('integration_plugin_bindings')) {
+            DB::table('integration_plugin_bindings')->truncate();
+        }
+        if (Schema::hasTable('integration_plugin_configs')) {
+            DB::table('integration_plugin_configs')->truncate();
+        }
+        DB::table('integration_plugins')->truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+}

--- a/backend/tests/Feature/V2AdminConfigurationApiTest.php
+++ b/backend/tests/Feature/V2AdminConfigurationApiTest.php
@@ -522,6 +522,13 @@ class V2AdminConfigurationApiTest extends TestCase
 
         Sanctum::actingAs($this->createAdmin([AdminPermissions::SUPPLIER_SYNC]));
 
+        $this->postJson('/api/v2/admin/suppliers/'.$supplier->id.'/tasks', [
+            'type' => 'server.supplier.bulk_connect',
+            'payload' => ['product_ids' => [1], 'first_product_group_code' => 'cloud_server'],
+        ])
+            ->assertForbidden()
+            ->assertJsonPath('code', 40300);
+
         $this->postJson('/api/v2/admin/suppliers/'.$supplier->id.'/tasks?per_page=20', [
             'type' => 'server.supplier.refresh_card',
         ])

--- a/backend/tests/Feature/ZjmfBillingRestoreCommandTest.php
+++ b/backend/tests/Feature/ZjmfBillingRestoreCommandTest.php
@@ -68,10 +68,9 @@ class ZjmfBillingRestoreCommandTest extends TestCase
         }
     }
 
-    public function test_restore_rejects_non_empty_target_without_force(): void
+    public function test_restore_rejects_non_empty_target_even_with_force(): void
     {
-        // 目标 invoices 表存在既有数据时，未显式 --force 必须拒绝物理删除覆盖，
-        // 防止误把 dump 快照后的新账单抹掉。
+        // 财务审计表非空时禁止覆盖恢复；--force 保留为兼容参数，但不再允许物理删除。
         $userId = (int) DB::table('users')->value('id');
         $invoiceNo = 'RESTORE-GUARD-'.strtoupper(bin2hex(random_bytes(4)));
         DB::table('invoices')->insert([
@@ -87,8 +86,8 @@ class ZjmfBillingRestoreCommandTest extends TestCase
 
         try {
             $this->expectException(\RuntimeException::class);
-            $this->expectExceptionMessage('--force');
-            app(ZjmfBillingRestoreService::class)->restoreFromSqlDump($path, false, false);
+            $this->expectExceptionMessage('禁止覆盖或物理删除既有账单/余额日志');
+            app(ZjmfBillingRestoreService::class)->restoreFromSqlDump($path, false, true);
         } finally {
             @unlink($path);
             DB::table('invoices')->where('invoice_no', $invoiceNo)->delete();

--- a/docs/参考资料/运维/部署与调度指南.md
+++ b/docs/参考资料/运维/部署与调度指南.md
@@ -118,6 +118,14 @@ php artisan route:cache
 > - `database/schema/mysql-schema.sql` 是当前生产库完整结构快照，包含 62 张表和 `migrations` 记录
 > - 历史迁移文件已归档至 `database/migrations/_archive/`，不再逐个执行
 > - 增量迁移（`database/migrations/*.php`）用于后续新功能上线
+> - `install_db.py` 最后会经 `SettingsSeeder::seed()` 幂等种入：
+>   - 系统核心默认配置（`settings` 表，含 `notification.email_enabled` / `sms_enabled` / `sms_template_code`）
+>   - 通知模板默认数据（`notification_templates` 表）：email 全量模板 + sms 验证码模板
+>   - schema baseline 仅导出表结构、不含模板数据，**模板种子必须经该 Seeder 执行**，切勿依赖迁移或手工补种
+>
+> **首次部署后请检查（管理后台 → 站点设置 → 通知总开关）**：
+> - 邮件通知 / 短信通知默认关闭，按需在后台打开
+> - 邮件/短信插件需在「插件管理」安装、配置并绑定，再前往「通知与接口」维护对应模板
 
 ### 3.2 前端部署
 

--- a/docs/参考资料/集成/插件/README.md
+++ b/docs/参考资料/集成/插件/README.md
@@ -621,6 +621,7 @@ php artisan schedule:list
 | 支付渠道      | `backend/plugins/gateways/yi_pay`                 | 易支付插件                      |
 | 实名认证      | `backend/plugins/certification/stay33`            | Stay33 实名认证插件             |
 | 实名认证      | `backend/plugins/certification/baidu_face`        | 百度人脸实名认证插件            |
+| 实名认证      | `backend/plugins/certification/smapi`             | 聚合实名认证插件（小沐实名 API）|
 | 实名认证      | `backend/plugins/certification/demo_verification` | 模拟实名插件                    |
 | 人机验证      | `backend/plugins/captcha/geetest`                 | GeeTest 验证码插件              |
 | 人机验证      | `backend/plugins/captcha/vaptcha`                 | Vaptcha 验证码插件              |

--- a/frontend-admin-v3/src/layouts/components/SideNav.vue
+++ b/frontend-admin-v3/src/layouts/components/SideNav.vue
@@ -222,7 +222,17 @@ function findExactMenuBranch(list: MenuRoute[], activePath: string, parents: Men
 function findExpandedByMenu(list: MenuRoute[], activePath: string, parents: MenuValue[] = []): MenuValue[] | null {
   for (const item of list || []) {
     const currentPath = String(item.path);
-    if (isRouteMatch(currentPath, activePath)) return parents;
+    if (isRouteMatch(currentPath, activePath)) {
+      // 前缀命中分组（隐藏子路由场景）：继续深入找最深匹配的祖先链；
+      // 子级无更深命中时展开本分组，避免返回空数组导致上层分组不展开。
+      if (item.children && item.children.length > 0) {
+        const childResult = findExpandedByMenu(item.children, activePath, [...parents, currentPath]);
+        return childResult ?? [...parents, currentPath];
+      }
+
+      // 叶子精确命中：无需展开自身，返回祖先链。
+      return parents;
+    }
 
     const childResult = findExpandedByMenu(item.children || [], activePath, [...parents, currentPath]);
     if (childResult) return childResult;

--- a/frontend-admin-v3/src/layouts/setting.vue
+++ b/frontend-admin-v3/src/layouts/setting.vue
@@ -339,7 +339,7 @@ watchEffect(() => {
       color: var(--td-text-color-disabled);
     }
 
-    > .t-radio-group.t-size-m {
+    > .t-radio-group.t-size-m:not(.setting-mode-radio) {
       pointer-events: none;
       opacity: 0.4;
       filter: grayscale(1);

--- a/frontend-admin-v3/src/layouts/setting.vue
+++ b/frontend-admin-v3/src/layouts/setting.vue
@@ -17,15 +17,15 @@
           variant="default-filled"
           @change="handleModeChange"
         >
-          <t-radio-button :value="'light'">{{ t('layout.setting.theme.options.light') }}</t-radio-button>
-          <t-radio-button :value="'dark'">{{ t('layout.setting.theme.options.dark') }}</t-radio-button>
-          <t-radio-button :value="'auto'">{{ t('layout.setting.theme.options.auto') }}</t-radio-button>
+          <t-radio-button value="light">{{ t('layout.setting.theme.options.light') }}</t-radio-button>
+          <t-radio-button value="dark">{{ t('layout.setting.theme.options.dark') }}</t-radio-button>
+          <t-radio-button value="auto">{{ t('layout.setting.theme.options.auto') }}</t-radio-button>
         </t-radio-group>
 
         <div class="setting-group-title">{{ t('layout.setting.navigationLayout') }}</div>
-        <t-radio-group v-model="formData.layout">
+        <t-radio-group v-model="formData.layout" :disabled="isMobile">
           <div v-for="(item, index) in LAYOUT_OPTION" :key="index" class="setting-layout-drawer">
-            <t-radio-button :key="index" :value="item">
+            <t-radio-button :key="index" :value="item" :disabled="isMobile">
               <thumbnail :src="getThumbnailUrl(item)" />
             </t-radio-button>
           </div>

--- a/frontend-admin-v3/src/pages/member-levels/index.vue
+++ b/frontend-admin-v3/src/pages/member-levels/index.vue
@@ -5,7 +5,7 @@
       <template #subtitle>共 {{ levels.length }} 个档位</template>
       <template #actions>
         <t-space>
-          <t-button theme="primary" @click="openCreateDialog">
+          <t-button v-if="canManage" theme="primary" @click="openCreateDialog">
             <template #icon><add-icon /></template>
             新增等级
           </t-button>
@@ -37,10 +37,11 @@
           <template #updatedAt="{ row }">{{ formatDateTime(row.updated_at) }}</template>
           <template #remark="{ row }">{{ fieldValue(row.remark) }}</template>
           <template #actions="{ row }">
-            <t-space size="small">
+            <t-space v-if="canManage" size="small">
               <t-button theme="primary" variant="text" @click="openEditDialog(row)">编辑</t-button>
               <t-button theme="danger" variant="text" @click="handleDelete(row)">删除</t-button>
             </t-space>
+            <span v-else>-</span>
           </template>
         </t-table>
       </div>
@@ -53,6 +54,7 @@
               <t-tag theme="success" variant="light">{{ formatPercent(row.reward_rate) }}</t-tag>
             </div>
             <t-dropdown
+              v-if="canManage"
               trigger="click"
               placement="bottom-right"
               :options="mobileActionOptions"
@@ -86,7 +88,7 @@
       v-model:visible="dialogVisible"
       :header="form.id ? '编辑会员等级' : '新增会员等级'"
       width="720px"
-      :confirm-btn="{ content: '保存', theme: 'primary' }"
+      :confirm-btn="canManage ? { content: '保存', theme: 'primary' } : null"
       :confirm-loading="saving"
       @confirm="submitForm"
     >
@@ -127,13 +129,15 @@ import './index.less';
 import { AddIcon } from 'tdesign-icons-vue-next';
 import type { DropdownOption, FormInstanceFunctions, FormRule, PrimaryTableCol } from 'tdesign-vue-next';
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next';
-import { onMounted, reactive, ref } from 'vue';
+import { computed, onMounted, reactive, ref } from 'vue';
 
 import type { MemberLevelPayload, MemberLevelRecord } from '@/api/admin';
 import { adminApi } from '@/api/admin';
+import { AdminPermissions } from '@/constants/permissions';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { fieldValue, formatDateTime, formatMoney } from '@/utils/format';
 import { required } from '@/utils/formRules';
+import { hasAdminPermission } from '@/utils/permission';
 import { errorMessage } from '@/utils/userMessage';
 
 interface MemberLevelForm {
@@ -154,6 +158,7 @@ const dialogVisible = ref(false);
 const formRef = ref<FormInstanceFunctions>();
 const levels = ref<MemberLevelRecord[]>([]);
 const isMobile = useMediaQuery('(max-width: 768px)');
+const canManage = computed(() => hasAdminPermission(AdminPermissions.MEMBER_LEVEL_MANAGE));
 
 const form = reactive<MemberLevelForm>(createDefaultForm());
 
@@ -205,11 +210,21 @@ async function loadLevels() {
 }
 
 function openCreateDialog() {
+  if (!canManage.value) {
+    MessagePlugin.warning('当前账号无会员等级管理权限');
+    return;
+  }
+
   Object.assign(form, createDefaultForm());
   dialogVisible.value = true;
 }
 
 function openEditDialog(row: MemberLevelRecord) {
+  if (!canManage.value) {
+    MessagePlugin.warning('当前账号无会员等级管理权限');
+    return;
+  }
+
   Object.assign(form, {
     id: row.id,
     name: String(row.name || ''),
@@ -226,6 +241,11 @@ function openEditDialog(row: MemberLevelRecord) {
 }
 
 async function submitForm() {
+  if (!canManage.value) {
+    MessagePlugin.warning('当前账号无会员等级管理权限');
+    return;
+  }
+
   const result = await formRef.value?.validate?.();
   if (result !== true) return;
 
@@ -269,6 +289,11 @@ function buildPayload(): MemberLevelPayload | null {
 }
 
 function handleDelete(row: MemberLevelRecord) {
+  if (!canManage.value) {
+    MessagePlugin.warning('当前账号无会员等级管理权限');
+    return;
+  }
+
   const dialog = DialogPlugin.confirm({
     header: '删除会员等级',
     body: `确认删除等级“${fieldValue(row.name)}”吗？`,

--- a/frontend-admin-v3/src/pages/products/components/Suppliers.vue
+++ b/frontend-admin-v3/src/pages/products/components/Suppliers.vue
@@ -227,22 +227,18 @@
                     'is-selectable': !row.product?.is_connected,
                     'is-selected': supplierBatchSelectedKeySet.has(row.productId || 0),
                   }"
-                  role="checkbox"
-                  :aria-checked="supplierBatchSelectedKeySet.has(row.productId || 0)"
-                  :aria-label="`${row.product?.name || '商品'}，点击切换选择`"
-                  :tabindex="row.product?.is_connected ? -1 : 0"
                   @click="
                     !row.product?.is_connected &&
-                      handleSupplierBatchProductCheck(row.productId || 0, !supplierBatchSelectedKeySet.has(row.productId || 0))
-                  "
-                  @keydown.enter.prevent="
-                    !row.product?.is_connected &&
-                      handleSupplierBatchProductCheck(row.productId || 0, !supplierBatchSelectedKeySet.has(row.productId || 0))
+                    handleSupplierBatchProductCheck(
+                      row.productId || 0,
+                      !supplierBatchSelectedKeySet.has(row.productId || 0),
+                    )
                   "
                 >
                   <t-checkbox
                     :checked="supplierBatchSelectedKeySet.has(row.productId || 0)"
                     :disabled="row.product?.is_connected"
+                    :aria-label="`${row.product?.name || '商品'}，点击切换选择`"
                     @click.stop
                     @change="
                       (checked: boolean) =>

--- a/frontend-admin-v3/src/pages/products/components/Suppliers.vue
+++ b/frontend-admin-v3/src/pages/products/components/Suppliers.vue
@@ -221,10 +221,29 @@
                 </div>
               </template>
               <template v-else>
-                <div class="supplier-tree-node__content supplier-tree-node__content--product">
+                <div
+                  class="supplier-tree-node__content supplier-tree-node__content--product"
+                  :class="{
+                    'is-selectable': !row.product?.is_connected,
+                    'is-selected': supplierBatchSelectedKeySet.has(row.productId || 0),
+                  }"
+                  role="checkbox"
+                  :aria-checked="supplierBatchSelectedKeySet.has(row.productId || 0)"
+                  :aria-label="`${row.product?.name || '商品'}，点击切换选择`"
+                  :tabindex="row.product?.is_connected ? -1 : 0"
+                  @click="
+                    !row.product?.is_connected &&
+                      handleSupplierBatchProductCheck(row.productId || 0, !supplierBatchSelectedKeySet.has(row.productId || 0))
+                  "
+                  @keydown.enter.prevent="
+                    !row.product?.is_connected &&
+                      handleSupplierBatchProductCheck(row.productId || 0, !supplierBatchSelectedKeySet.has(row.productId || 0))
+                  "
+                >
                   <t-checkbox
                     :checked="supplierBatchSelectedKeySet.has(row.productId || 0)"
                     :disabled="row.product?.is_connected"
+                    @click.stop
                     @change="
                       (checked: boolean) =>
                         !row.product?.is_connected && handleSupplierBatchProductCheck(row.productId || 0, checked)

--- a/frontend-admin-v3/src/pages/products/components/Suppliers.vue
+++ b/frontend-admin-v3/src/pages/products/components/Suppliers.vue
@@ -561,6 +561,7 @@ const supplierCredentialValues = reactive<Record<string, unknown>>({});
 const supplierSecretEdited = reactive<Record<string, boolean>>({});
 const canManageSuppliers = computed(() => hasAdminPermission(AdminPermissions.SUPPLIER_MANAGE));
 const canSyncSuppliers = computed(() => hasAdminPermission(AdminPermissions.SUPPLIER_SYNC));
+const canBulkConnectSupplierProducts = computed(() => hasAdminPermission(AdminPermissions.PRODUCT_SYNC));
 const canRevealSupplierSecrets = computed(() => hasAdminPermission(AdminPermissions.SUPPLIER_SECRET_REVEAL));
 
 const supplierRules = {
@@ -667,6 +668,16 @@ function supplierCardFields(row: SupplierRecord): SupplierCardField[] {
     : [];
 }
 
+function canRunSupplierCardAction(action: SupplierCardAction) {
+  if (!canSyncSuppliers.value) return false;
+  const requestAction = String(action.request_action || '').trim();
+  if (requestAction === 'server.supplier.bulk_connect' || action.action === 'supplier.batch_connect') {
+    return canBulkConnectSupplierProducts.value;
+  }
+
+  return true;
+}
+
 function supplierCardActions(row: SupplierRecord): SupplierCardAction[] {
   const actions = supplierCard(row).actions;
   if (!canSyncSuppliers.value || !Array.isArray(actions)) return [];
@@ -686,7 +697,10 @@ function supplierCardActions(row: SupplierRecord): SupplierCardAction[] {
     })
     .filter(
       (action) =>
-        String(action.key || '').trim() && String(action.action || '').trim() && String(action.label || '').trim(),
+        String(action.key || '').trim() &&
+        String(action.action || '').trim() &&
+        String(action.label || '').trim() &&
+        canRunSupplierCardAction(action),
     );
 }
 
@@ -799,6 +813,11 @@ function patchSupplierCard(supplierId: SupplierRecord['id'], card: unknown) {
 }
 
 function handleSupplierCardAction(row: SupplierRecord, action: SupplierCardAction) {
+  if (!canRunSupplierCardAction(action)) {
+    MessagePlugin.warning('当前账号无权执行该供应商插件动作');
+    return;
+  }
+
   if (supplierCardActionDisabled(action)) {
     MessagePlugin.warning(action.disabled_reason || '插件动作暂不可用');
     return;
@@ -1283,7 +1302,10 @@ async function loadSupplierBatchProducts() {
 }
 
 async function openSupplierBatchDialog(row: SupplierRecord, action: SupplierCardAction) {
-  if (!canSyncSuppliers.value) return;
+  if (!canRunSupplierCardAction(action)) {
+    MessagePlugin.warning('当前账号无权执行批量商品对接');
+    return;
+  }
 
   if (supplierCardActionDisabled(action)) {
     MessagePlugin.warning(action.disabled_reason || '插件动作暂不可用');
@@ -1324,7 +1346,7 @@ function selectSupplierBatchTargetGroup(groupKey: string) {
 }
 
 async function reloadSupplierBatchProducts() {
-  if (!canSyncSuppliers.value) return;
+  if (!canRunSupplierCardAction(supplierBatchAction.value || ({} as SupplierCardAction))) return;
 
   await Promise.all([loadSupplierBatchProducts(), loadSupplierBatchLocalProducts()]);
   setAllSupplierBatchRemoteExpanded(true);
@@ -1341,7 +1363,10 @@ function resolveSupplierBatchTargetFirstGroupCode() {
 }
 
 async function submitSupplierBatchConnect() {
-  if (!canSyncSuppliers.value) return;
+  if (!canRunSupplierCardAction(supplierBatchAction.value || ({} as SupplierCardAction))) {
+    MessagePlugin.warning('当前账号无权执行批量商品对接');
+    return;
+  }
   if (!supplierBatchSupplier.value?.id) return;
   const requestAction = String(supplierBatchAction.value?.request_action || '').trim();
   if (!requestAction) {

--- a/frontend-admin-v3/src/pages/products/index.less
+++ b/frontend-admin-v3/src/pages/products/index.less
@@ -1863,6 +1863,30 @@
   background: var(--td-bg-color-container-hover);
 }
 
+/* 上游商品卡片：整体可点击切换选中（左侧未对接面板） */
+.supplier-tree-node--product .supplier-tree-node__content--product.is-selectable {
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--td-brand-color-light);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--td-brand-color-focus);
+    outline-offset: 1px;
+  }
+}
+
+.supplier-tree-node--product .supplier-tree-node__content--product.is-selected {
+  border-color: var(--td-brand-color);
+  background: var(--td-brand-color-light);
+
+  .supplier-tree-product strong,
+  .supplier-tree-product span {
+    color: var(--td-brand-color);
+  }
+}
+
 .supplier-tree-node--product.is-disabled {
   .supplier-tree-node__content--product {
     background: var(--td-bg-color-component);

--- a/frontend-admin-v3/src/pages/settings/index.vue
+++ b/frontend-admin-v3/src/pages/settings/index.vue
@@ -776,6 +776,28 @@ const configs: Record<Exclude<SettingsTab, 'site_hero'>, SettingsConfig> = {
           { key: 'privacy_url', label: '隐私政策链接', type: 'input', default: '', maxlength: 255 },
         ],
       },
+      {
+        title: '通知总开关',
+        description: '邮件与短信的全局开关；关闭后对应渠道的验证码与业务通知不再发送。',
+        fields: [
+          {
+            key: 'email_enabled',
+            label: '启用邮件通知',
+            type: 'switch',
+            group: 'notification',
+            default: false,
+            help: '关闭后系统邮件（邮箱验证码、服务/账单等通知）不再发送。',
+          },
+          {
+            key: 'sms_enabled',
+            label: '启用短信通知',
+            type: 'switch',
+            group: 'notification',
+            default: false,
+            help: '关闭后系统短信（短信验证码等）不再发送。',
+          },
+        ],
+      },
     ],
   },
 };

--- a/frontend-admin-v3/src/pages/users/index.vue
+++ b/frontend-admin-v3/src/pages/users/index.vue
@@ -15,7 +15,7 @@
           <t-option label="正常" :value="1" />
           <t-option label="禁用" :value="0" />
         </t-select>
-        <t-button size="medium" theme="primary" @click="openCreateDialog">
+        <t-button v-if="canManageUsers" size="medium" theme="primary" @click="openCreateDialog">
           <template #icon><user-add-icon /></template>
           新增用户
         </t-button>
@@ -152,14 +152,17 @@ import { useRouter } from 'vue-router';
 
 import type { AdminUser } from '@/api/user';
 import { userApi } from '@/api/user';
+import { AdminPermissions } from '@/constants/permissions';
 import { formatDateTime, formatMoney } from '@/utils/format';
 import { required } from '@/utils/formRules';
+import { hasAdminPermission } from '@/utils/permission';
 
 defineOptions({
   name: 'AdminUsers',
 });
 
 const router = useRouter();
+const canManageUsers = computed(() => hasAdminPermission(AdminPermissions.USER_MANAGE));
 
 const loading = ref(false);
 const submitLoading = ref(false);
@@ -226,11 +229,21 @@ function handlePageChange(pageInfo: PageInfo) {
 }
 
 function openCreateDialog() {
+  if (!canManageUsers.value) {
+    MessagePlugin.warning('当前账号无用户管理权限');
+    return;
+  }
+
   Object.assign(createForm, { email: '', nickname: '', phone: '', password: '' });
   createVisible.value = true;
 }
 
 async function handleCreate() {
+  if (!canManageUsers.value) {
+    MessagePlugin.warning('当前账号无用户管理权限');
+    return;
+  }
+
   const result = await createFormRef.value?.validate?.();
   if (result !== true) return;
 

--- a/frontend-admin-v3/src/store/modules/setting.ts
+++ b/frontend-admin-v3/src/store/modules/setting.ts
@@ -64,6 +64,12 @@ export const useSettingStore = defineStore('setting', {
       document.documentElement.setAttribute('theme-mode', isDarkMode ? 'dark' : '');
 
       this.chartColors = isDarkMode ? DARK_CHART_COLORS : LIGHT_CHART_COLORS;
+
+      // 模式/跟随系统变化后重放品牌主题色：品牌色阶分浅/深两套动态样式且仅按 displayMode 插入，
+      // 若不重放，切换模式后品牌色（--td-brand-color-N）会残留旧模式的样式。
+      if (this.brandTheme) {
+        this.changeBrandTheme(this.brandTheme as string);
+      }
     },
     async changeSideMode(mode: ModeType) {
       const isDarkMode = mode === 'dark';

--- a/frontend-admin-v3/src/store/modules/setting.ts
+++ b/frontend-admin-v3/src/store/modules/setting.ts
@@ -36,14 +36,15 @@ export const useSettingStore = defineStore('setting', {
       }
       return state.mode as ModeType;
     },
-    displaySideMode: (state): ModeType => {
+    displaySideMode(state: TState): ModeType {
       // 侧边栏跟随主主题模式：浅色主题 → 浅色侧边栏；深色主题 → 深色侧边栏。
       // 若 sideMode 被显式配置为深色，则侧边栏独立使用深色（保留独立配色能力）。
       const explicitSideMode = state.sideMode as ModeType;
       if (explicitSideMode === 'dark') {
         return 'dark';
       }
-      return state.displayMode;
+      // displayMode 是 getter 而非 state 字段，必须通过 this 访问。
+      return this.displayMode;
     },
   },
   actions: {
@@ -52,7 +53,12 @@ export const useSettingStore = defineStore('setting', {
 
       if (mode === 'auto') {
         theme = this.getMediaColor();
+        // auto 模式：监听系统主题变化，切回其他模式时移除监听。
+        watchSystemTheme();
+      } else {
+        unwatchSystemTheme();
       }
+
       const isDarkMode = theme === 'dark';
 
       document.documentElement.setAttribute('theme-mode', isDarkMode ? 'dark' : '');
@@ -115,4 +121,42 @@ export const useSettingStore = defineStore('setting', {
 
 export function getSettingStore() {
   return useSettingStore(store);
+}
+
+// auto 模式系统主题监听：模块级变量，不参与持久化。
+let systemThemeMedia: MediaQueryList | null = null;
+let systemThemeHandler: ((event: MediaQueryListEvent) => void) | null = null;
+
+function watchSystemTheme(): void {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return;
+  }
+  if (systemThemeMedia && systemThemeHandler) {
+    return; // 已监听，避免重复挂载
+  }
+  systemThemeMedia = window.matchMedia('(prefers-color-scheme:dark)');
+  systemThemeHandler = () => {
+    // 仅当仍处于 auto 模式时跟随系统主题变化。
+    if (getSettingStore().mode === 'auto') {
+      getSettingStore().changeMode('auto');
+    }
+  };
+  if (typeof systemThemeMedia.addEventListener === 'function') {
+    systemThemeMedia.addEventListener('change', systemThemeHandler);
+  } else {
+    // 旧浏览器兼容
+    systemThemeMedia.addListener(systemThemeHandler);
+  }
+}
+
+function unwatchSystemTheme(): void {
+  if (systemThemeMedia && systemThemeHandler) {
+    if (typeof systemThemeMedia.removeEventListener === 'function') {
+      systemThemeMedia.removeEventListener('change', systemThemeHandler);
+    } else {
+      systemThemeMedia.removeListener(systemThemeHandler);
+    }
+    systemThemeMedia = null;
+    systemThemeHandler = null;
+  }
 }

--- a/frontend-admin-v3/src/utils/request/index.ts
+++ b/frontend-admin-v3/src/utils/request/index.ts
@@ -19,6 +19,24 @@ if (!host) {
   throw new Error('VITE_API_BASE_URL 必须配置');
 }
 
+const SAFE_RETRY_METHODS = new Set(['get', 'head', 'options']);
+
+function normalizeRequestMethod(config: Recordable | undefined): string {
+  return String(config?.method || 'get').toLowerCase();
+}
+
+function canRetryRequest(config: Recordable | undefined): boolean {
+  return Boolean(config?.requestOptions?.retry && SAFE_RETRY_METHODS.has(normalizeRequestMethod(config)));
+}
+
+function createRequestId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `admin-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
 // 数据处理，方便区分多种处理方式
 const transform: AxiosTransform = {
   // 处理请求数据。如果数据不是预期格式，可直接抛出错误
@@ -135,9 +153,18 @@ const transform: AxiosTransform = {
     // 请求之前处理config
     const token = getAdminToken();
 
+    const headers = { ...((config as Recordable).headers || {}) };
+
     if (token && (config as Recordable)?.requestOptions?.withToken !== false) {
-      (config as Recordable).headers.Authorization = `${options.authenticationScheme || 'Bearer'} ${token}`;
+      headers.Authorization = `${options.authenticationScheme || 'Bearer'} ${token}`;
     }
+
+    if (!SAFE_RETRY_METHODS.has(normalizeRequestMethod(config as Recordable))) {
+      headers['X-Request-Id'] = String(headers['X-Request-Id'] || createRequestId());
+    }
+
+    (config as Recordable).headers = headers;
+
     return config;
   },
 
@@ -154,7 +181,7 @@ const transform: AxiosTransform = {
       error.message = toUserMessage(responseMessage, error.message || '请求接口错误');
     }
 
-    if (!config || !config.requestOptions.retry) return Promise.reject(error);
+    if (!canRetryRequest(config)) return Promise.reject(error);
 
     // 4xx 客户端错误（认证失败/无权限/参数错误/限流等）重试无意义且会加剧限流，直接返回
     const status = error?.response?.status;

--- a/frontend-user-v3-www/src/app/router/guards.ts
+++ b/frontend-user-v3-www/src/app/router/guards.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/stores/app'
+import { setToken } from '@/utils/auth'
 import { applyRouteMeta } from '@/utils/pageMeta'
 
 const DEFAULT_PUBLIC_SITE_URL = 'https://www.coyjs.cn'
@@ -6,6 +7,26 @@ const DYNAMIC_IMPORT_RELOAD_KEY = 'www-router-dynamic-import-reload'
 const dynamicImportErrorPattern = /Failed to fetch dynamically imported module|Importing a module script failed/i
 
 export function registerClientGuards(router) {
+  router.beforeEach((to) => {
+    const rawToken = to.query?._token
+    const token = Array.isArray(rawToken) ? rawToken[0] : rawToken
+
+    if (typeof token !== 'string' || token.trim() === '') {
+      return true
+    }
+
+    setToken(token.trim())
+    const query = { ...to.query }
+    delete query._token
+
+    return {
+      path: to.path,
+      query,
+      hash: to.hash,
+      replace: true,
+    }
+  })
+
   router.afterEach((to) => {
     if (typeof window === 'undefined') {
       return

--- a/frontend-user-v3-www/src/views/website/ProductDetail/index.vue
+++ b/frontend-user-v3-www/src/views/website/ProductDetail/index.vue
@@ -512,7 +512,10 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { ElMessage } from "element-plus/es/components/message/index.mjs";
 import siteApi from "@/api/site";
+import { useUserStore } from "@/stores/user";
+import { getToken } from "@/utils/auth";
 import {
+  resolveMissingPurchaseRequirements,
   resolvePurchaseRequirementList,
   resolvePurchaseRequirementSummary,
 } from "@/utils/productPurchaseRequirements";
@@ -531,6 +534,7 @@ import {
   savePendingWebsiteCheckout,
 } from "@/utils/websiteCheckout";
 import { buildPendingCouponRedirectUrl } from "@/utils/websiteCoupon";
+import { updatePageMeta } from "@/utils/pageMeta";
 import {
   isCpuConfigKey,
   isMemoryConfigKey,
@@ -540,6 +544,7 @@ import { useWebsiteProductConfigurator } from "@/domains/products/useWebsiteProd
 
 const route = useRoute();
 const router = useRouter();
+const userStore = useUserStore();
 
 const loading = ref(false);
 const submitting = ref(false);
@@ -810,6 +815,7 @@ const purchaseRequirementSummary = computed(() =>
 let quoteTimer = null;
 let quoteAbortController = null;
 let quoteExecuteToken = 0;
+let quoteWatchSuspendCount = 0;
 let productLoadToken = 0;
 
 function createQuoteSignal() {
@@ -924,6 +930,10 @@ async function clearCoupon() {
 }
 
 function fetchQuote() {
+  if (quoteWatchSuspendCount > 0) {
+    return;
+  }
+
   clearTimeout(quoteTimer);
   quoteTimer = setTimeout(() => {
     executeQuote(selectedCouponId.value, { fallbackInvalidCoupon: true });
@@ -1033,6 +1043,40 @@ function redirectToConsoleCheckout(orderPayload, idempotencyKey) {
   );
 }
 
+async function ensurePurchaseRequirementsBeforeCheckout() {
+  const requirements = resolvePurchaseRequirementList(product.value);
+  if (!requirements.length) {
+    return true;
+  }
+
+  if (!getToken()) {
+    ElMessage.warning("请先登录后再购买该商品");
+    navigateToConsole("/client/login");
+    return false;
+  }
+
+  let user = userStore.info;
+  if (!user) {
+    try {
+      user = await userStore.fetchUserInfo();
+    } catch {
+      ElMessage.warning("登录状态已失效，请重新登录");
+      navigateToConsole("/client/login");
+      return false;
+    }
+  }
+
+  const missing = resolveMissingPurchaseRequirements(product.value, user);
+  if (!missing.length) {
+    return true;
+  }
+
+  const primary = missing[0];
+  ElMessage.warning(primary.unmetMessage || "请先完成购买前置要求");
+  navigateToConsole(primary.route || "/client/profile");
+  return false;
+}
+
 async function submitOrder() {
   if (productStockLoading.value) {
     ElMessage.warning("库存同步中，请稍候");
@@ -1052,6 +1096,10 @@ async function submitOrder() {
   }
   if (!canSubmit.value) {
     ElMessage.warning("请选择计费周期");
+    return;
+  }
+
+  if (!(await ensurePurchaseRequirementsBeforeCheckout())) {
     return;
   }
 
@@ -1079,18 +1127,57 @@ function switchProduct(id) {
 }
 
 function initDefaults() {
-  configurator.initProductDefaults({
-    selectedCycleRef: selectedCycle,
-    quantityRef: quantity,
-    resetQuoteState: () => {
-      quoteResult.value = null;
-      quoteToken.value = "";
+  quoteWatchSuspendCount += 1;
+  try {
+    configurator.initProductDefaults({
+      selectedCycleRef: selectedCycle,
+      quantityRef: quantity,
+      resetQuoteState: () => {
+        quoteResult.value = null;
+        quoteToken.value = "";
+      },
+    });
+
+    hostname.value = defaultHostname.value;
+    password.value = "";
+  } finally {
+    quoteWatchSuspendCount = Math.max(0, quoteWatchSuspendCount - 1);
+  }
+
+  fetchQuote();
+}
+
+function plainTextSummary(value, maxLength = 160) {
+  return String(value || "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function syncProductMeta(nextProduct) {
+  if (!nextProduct) return;
+  const title = resolveProductDisplayName(nextProduct) || "云产品详情";
+  const description = plainTextSummary(
+    nextProduct.description ||
+      nextProduct.group?.slogan ||
+      nextProduct.group?.parent_slogan ||
+      "图拉云产品详情与实时购买报价",
+  );
+  const canonical = typeof window !== "undefined" ? new URL(route.path, window.location.origin).toString() : "";
+
+  updatePageMeta({
+    title: `${title} - 云产品`,
+    description,
+    keywords: [title, nextProduct.type_label, nextProduct.group?.full_name].filter(Boolean).join(","),
+    canonical,
+    structuredData: {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      name: title,
+      description,
     },
   });
-
-  hostname.value = defaultHostname.value;
-  password.value = "";
-  fetchQuote();
 }
 
 async function loadProduct() {
@@ -1109,6 +1196,7 @@ async function loadProduct() {
     if (token !== productLoadToken) return;
     product.value = res.data.product || null;
     siblings.value = res.data.product?.siblings || [];
+    syncProductMeta(product.value);
     initDefaults();
   } catch {
     if (token !== productLoadToken) return;

--- a/frontend-user-v3-www/src/views/website/content/ContentDetailPage.vue
+++ b/frontend-user-v3-www/src/views/website/content/ContentDetailPage.vue
@@ -31,7 +31,16 @@
             </div>
           </header>
 
-          <template v-if="currentArticle">
+          <el-alert
+            v-if="errorText && !loading"
+            :title="errorText"
+            type="error"
+            show-icon
+            :closable="false"
+            class="reader-error"
+          />
+
+          <template v-else-if="currentArticle">
             <el-divider />
 
             <div
@@ -92,6 +101,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { ArrowRight } from '@element-plus/icons-vue'
 import siteApi from '@/api/site'
 import { renderMarkdown } from '@/utils/markdown'
+import { updatePageMeta } from '@/utils/pageMeta'
 import { rewriteApiAssetUrlsInHtml } from '@/utils/apiAssetUrl'
 import { getContentConfig } from './contentConfig'
 
@@ -139,6 +149,7 @@ const api = computed(() => siteApi)
 const config = computed(() => getContentConfig(props.contentType, props.scope))
 
 const loading = ref(false)
+const errorText = ref('')
 const categories = ref([])
 const currentArticle = ref(null)
 const currentCategoryId = ref(null)
@@ -196,6 +207,42 @@ const articleContentHtml = computed(() => {
   return rewriteApiAssetUrlsInHtml(rendered, apiBaseUrl)
 })
 
+function plainTextSummary(value, maxLength = 160) {
+  return String(value || '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[>#*_\-[\]()!]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+}
+
+function currentCanonicalUrl() {
+  if (typeof window === 'undefined') return ''
+  return new URL(route.path, window.location.origin).toString()
+}
+
+function syncArticleMeta(article) {
+  if (!article) return
+  const title = String(article.title || config.value.detailTitle || '').trim()
+  const description = plainTextSummary(article.summary || article.excerpt || article.content || config.value.description)
+  updatePageMeta({
+    title: `${title} - ${config.value.pageTitle}`,
+    description,
+    keywords: [article.category_name, title, config.value.pageTitle].filter(Boolean).join(','),
+    canonical: currentCanonicalUrl(),
+    structuredData: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: title,
+      description,
+      datePublished: article.publish_at || article.created_at || undefined,
+      dateModified: article.updated_at || undefined,
+    },
+  })
+}
+
 async function loadOverview() {
   const cacheKey = config.value.overviewCategoryKey
   const cached = getCachedOverview(cacheKey)
@@ -213,16 +260,25 @@ async function loadArticleDetail(articleId) {
   const res = await api.value[config.value.apiDetailMethod](articleId)
   currentArticle.value = res.data || null
   currentCategoryId.value = Number(res.data?.category_id || 0) || null
+  syncArticleMeta(currentArticle.value)
 }
 
 async function syncPage() {
   loading.value = true
+  errorText.value = ''
+  currentArticle.value = null
+  currentCategoryId.value = null
+  tocItems.value = [{ id: 'article-top', label: '全文', level: 1 }]
 
   try {
     await Promise.all([
       loadOverview(),
       loadArticleDetail(route.params.id),
     ])
+  } catch (error) {
+    currentArticle.value = null
+    currentCategoryId.value = null
+    errorText.value = error?.response?.data?.message || error?.message || `${config.value.detailTitle}加载失败，请稍后重试`
   } finally {
     loading.value = false
   }
@@ -341,6 +397,10 @@ watch(
   grid-template-columns: minmax(0, 1fr) 320px;
   gap: 20px;
   align-items: start;
+}
+
+.reader-error {
+  margin-top: 18px;
 }
 
 .reader-main {

--- a/frontend-user-v3-www/src/views/website/products/useWebsiteProductCheckout.js
+++ b/frontend-user-v3-www/src/views/website/products/useWebsiteProductCheckout.js
@@ -2,6 +2,7 @@ import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { ElMessage } from "element-plus/es/components/message/index.mjs";
 import siteApi from "@/api/site";
 import {
+  resolveMissingPurchaseRequirements,
   resolvePurchaseRequirementList,
   resolvePurchaseRequirementSummary,
 } from "@/utils/productPurchaseRequirements";
@@ -9,6 +10,8 @@ import {
   normalizeMoneyText,
   resolveProductDisplayName,
 } from "@/utils/websiteProductConfig";
+import { useUserStore } from "@/stores/user";
+import { getToken } from "@/utils/auth";
 import { navigateToConsole } from "@/utils/consoleUrl";
 import {
   buildIdempotencyKey,
@@ -29,6 +32,7 @@ export function useWebsiteProductCheckout({
   initProductDefaults,
   resetConfigForm,
 }) {
+  const userStore = useUserStore();
   const configLoading = ref(false);
   const submitting = ref(false);
   const selectedCycle = ref("");
@@ -417,6 +421,40 @@ export function useWebsiteProductCheckout({
     }, 250);
   }
 
+  async function ensurePurchaseRequirementsBeforeCheckout() {
+    const requirements = resolvePurchaseRequirementList(selectedProduct.value);
+    if (!requirements.length) {
+      return true;
+    }
+
+    if (!getToken()) {
+      ElMessage.warning("请先登录后再购买该商品");
+      navigateToConsole("/client/login");
+      return false;
+    }
+
+    let user = userStore.info;
+    if (!user) {
+      try {
+        user = await userStore.fetchUserInfo();
+      } catch {
+        ElMessage.warning("登录状态已失效，请重新登录");
+        navigateToConsole("/client/login");
+        return false;
+      }
+    }
+
+    const missing = resolveMissingPurchaseRequirements(selectedProduct.value, user);
+    if (!missing.length) {
+      return true;
+    }
+
+    const primary = missing[0];
+    ElMessage.warning(primary.unmetMessage || "请先完成购买前置要求");
+    navigateToConsole(primary.route || "/client/profile");
+    return false;
+  }
+
   async function submitOrder() {
     if (productStockLoading.value) {
       ElMessage.warning("库存同步中，请稍候");
@@ -445,6 +483,10 @@ export function useWebsiteProductCheckout({
 
     if (quoteLoading.value) {
       ElMessage.warning("价格计算中，请稍候");
+      return;
+    }
+
+    if (!(await ensurePurchaseRequirementsBeforeCheckout())) {
       return;
     }
 

--- a/frontend-user-v3-www/src/views/website/products/useWebsiteProductsCatalog.js
+++ b/frontend-user-v3-www/src/views/website/products/useWebsiteProductsCatalog.js
@@ -102,7 +102,13 @@ export function useWebsiteProductsCatalog({
 
     return Number(activeGroup.value?.effective_product_group_id || 0);
   });
-  const showMobileTypePicker = computed(() => false);
+  const showMobileTypePicker = computed(
+    () =>
+      isMobile.value &&
+      !mobileTypeEntered.value &&
+      productTypes.value.length > 1 &&
+      !hasWebsiteProductRouteParams(readWebsiteProductRouteParams(route)),
+  );
   const shouldAutoSelectProduct = computed(
     () => getPendingWebsiteCouponId() <= 0,
   );
@@ -640,6 +646,16 @@ export function useWebsiteProductsCatalog({
 
         const linked = await applyRouteSelection();
         return linked;
+      }
+
+      if (!hasRouteTarget && isMobile.value) {
+        activeTypeValue.value = "";
+        rootGroups.value = [];
+        childGroups.value = [];
+        productsByGroup.value = {};
+        resetSelectedProduct({ syncRoute: false });
+        mobileTypeEntered.value = false;
+        return true;
       }
 
       const types = productTypes.value;

--- a/frontend-user-v4-console/src/api/client.ts
+++ b/frontend-user-v4-console/src/api/client.ts
@@ -185,7 +185,7 @@ function v2InvoiceDetail(id: number | string) {
 }
 
 function v2FinanceLedger(params?: QueryParams) {
-  return getEnvelope<V2ClientLedgerPayload>('/v2/client/ledger', { params }).then((response) =>
+  return getEnvelope<V2ClientLedgerPayload>('/v2/client/finance/ledger', { params }).then((response) =>
     dataEnvelope(response, {
       list: response.data?.list || [],
       total: Number(response.data?.total || 0),
@@ -196,13 +196,9 @@ function v2FinanceLedger(params?: QueryParams) {
 }
 
 function v2FinanceLedgerSummary(params?: QueryParams) {
-  return getEnvelope<V2ClientLedgerPayload>('/v2/client/ledger', {
-    params: {
-      ...(params || {}),
-      page: 1,
-      page_size: 1,
-    },
-  }).then((response) => dataEnvelope(response, response.data?.summary || {}));
+  return getEnvelope<FinanceLedgerSummary>('/v2/client/finance/ledger/summary', { params }).then((response) =>
+    dataEnvelope(response, response.data || {}),
+  );
 }
 
 function v2ServiceDetail(id: number | string, config?: RequestConfig) {

--- a/frontend-user-v4-console/src/domains/account/useProfile.ts
+++ b/frontend-user-v4-console/src/domains/account/useProfile.ts
@@ -10,7 +10,7 @@ import { getErrorMessage } from '@/utils/error';
 import { copyText as copyShared } from '@/utils/format';
 
 type TagTheme = 'default' | 'success' | 'warning' | 'primary' | 'danger';
-type ProfileTab = 'profile' | 'security' | 'agent' | 'notification';
+type ProfileTab = 'profile' | 'security' | 'agent' | 'notification' | 'display';
 type NotificationKey = keyof ClientNotificationPreferences;
 interface NotificationItem {
   key: NotificationKey;
@@ -19,7 +19,7 @@ interface NotificationItem {
   enabled: boolean;
 }
 
-const PROFILE_TABS = new Set<ProfileTab>(['profile', 'security', 'agent', 'notification']);
+const PROFILE_TABS = new Set<ProfileTab>(['profile', 'security', 'agent', 'notification', 'display']);
 
 export function useProfile() {
   const router = useRouter();

--- a/frontend-user-v4-console/src/domains/finance/useInvoices.ts
+++ b/frontend-user-v4-console/src/domains/finance/useInvoices.ts
@@ -172,6 +172,7 @@ export function useInvoiceList(options: { fixedTypes?: unknown; pageSize?: numbe
   const summaryLoading = ref(false);
   const canceling = ref(false);
   const list = shallowRef<InvoiceRecord[]>([]);
+  const listError = ref('');
   const total = ref(0);
   const summary = shallowRef<InvoiceListSummary>({});
   const detailVisible = ref(false);
@@ -224,12 +225,16 @@ export function useInvoiceList(options: { fixedTypes?: unknown; pageSize?: numbe
   async function loadList() {
     loading.value = true;
     try {
+      listError.value = '';
       const res = await clientApi.invoices(buildParams());
       const payload = resolveListPayload(res);
       list.value = payload.list;
       total.value = payload.total;
     } catch (error: unknown) {
-      MessagePlugin.error(getErrorMessage(error, '账单列表加载失败'));
+      list.value = [];
+      total.value = 0;
+      listError.value = getErrorMessage(error, '账单列表加载失败');
+      MessagePlugin.error(listError.value);
     } finally {
       loading.value = false;
     }
@@ -309,8 +314,14 @@ export function useInvoiceList(options: { fixedTypes?: unknown; pageSize?: numbe
   }
 
   function goToPay(row: InvoiceRecord) {
+    const invoiceId = normalizeInvoiceId(row?.id);
+    if (!invoiceId) {
+      MessagePlugin.warning('账单 ID 缺失，无法发起支付');
+      return;
+    }
+
     detailVisible.value = false;
-    router.push(`/client/invoices/${row.id}/pay`);
+    router.push(`/client/invoices/${invoiceId}/pay`);
   }
 
   function cancelInvoice(row: InvoiceRecord) {
@@ -367,6 +378,7 @@ export function useInvoiceList(options: { fixedTypes?: unknown; pageSize?: numbe
     summaryLoading,
     canceling,
     list,
+    listError,
     total,
     summary,
     filters,
@@ -718,9 +730,17 @@ export function useInvoiceDetail() {
     },
   );
 
-  onMounted(() => {
-    void loadDetail();
-  });
+  watch(
+    invoiceId,
+    (id) => {
+      detail.value = null;
+      selectedPayMethod.value = '';
+      allowBalanceDeduction.value = false;
+      resetPaymentPayload();
+      if (id > 0) void loadDetail();
+    },
+    { immediate: true },
+  );
 
   onBeforeUnmount(() => {
     clearPollingTimer();

--- a/frontend-user-v4-console/src/domains/finance/useInvoices.ts
+++ b/frontend-user-v4-console/src/domains/finance/useInvoices.ts
@@ -529,11 +529,18 @@ export function useInvoiceDetail() {
     alipayDialogVisible.value = Boolean(alipayQrCode.value);
   }
 
+  // 详情并发守卫：快速切换发票/订单/支付详情时，旧请求晚返回不得覆盖当前路由的最新态。
+  let detailRequestSeq = 0;
+
   async function loadDetail() {
     if (!invoiceId.value) return;
+    const seq = ++detailRequestSeq;
     loading.value = true;
     try {
       const res = await clientApi.invoiceDetail(invoiceId.value);
+      if (seq !== detailRequestSeq) {
+        return;
+      }
       detail.value = res.data || null;
       alipayAmount.value = formatMoney(payableAmount.value);
       syncPayMethod();
@@ -549,9 +556,14 @@ export function useInvoiceDetail() {
         resetPaymentPayload();
       }
     } catch (error: unknown) {
+      if (seq !== detailRequestSeq) {
+        return;
+      }
       MessagePlugin.error(getErrorMessage(error, '账单详情加载失败'));
     } finally {
-      loading.value = false;
+      if (seq === detailRequestSeq) {
+        loading.value = false;
+      }
     }
   }
 

--- a/frontend-user-v4-console/src/domains/finance/useOrders.ts
+++ b/frontend-user-v4-console/src/domains/finance/useOrders.ts
@@ -172,16 +172,28 @@ export function useOrderDetail() {
   const canceling = ref(false);
   const detail = shallowRef<OrderRecord | null>(null);
 
+  // 并发守卫：快速切换订单详情时丢弃晚返回的旧请求结果。
+  let requestSeq = 0;
+
   async function loadDetail(id: number | string) {
     if (!id) return;
+    const seq = ++requestSeq;
     loading.value = true;
     try {
       const res = await clientApi.orderDetail(id);
+      if (seq !== requestSeq) {
+        return;
+      }
       detail.value = res.data || null;
     } catch (error: unknown) {
+      if (seq !== requestSeq) {
+        return;
+      }
       MessagePlugin.error(getErrorMessage(error, '订单详情加载失败'));
     } finally {
-      loading.value = false;
+      if (seq === requestSeq) {
+        loading.value = false;
+      }
     }
   }
 

--- a/frontend-user-v4-console/src/domains/finance/useOrders.ts
+++ b/frontend-user-v4-console/src/domains/finance/useOrders.ts
@@ -30,6 +30,7 @@ export function useOrderList(options: { pageSize?: number } = {}) {
   const summaryLoading = ref(false);
   const canceling = ref(false);
   const list = shallowRef<OrderRecord[]>([]);
+  const listError = ref('');
   const total = ref(0);
   const summary = shallowRef<OrderListSummary>({});
   const filters = reactive({
@@ -72,12 +73,16 @@ export function useOrderList(options: { pageSize?: number } = {}) {
   async function loadList() {
     loading.value = true;
     try {
+      listError.value = '';
       const res = await clientApi.orders(buildParams());
       const payload = res.data;
       list.value = payload && !Array.isArray(payload) && Array.isArray(payload.list) ? payload.list : [];
       total.value = payload && !Array.isArray(payload) ? Number(payload.total || 0) : 0;
     } catch (error: unknown) {
-      MessagePlugin.error(getErrorMessage(error, '订单列表加载失败'));
+      list.value = [];
+      total.value = 0;
+      listError.value = getErrorMessage(error, '订单列表加载失败');
+      MessagePlugin.error(listError.value);
     } finally {
       loading.value = false;
     }
@@ -148,6 +153,7 @@ export function useOrderList(options: { pageSize?: number } = {}) {
     summaryLoading,
     canceling,
     list,
+    listError,
     total,
     summary,
     filters,

--- a/frontend-user-v4-console/src/domains/finance/useOrders.ts
+++ b/frontend-user-v4-console/src/domains/finance/useOrders.ts
@@ -176,11 +176,16 @@ export function useOrderDetail() {
   let requestSeq = 0;
 
   async function loadDetail(id: number | string) {
-    if (!id) return;
+    const validId = Number(id);
+    if (!Number.isInteger(validId) || validId <= 0) {
+      // 无效 ID（0/负数/NaN）：失效进行中的请求并复位详情与加载态，避免调用接口。
+      invalidateDetail();
+      return;
+    }
     const seq = ++requestSeq;
     loading.value = true;
     try {
-      const res = await clientApi.orderDetail(id);
+      const res = await clientApi.orderDetail(validId);
       if (seq !== requestSeq) {
         return;
       }

--- a/frontend-user-v4-console/src/domains/finance/useOrders.ts
+++ b/frontend-user-v4-console/src/domains/finance/useOrders.ts
@@ -197,6 +197,12 @@ export function useOrderDetail() {
     }
   }
 
+  function invalidateDetail(): void {
+    requestSeq += 1; // 使进行中的旧请求失效
+    detail.value = null;
+    loading.value = false;
+  }
+
   function cancelOrder(onSuccess?: () => void) {
     if (!detail.value) return;
     const row = detail.value;
@@ -230,6 +236,7 @@ export function useOrderDetail() {
     canceling,
     detail,
     loadDetail,
+    invalidateDetail,
     cancelOrder,
   };
 }

--- a/frontend-user-v4-console/src/domains/services/console/useConsoleTabs.ts
+++ b/frontend-user-v4-console/src/domains/services/console/useConsoleTabs.ts
@@ -41,6 +41,7 @@ function createEmptyFinanceState() {
     loading: false,
     list: [] as FinanceLedgerRecord[],
     total: 0,
+    error: '',
     page: 1,
     page_size: 10,
     summary: {
@@ -228,6 +229,7 @@ export function useConsoleTabs(options: UseConsoleTabsOptions) {
   async function loadFinanceLogs() {
     financeState.loading = true;
     try {
+      financeState.error = '';
       const params: Record<string, unknown> = {
         page: financeState.page,
         page_size: financeState.page_size,
@@ -244,7 +246,10 @@ export function useConsoleTabs(options: UseConsoleTabsOptions) {
       financeState.total = Number(listPayload.total || 0);
       financeState.summary = { ...financeState.summary, ...summaryPayload };
     } catch (error: unknown) {
-      MessagePlugin.error(resolveErrorMessage(error, '加载财务日志失败'));
+      financeState.list = [];
+      financeState.total = 0;
+      financeState.error = resolveErrorMessage(error, '加载财务日志失败');
+      MessagePlugin.error(financeState.error);
     } finally {
       financeState.loading = false;
     }

--- a/frontend-user-v4-console/src/layouts/setting.vue
+++ b/frontend-user-v4-console/src/layouts/setting.vue
@@ -233,7 +233,11 @@ const getThumbnailUrl = (name: string): string => {
 };
 
 watchEffect(() => {
-  if (formData.value.brandTheme) settingStore.updateConfig(formData.value);
+  // 仅设置面板打开时把表单同步到 store；面板关闭时不写 store，
+  // 避免常驻 watchEffect 在用户切换主题后把 mode 重置回表单旧值。
+  if (formData.value.brandTheme && settingStore.showSettingPanel) {
+    settingStore.updateConfig(formData.value);
+  }
 });
 </script>
 <!-- teleport导致drawer 内 scoped样式问题无法生效 先规避下 -->

--- a/frontend-user-v4-console/src/layouts/setting.vue
+++ b/frontend-user-v4-console/src/layouts/setting.vue
@@ -108,7 +108,7 @@
 import { useClipboard } from '@vueuse/core';
 import type { PopupVisibleChangeContext } from 'tdesign-vue-next';
 import { MessagePlugin } from 'tdesign-vue-next';
-import { computed, onBeforeUnmount, onMounted, ref, watchEffect } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch, watchEffect } from 'vue';
 
 import SettingAutoIcon from '@/assets/assets-setting-auto.svg';
 import SettingDarkIcon from '@/assets/assets-setting-dark.svg';
@@ -148,6 +148,24 @@ const dynamicColor = computed(() => {
 });
 const formData = ref({ ...initStyleConfig() });
 const isColoPickerDisplay = ref(false);
+
+// 打开设置抽屉前从 store 刷新表单快照：用户在个人设置等处改了主题后，
+// 若沿用初始化时的旧 formData，watchEffect 会在打开抽屉时把旧值写回 store，撤销用户的选择。
+watch(
+  () => settingStore.showSettingPanel,
+  (visible) => {
+    if (!visible) {
+      return;
+    }
+    const fresh = { ...STYLE_CONFIG } as Record<keyof typeof STYLE_CONFIG, unknown>;
+    for (const key of Object.keys(STYLE_CONFIG) as Array<keyof typeof STYLE_CONFIG>) {
+      if (settingStore[key] !== undefined) {
+        fresh[key] = settingStore[key];
+      }
+    }
+    formData.value = fresh as typeof STYLE_CONFIG;
+  },
+);
 
 const showSettingPanel = computed({
   get() {

--- a/frontend-user-v4-console/src/main.ts
+++ b/frontend-user-v4-console/src/main.ts
@@ -3,7 +3,7 @@ import { createApp } from 'vue';
 
 import App from './App.vue';
 import router from './router';
-import { store } from './store';
+import { getSettingStore, store } from './store';
 import i18n from './locales';
 import { initClientRuntimeConnectionHints } from './app/runtime/network';
 import { initClientSessionActivityTracking } from './app/runtime/session';
@@ -26,5 +26,15 @@ initClientRuntimeConnectionHints();
 app.use(store);
 app.use(router);
 app.use(i18n);
+
+// 恢复持久化的主题模式与主题色：pinia persist 已在 store 实例化时恢复 state，
+// 这里把 theme-mode / theme-color 同步到 <html>，保证刷新后仍保持暗色/主题色一致。
+const settingStore = getSettingStore();
+if (settingStore.mode) {
+  settingStore.changeMode(settingStore.mode as 'light' | 'dark' | 'auto');
+}
+if (settingStore.brandTheme) {
+  settingStore.changeBrandTheme(settingStore.brandTheme as string);
+}
 
 app.mount('#app');

--- a/frontend-user-v4-console/src/pages/client/catalog/index.vue
+++ b/frontend-user-v4-console/src/pages/client/catalog/index.vue
@@ -3,16 +3,14 @@
     <t-card class="catalog-card" :bordered="false">
       <div class="catalog-result">
         <t-empty type="maintenance" description="统一使用官网产品目录" />
-        <p>购买、报价和配置流程已经收口到 /products，客户端这里保留为稳定入口。</p>
-        <t-button theme="primary" @click="router.push('/products')">打开产品目录</t-button>
+        <p>购买、报价和配置流程已经收口到官网产品目录，客户端这里保留为稳定入口。</p>
+        <t-button theme="primary" @click="openPublicProducts">打开产品目录</t-button>
       </div>
     </t-card>
   </section>
 </template>
 <script setup lang="ts">
-import { useRouter } from 'vue-router';
-
-const router = useRouter();
+import { openPublicProducts } from '@/utils/publicSite';
 </script>
 <style scoped lang="less">
 .catalog-page {

--- a/frontend-user-v4-console/src/pages/client/checkout-resume/index.vue
+++ b/frontend-user-v4-console/src/pages/client/checkout-resume/index.vue
@@ -34,6 +34,7 @@ import { useRoute, useRouter } from 'vue-router';
 
 import clientApi from '@/api/client';
 import { formatBillingCycle } from '@/domains/finance/useRecords';
+import { openPublicProducts } from '@/utils/publicSite';
 import type { PendingWebsiteCheckout } from '@/utils/websiteCheckout';
 import {
   clearPendingWebsiteCheckout,
@@ -141,7 +142,7 @@ function resolvePendingCheckout() {
 }
 
 function openProducts() {
-  router.push('/products');
+  openPublicProducts();
 }
 
 function openInvoices() {

--- a/frontend-user-v4-console/src/pages/client/content-list/ContentListPage.vue
+++ b/frontend-user-v4-console/src/pages/client/content-list/ContentListPage.vue
@@ -2,7 +2,7 @@
   <section class="content-list-page">
     <div class="content-list-layout">
       <main class="content-main">
-        <t-card class="content-card hero-card" :bordered="false">
+        <section class="content-intro">
           <div class="hero-copy">
             <h1>{{ config.pageTitle }}</h1>
             <p>{{ config.heroDescription }}</p>
@@ -28,7 +28,7 @@
           >
             <template #suffixIcon><search-icon /></template>
           </t-input>
-        </t-card>
+        </section>
 
         <t-card class="content-card category-card" :bordered="false">
           <t-space break-line>
@@ -176,10 +176,12 @@ async function handleMarkAllRead() {
   box-shadow: var(--td-shadow-1);
 }
 
-.hero-card {
+.content-intro {
   display: flex;
   flex-direction: column;
   gap: var(--td-comp-margin-m);
+  padding: var(--td-comp-paddingTB-m) 0;
+  border-bottom: thin solid var(--td-border-color);
 }
 
 .hero-copy {
@@ -333,7 +335,6 @@ async function handleMarkAllRead() {
 }
 
 @media (width <= 48rem) {
-  .hero-card,
   .content-sidebar {
     grid-template-columns: 1fr;
   }

--- a/frontend-user-v4-console/src/pages/client/dashboard/index.vue
+++ b/frontend-user-v4-console/src/pages/client/dashboard/index.vue
@@ -911,8 +911,8 @@ onMounted(() => {
     color var(--td-anim-duration-base) var(--td-anim-time-fn-easing);
 
   &:focus-visible {
-    outline: 2px solid var(--td-brand-color);
-    outline-offset: 1px;
+    outline: 0.125rem solid var(--td-brand-color);
+    outline-offset: 0.0625rem;
   }
 }
 
@@ -1047,7 +1047,7 @@ onMounted(() => {
   width: 68%;
   min-height: 0;
   background: var(--td-brand-color);
-  border-radius: 3px 3px 0 0;
+  border-radius: 0.1875rem 0.1875rem 0 0;
 }
 
 .bar-chart__label {
@@ -1183,9 +1183,9 @@ onMounted(() => {
 }
 
 .todo-row__alert-icon {
-  margin-right: 2px;
-  font-size: 14px;
-  vertical-align: -1px;
+  margin-right: 0.125rem;
+  font-size: var(--td-font-size-body-medium);
+  vertical-align: -0.0625rem;
 }
 
 .quick-grid {

--- a/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
+++ b/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
@@ -11,7 +11,7 @@
     <div class="detail-toolbar">
       <t-button variant="outline" @click="router.push('/client/invoices')">返回列表</t-button>
       <div class="detail-toolbar__actions">
-        <t-button variant="outline" :loading="loading" @click="loadInvoice">
+        <t-button variant="outline" :loading="loading" @click="loadInvoice()">
           <template #icon><refresh-icon /></template>
           刷新
         </t-button>
@@ -149,7 +149,7 @@ import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP, PAYMENT_STATUS_MAP } from '@turai
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
 import { RefreshIcon } from 'tdesign-icons-vue-next';
 import type { PrimaryTableCol } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import clientApi from '@/api/client';
@@ -163,7 +163,7 @@ const loading = ref(false);
 const detail = ref<InvoiceRecord | null>(null);
 const activeTab = ref('basic');
 
-const invoiceId = Number(route.params.id || 0);
+const invoiceId = computed(() => Number(route.params.id || 0));
 
 function isPayable(row: InvoiceRecord | null) {
   return isPayableInvoice(row);
@@ -206,11 +206,11 @@ const paymentColumns: PrimaryTableCol[] = [
   { colKey: 'paid_at', title: '支付时间', minWidth: '12rem' },
 ];
 
-async function loadInvoice() {
-  if (!invoiceId) return;
+async function loadInvoice(id = invoiceId.value) {
+  if (!id) return;
   loading.value = true;
   try {
-    const res = await clientApi.invoiceDetail(invoiceId);
+    const res = await clientApi.invoiceDetail(id);
     detail.value = res.data || null;
   } catch {
     detail.value = null;
@@ -219,9 +219,14 @@ async function loadInvoice() {
   }
 }
 
-onMounted(() => {
-  void loadInvoice();
-});
+watch(
+  invoiceId,
+  (id) => {
+    detail.value = null;
+    if (id > 0) void loadInvoice(id);
+  },
+  { immediate: true },
+);
 </script>
 <style scoped lang="less">
 .invoice-breadcrumb {

--- a/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
+++ b/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
@@ -234,8 +234,13 @@ async function loadInvoice(id = invoiceId.value) {
 watch(
   invoiceId,
   (id) => {
+    requestSeq += 1; // 失效进行中的旧请求，避免其晚返回覆盖当前路由
     detail.value = null;
-    if (id > 0) void loadInvoice(id);
+    if (id > 0) {
+      void loadInvoice(id);
+    } else {
+      loading.value = false;
+    }
   },
   { immediate: true },
 );

--- a/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
+++ b/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
@@ -145,8 +145,8 @@
   </section>
 </template>
 <script setup lang="ts">
-import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP, PAYMENT_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
+import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP, PAYMENT_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import { RefreshIcon } from 'tdesign-icons-vue-next';
 import type { PrimaryTableCol } from 'tdesign-vue-next';
 import { computed, ref, watch } from 'vue';
@@ -206,16 +206,28 @@ const paymentColumns: PrimaryTableCol[] = [
   { colKey: 'paid_at', title: '支付时间', minWidth: '12rem' },
 ];
 
+// 并发守卫：快速切换发票详情时丢弃晚返回的旧请求结果。
+let requestSeq = 0;
+
 async function loadInvoice(id = invoiceId.value) {
   if (!id) return;
+  const seq = ++requestSeq;
   loading.value = true;
   try {
     const res = await clientApi.invoiceDetail(id);
+    if (seq !== requestSeq) {
+      return;
+    }
     detail.value = res.data || null;
   } catch {
+    if (seq !== requestSeq) {
+      return;
+    }
     detail.value = null;
   } finally {
-    loading.value = false;
+    if (seq === requestSeq) {
+      loading.value = false;
+    }
   }
 }
 

--- a/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
+++ b/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
@@ -210,11 +210,18 @@ const paymentColumns: PrimaryTableCol[] = [
 let requestSeq = 0;
 
 async function loadInvoice(id = invoiceId.value) {
-  if (!id) return;
+  const validId = Number(id);
+  if (!Number.isInteger(validId) || validId <= 0) {
+    // 无效 ID（0/负数/NaN）：失效进行中的请求并复位详情与加载态，避免调用接口。
+    requestSeq += 1;
+    detail.value = null;
+    loading.value = false;
+    return;
+  }
   const seq = ++requestSeq;
   loading.value = true;
   try {
-    const res = await clientApi.invoiceDetail(id);
+    const res = await clientApi.invoiceDetail(validId);
     if (seq !== requestSeq) {
       return;
     }

--- a/frontend-user-v4-console/src/pages/client/invoices/index.vue
+++ b/frontend-user-v4-console/src/pages/client/invoices/index.vue
@@ -45,7 +45,7 @@
     </t-card>
 
     <section class="record-list-card">
-      <data-state :loading="loading" :empty="!list.length" description="暂无账单记录">
+      <data-state :loading="loading" :empty="!list.length" :description="listError || '暂无账单记录'">
         <t-table class="record-table" row-key="id" :data="list" :columns="columns" :pagination="null" hover>
           <template #invoice="{ row }">
             <div class="stack-cell">
@@ -186,6 +186,7 @@ const router = useRouter();
 const {
   loading,
   list,
+  listError,
   total,
   filters,
   loadList,

--- a/frontend-user-v4-console/src/pages/client/order-create/index.vue
+++ b/frontend-user-v4-console/src/pages/client/order-create/index.vue
@@ -4,7 +4,7 @@
       <div class="order-create-state">
         <t-tag theme="warning" variant="light">购买链路</t-tag>
         <h1>购买入口已重定向到统一购买链路</h1>
-        <p>新的购买、登录续接与账单创建均在 /products 与 /client/checkout-resume 中完成。</p>
+        <p>新的购买、登录续接与账单创建均在官网产品目录与 /client/checkout-resume 中完成。</p>
         <div class="order-create-actions">
           <t-button theme="primary" @click="openProducts">打开购买页</t-button>
         </div>
@@ -13,12 +13,10 @@
   </section>
 </template>
 <script setup lang="ts">
-import { useRouter } from 'vue-router';
-
-const router = useRouter();
+import { openPublicProducts } from '@/utils/publicSite';
 
 function openProducts() {
-  router.push('/products');
+  openPublicProducts();
 }
 </script>
 <style scoped lang="less">

--- a/frontend-user-v4-console/src/pages/client/order-detail/index.vue
+++ b/frontend-user-v4-console/src/pages/client/order-detail/index.vue
@@ -16,9 +16,9 @@
           刷新
         </t-button>
         <t-button
-          v-if="detail && Number(detail.status) === 0"
+          v-if="canPayDetail"
           theme="primary"
-          @click="router.push(`/client/invoices/${detail.invoice?.id}/pay`)"
+          @click="goPayDetail"
         >
           去支付
         </t-button>
@@ -193,7 +193,7 @@
 import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
 import { RefreshIcon } from 'tdesign-icons-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import { formatMoney, orderProductDisplay, useOrderDetail } from '@/domains/finance/useOrders';
@@ -202,6 +202,8 @@ import { configValueLabelMap, flattenSnapshot } from '@/domains/finance/useRecor
 const route = useRoute();
 const router = useRouter();
 const activeTab = ref('basic');
+const { loading, canceling, detail, loadDetail, cancelOrder } = useOrderDetail();
+
 const showConfigTab = computed(() => {
   const type = String(detail.value?.type || '').toLowerCase();
   return ['new', 'normal'].includes(type);
@@ -215,9 +217,19 @@ const pricingSnapshotView = computed(() =>
   flattenSnapshot(detail.value?.config_pricing_snapshot as Record<string, unknown> | undefined),
 );
 
-const { loading, canceling, detail, loadDetail, cancelOrder } = useOrderDetail();
+const payableInvoiceId = computed(() => {
+  const id = Number(detail.value?.invoice?.id || detail.value?.invoice_id || 0);
+  return Number.isFinite(id) && id > 0 ? id : 0;
+});
+const canPayDetail = computed(() => Number(detail.value?.status) === 0 && payableInvoiceId.value > 0);
 
-const orderId = Number(route.params.id || 0);
+function goPayDetail() {
+  if (payableInvoiceId.value > 0) {
+    router.push(`/client/invoices/${payableInvoiceId.value}/pay`);
+  }
+}
+
+const orderId = computed(() => Number(route.params.id || 0));
 
 const BILLING_CYCLE_MAP: Record<string, string> = {
   monthly: '月付',
@@ -235,11 +247,14 @@ function billingCycleLabel(value?: string) {
   return BILLING_CYCLE_MAP[value] || value;
 }
 
-onMounted(() => {
-  if (orderId) {
-    void loadDetail(orderId);
-  }
-});
+watch(
+  orderId,
+  (id) => {
+    detail.value = null;
+    if (id > 0) void loadDetail(id);
+  },
+  { immediate: true },
+);
 </script>
 <style scoped lang="less">
 .order-breadcrumb {

--- a/frontend-user-v4-console/src/pages/client/order-detail/index.vue
+++ b/frontend-user-v4-console/src/pages/client/order-detail/index.vue
@@ -15,13 +15,7 @@
           <template #icon><refresh-icon /></template>
           刷新
         </t-button>
-        <t-button
-          v-if="canPayDetail"
-          theme="primary"
-          @click="goPayDetail"
-        >
-          去支付
-        </t-button>
+        <t-button v-if="canPayDetail" theme="primary" @click="goPayDetail"> 去支付 </t-button>
         <t-button
           v-if="detail && Number(detail.status) === 0"
           theme="danger"
@@ -190,8 +184,8 @@
   </section>
 </template>
 <script setup lang="ts">
-import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
+import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import { RefreshIcon } from 'tdesign-icons-vue-next';
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
@@ -202,7 +196,7 @@ import { configValueLabelMap, flattenSnapshot } from '@/domains/finance/useRecor
 const route = useRoute();
 const router = useRouter();
 const activeTab = ref('basic');
-const { loading, canceling, detail, loadDetail, cancelOrder } = useOrderDetail();
+const { loading, canceling, detail, loadDetail, invalidateDetail, cancelOrder } = useOrderDetail();
 
 const showConfigTab = computed(() => {
   const type = String(detail.value?.type || '').toLowerCase();
@@ -250,8 +244,11 @@ function billingCycleLabel(value?: string) {
 watch(
   orderId,
   (id) => {
-    detail.value = null;
-    if (id > 0) void loadDetail(id);
+    if (id > 0) {
+      void loadDetail(id);
+    } else {
+      invalidateDetail(); // 失效进行中的旧请求并将详情/加载态复位
+    }
   },
   { immediate: true },
 );

--- a/frontend-user-v4-console/src/pages/client/orders/index.vue
+++ b/frontend-user-v4-console/src/pages/client/orders/index.vue
@@ -39,7 +39,7 @@
     </t-card>
 
     <section class="record-list-card">
-      <data-state :loading="loading" :empty="!list.length" description="暂无订单记录">
+      <data-state :loading="loading" :empty="!list.length" :description="listError || '暂无订单记录'">
         <t-table class="record-table" row-key="id" :data="list" :columns="columns" :pagination="null" hover>
           <template #order="{ row }">
             <div class="stack-cell">
@@ -80,11 +80,11 @@
                 详情
               </t-button>
               <t-button
-                v-if="Number(row.status) === 0"
+                v-if="canPayOrder(row)"
                 size="small"
                 theme="primary"
                 variant="outline"
-                @click="router.push(`/client/invoices/${row.invoice?.id}/pay`)"
+                @click="goPayOrder(row)"
               >
                 去支付
               </t-button>
@@ -132,11 +132,11 @@
                 详情
               </t-button>
               <t-button
-                v-if="Number(row.status) === 0"
+                v-if="canPayOrder(row)"
                 size="small"
                 theme="primary"
                 variant="outline"
-                @click.stop="router.push(`/client/invoices/${row.invoice?.id}/pay`)"
+                @click.stop="goPayOrder(row)"
               >
                 去支付
               </t-button>
@@ -191,6 +191,7 @@ const {
   loading,
   canceling,
   list,
+  listError,
   total,
   filters,
   loadList,
@@ -199,6 +200,22 @@ const {
   applyQuickFilter,
   cancelOrder,
 } = useOrderList();
+
+function invoicePayId(row: { invoice?: { id?: number | string | null } | null; invoice_id?: number | string | null }) {
+  const id = Number(row.invoice?.id || row.invoice_id || 0);
+  return Number.isFinite(id) && id > 0 ? id : 0;
+}
+
+function canPayOrder(row: { status?: number | string; invoice?: { id?: number | string | null } | null; invoice_id?: number | string | null }) {
+  return Number(row.status) === 0 && invoicePayId(row) > 0;
+}
+
+function goPayOrder(row: { invoice?: { id?: number | string | null } | null; invoice_id?: number | string | null }) {
+  const id = invoicePayId(row);
+  if (id > 0) {
+    router.push(`/client/invoices/${id}/pay`);
+  }
+}
 
 const quickFilters = [
   { key: '', label: '全部' },

--- a/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
+++ b/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
@@ -11,7 +11,7 @@
     <div class="detail-toolbar">
       <t-button variant="outline" @click="router.push('/client/payments')">返回列表</t-button>
       <div class="detail-toolbar__actions">
-        <t-button variant="outline" :loading="loading" @click="loadPayment">
+        <t-button variant="outline" :loading="loading" @click="loadPayment()">
           <template #icon><refresh-icon /></template>
           刷新
         </t-button>
@@ -96,7 +96,7 @@
 import { INVOICE_STATUS_MAP, PAYMENT_STATUS_MAP } from '@shared/statusConfig';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
 import { RefreshIcon } from 'tdesign-icons-vue-next';
-import { onMounted, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import clientApi from '@/api/client';
@@ -108,13 +108,13 @@ const router = useRouter();
 const loading = ref(false);
 const detail = ref<PaymentRecord | null>(null);
 
-const paymentId = Number(route.params.id || 0);
+const paymentId = computed(() => Number(route.params.id || 0));
 
-async function loadPayment() {
-  if (!paymentId) return;
+async function loadPayment(id = paymentId.value) {
+  if (!id) return;
   loading.value = true;
   try {
-    const res = await clientApi.paymentDetail(paymentId);
+    const res = await clientApi.paymentDetail(id);
     detail.value = res.data || null;
   } catch {
     detail.value = null;
@@ -123,9 +123,14 @@ async function loadPayment() {
   }
 }
 
-onMounted(() => {
-  void loadPayment();
-});
+watch(
+  paymentId,
+  (id) => {
+    detail.value = null;
+    if (id > 0) void loadPayment(id);
+  },
+  { immediate: true },
+);
 </script>
 <style scoped lang="less">
 .payment-breadcrumb {

--- a/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
+++ b/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
@@ -114,11 +114,18 @@ const paymentId = computed(() => Number(route.params.id || 0));
 let requestSeq = 0;
 
 async function loadPayment(id = paymentId.value) {
-  if (!id) return;
+  const validId = Number(id);
+  if (!Number.isInteger(validId) || validId <= 0) {
+    // 无效 ID（0/负数/NaN）：失效进行中的请求并复位详情与加载态，避免调用接口。
+    requestSeq += 1;
+    detail.value = null;
+    loading.value = false;
+    return;
+  }
   const seq = ++requestSeq;
   loading.value = true;
   try {
-    const res = await clientApi.paymentDetail(id);
+    const res = await clientApi.paymentDetail(validId);
     if (seq !== requestSeq) {
       return;
     }

--- a/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
+++ b/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
@@ -110,16 +110,28 @@ const detail = ref<PaymentRecord | null>(null);
 
 const paymentId = computed(() => Number(route.params.id || 0));
 
+// 并发守卫：快速切换支付详情时丢弃晚返回的旧请求结果。
+let requestSeq = 0;
+
 async function loadPayment(id = paymentId.value) {
   if (!id) return;
+  const seq = ++requestSeq;
   loading.value = true;
   try {
     const res = await clientApi.paymentDetail(id);
+    if (seq !== requestSeq) {
+      return;
+    }
     detail.value = res.data || null;
   } catch {
+    if (seq !== requestSeq) {
+      return;
+    }
     detail.value = null;
   } finally {
-    loading.value = false;
+    if (seq === requestSeq) {
+      loading.value = false;
+    }
   }
 }
 

--- a/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
+++ b/frontend-user-v4-console/src/pages/client/payment-detail/index.vue
@@ -138,8 +138,13 @@ async function loadPayment(id = paymentId.value) {
 watch(
   paymentId,
   (id) => {
+    requestSeq += 1; // 失效进行中的旧请求，避免其晚返回覆盖当前路由
     detail.value = null;
-    if (id > 0) void loadPayment(id);
+    if (id > 0) {
+      void loadPayment(id);
+    } else {
+      loading.value = false;
+    }
   },
   { immediate: true },
 );

--- a/frontend-user-v4-console/src/pages/client/profile/index.vue
+++ b/frontend-user-v4-console/src/pages/client/profile/index.vue
@@ -24,6 +24,7 @@
           <t-menu-item value="profile">个人资料</t-menu-item>
           <t-menu-item value="security">账户安全</t-menu-item>
           <t-menu-item value="notification">消息提醒</t-menu-item>
+          <t-menu-item value="display">显示设置</t-menu-item>
         </t-menu>
       </t-card>
     </aside>
@@ -75,7 +76,7 @@
         </div>
       </t-card>
 
-      <t-card v-else class="profile-card" :bordered="false">
+      <t-card v-else-if="activeTab === 'notification'" class="profile-card" :bordered="false">
         <template #title>消息提醒</template>
         <template #actions
           ><t-tag variant="light">已开启 {{ enabledNotificationCount }}</t-tag></template
@@ -94,6 +95,22 @@
           <t-button theme="primary" :loading="notificationLoading" @click="saveNotificationPreferences"
             >保存设置</t-button
           >
+        </div>
+      </t-card>
+
+      <t-card v-else class="profile-card" :bordered="false">
+        <template #title>显示设置</template>
+        <template #actions><t-tag variant="light">主题外观</t-tag></template>
+        <div class="display-options">
+          <div class="display-option-head">
+            <strong>主题模式</strong>
+            <p>选择明亮、深色或跟随系统的外观主题；选择会保存在本机。</p>
+          </div>
+          <t-radio-group v-model="themeMode" variant="default-filled" @change="handleThemeModeChange">
+            <t-radio-button value="light">明亮</t-radio-button>
+            <t-radio-button value="dark">深色</t-radio-button>
+            <t-radio-button value="auto">跟随系统</t-radio-button>
+          </t-radio-group>
         </div>
       </t-card>
     </main>
@@ -185,13 +202,30 @@
 </template>
 <script setup lang="ts">
 import { CopyIcon } from 'tdesign-icons-vue-next';
+import { ref } from 'vue';
 
 import { useProfile } from '@/domains/account/useProfile';
+import { getSettingStore, useSettingStore } from '@/store';
+
+const settingStore = useSettingStore();
+const themeMode = ref<'light' | 'dark' | 'auto'>(
+  settingStore.mode === 'auto' ? 'auto' : (settingStore.mode as 'light' | 'dark') || 'light',
+);
+
+const handleThemeModeChange = (mode: unknown) => {
+  const next = (mode === 'auto' ? 'auto' : mode === 'dark' ? 'dark' : 'light') as 'light' | 'dark' | 'auto';
+  const s = getSettingStore();
+  if (s.mode !== next) {
+    s.mode = next;
+  }
+  s.changeMode(next);
+};
 
 const profileTabs = [
   { value: 'profile', label: '个人资料' },
   { value: 'security', label: '账户安全' },
   { value: 'notification', label: '消息提醒' },
+  { value: 'display', label: '显示设置' },
 ] as const;
 
 const {
@@ -306,6 +340,26 @@ const {
 
 .profile-tabs-mobile {
   display: none;
+}
+
+.display-options {
+  max-width: 46rem;
+
+  .display-option-head {
+    margin-bottom: var(--td-comp-margin-m);
+
+    strong {
+      color: var(--td-text-color-primary);
+      font: var(--td-font-title-small);
+    }
+
+    p {
+      margin: var(--td-comp-margin-xs) 0 0;
+      color: var(--td-text-color-secondary);
+      font-size: 0.8125rem;
+      line-height: 1.6;
+    }
+  }
 }
 
 .profile-footer {

--- a/frontend-user-v4-console/src/pages/client/profile/index.vue
+++ b/frontend-user-v4-console/src/pages/client/profile/index.vue
@@ -98,7 +98,7 @@
         </div>
       </t-card>
 
-      <t-card v-else class="profile-card" :bordered="false">
+      <t-card v-else-if="activeTab === 'display'" class="profile-card" :bordered="false">
         <template #title>显示设置</template>
         <template #actions><t-tag variant="light">主题外观</t-tag></template>
         <div class="display-options">

--- a/frontend-user-v4-console/src/pages/client/service-console/components/tabs/FinanceTab.vue
+++ b/frontend-user-v4-console/src/pages/client/service-console/components/tabs/FinanceTab.vue
@@ -10,7 +10,12 @@
         <span>支出 ¥{{ formatMoney(financeState.summary.total_out || 0) }}</span>
         <span>退款 ¥{{ formatMoney(financeState.summary.refund_in || 0) }}</span>
       </div>
-      <t-table
+      <data-state
+        :loading="financeState.loading"
+        :empty="!financeState.list.length"
+        :description="financeState.error || '暂无财务记录'"
+      >
+        <t-table
         row-key="id"
         :data="financeState.list"
         :columns="financeColumns"
@@ -47,20 +52,22 @@
           {{ row.invoice?.invoice_no || '--' }}
         </template>
       </t-table>
-      <div v-if="financeState.total > 0" class="console-pagination">
-        <t-pagination
-          v-model="financeState.page"
-          v-model:page-size="financeState.page_size"
-          :total="financeState.total"
-          :page-size-options="[10, 20, 50]"
-          show-total
-          @change="loadFinanceLogs"
-        />
-      </div>
+        <div v-if="financeState.total > 0" class="console-pagination">
+          <t-pagination
+            v-model="financeState.page"
+            v-model:page-size="financeState.page_size"
+            :total="financeState.total"
+            :page-size-options="[10, 20, 50]"
+            show-total
+            @change="loadFinanceLogs"
+          />
+        </div>
+      </data-state>
     </t-card>
   </section>
 </template>
 <script setup lang="ts">
+import DataState from '@shared/user-v3/components/DataState.vue';
 import {
   financeColumns,
   resolveFinanceBusinessLabel,

--- a/frontend-user-v4-console/src/pages/client/services/index.vue
+++ b/frontend-user-v4-console/src/pages/client/services/index.vue
@@ -242,7 +242,7 @@
       </data-state>
 
       <div v-if="!loading && !list.length" class="service-empty-action">
-        <t-button theme="primary" @click="router.push('/products')">去选购产品</t-button>
+        <t-button theme="primary" @click="openPublicProducts">去选购产品</t-button>
       </div>
     </section>
 
@@ -341,6 +341,7 @@ import { CatalogIcon, DashboardIcon, EditIcon, SearchIcon } from 'tdesign-icons-
 import type { PrimaryTableCol } from 'tdesign-vue-next';
 import { shallowRef, triggerRef } from 'vue';
 
+import { openPublicProducts } from '@/utils/publicSite';
 import {
   findListSpecValue,
   formatMoney,

--- a/frontend-user-v4-console/src/store/modules/setting.ts
+++ b/frontend-user-v4-console/src/store/modules/setting.ts
@@ -63,6 +63,12 @@ export const useSettingStore = defineStore('setting', {
       document.documentElement.setAttribute('theme-mode', isDarkMode ? 'dark' : '');
 
       this.chartColors = isDarkMode ? DARK_CHART_COLORS : LIGHT_CHART_COLORS;
+
+      // 模式/跟随系统变化后重放品牌主题色：品牌色阶分浅/深两套动态样式且仅按 displayMode 插入，
+      // 若不重放，切换模式后品牌色（--td-brand-color-N）会残留旧模式的样式。
+      if (this.brandTheme) {
+        this.changeBrandTheme(this.brandTheme as string);
+      }
     },
     async changeSideMode(mode: ModeType) {
       const isDarkMode = mode === 'dark';

--- a/frontend-user-v4-console/src/store/modules/setting.ts
+++ b/frontend-user-v4-console/src/store/modules/setting.ts
@@ -35,8 +35,15 @@ export const useSettingStore = defineStore('setting', {
       }
       return state.mode as ModeType;
     },
-    displaySideMode: (state): ModeType => {
-      return state.sideMode as ModeType;
+    displaySideMode(state: TState): ModeType {
+      // 侧边栏跟随主主题模式：浅色主题 → 浅色侧边栏；深色主题 → 深色侧边栏。
+      // 若 sideMode 被显式配置为深色，则侧边栏独立使用深色（保留独立配色能力）。
+      const explicitSideMode = state.sideMode as ModeType;
+      if (explicitSideMode === 'dark') {
+        return 'dark';
+      }
+      // displayMode 是 getter 而非 state 字段，必须通过 this 访问。
+      return this.displayMode;
     },
   },
   actions: {
@@ -45,7 +52,12 @@ export const useSettingStore = defineStore('setting', {
 
       if (mode === 'auto') {
         theme = this.getMediaColor();
+        // auto 模式：监听系统主题变化，切回其他模式时移除监听。
+        watchSystemTheme();
+      } else {
+        unwatchSystemTheme();
       }
+
       const isDarkMode = theme === 'dark';
 
       document.documentElement.setAttribute('theme-mode', isDarkMode ? 'dark' : '');
@@ -108,4 +120,42 @@ export const useSettingStore = defineStore('setting', {
 
 export function getSettingStore() {
   return useSettingStore(store);
+}
+
+// auto 模式系统主题监听：模块级变量，不参与持久化。
+let systemThemeMedia: MediaQueryList | null = null;
+let systemThemeHandler: ((event: MediaQueryListEvent) => void) | null = null;
+
+function watchSystemTheme(): void {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return;
+  }
+  if (systemThemeMedia && systemThemeHandler) {
+    return; // 已监听，避免重复挂载
+  }
+  systemThemeMedia = window.matchMedia('(prefers-color-scheme:dark)');
+  systemThemeHandler = () => {
+    // 仅当仍处于 auto 模式时跟随系统主题变化。
+    if (getSettingStore().mode === 'auto') {
+      getSettingStore().changeMode('auto');
+    }
+  };
+  if (typeof systemThemeMedia.addEventListener === 'function') {
+    systemThemeMedia.addEventListener('change', systemThemeHandler);
+  } else {
+    // 旧浏览器兼容
+    systemThemeMedia.addListener(systemThemeHandler);
+  }
+}
+
+function unwatchSystemTheme(): void {
+  if (systemThemeMedia && systemThemeHandler) {
+    if (typeof systemThemeMedia.removeEventListener === 'function') {
+      systemThemeMedia.removeEventListener('change', systemThemeHandler);
+    } else {
+      systemThemeMedia.removeListener(systemThemeHandler);
+    }
+    systemThemeMedia = null;
+    systemThemeHandler = null;
+  }
 }

--- a/frontend-user-v4-console/src/utils/publicSite.ts
+++ b/frontend-user-v4-console/src/utils/publicSite.ts
@@ -1,0 +1,32 @@
+function resolvePublicSiteOrigin() {
+  const configuredOrigin = String(import.meta.env.VITE_PUBLIC_SITE_URL || '').trim().replace(/\/+$/, '');
+  if (configuredOrigin) return configuredOrigin;
+
+  if (typeof window === 'undefined') return '';
+
+  const { protocol, hostname, port } = window.location;
+  if (hostname.startsWith('console.')) {
+    return `${protocol}//www.${hostname.slice('console.'.length)}${port ? `:${port}` : ''}`;
+  }
+
+  if (hostname === '127.0.0.1' || hostname === 'localhost') {
+    const publicSitePort = String(import.meta.env.VITE_WWW_DEV_PORT || '5175').trim();
+    return `${protocol}//${hostname}${publicSitePort ? `:${publicSitePort}` : ''}`;
+  }
+
+  return '';
+}
+
+export function buildPublicSiteUrl(path = '/products') {
+  const normalizedPath = String(path || '/products').startsWith('/') ? String(path || '/products') : `/${path}`;
+  const origin = resolvePublicSiteOrigin();
+  return origin ? `${origin}${normalizedPath}` : normalizedPath;
+}
+
+export function openPublicProducts() {
+  const target = buildPublicSiteUrl('/products');
+  if (typeof window !== 'undefined') {
+    window.location.assign(target);
+  }
+  return target;
+}

--- a/theme.css
+++ b/theme.css
@@ -216,6 +216,12 @@
   --td-scrollbar-color: rgba(255, 255, 255, 0.1);
   --td-scrollbar-hover-color: rgba(255, 255, 255, 0.3);
   --td-scroll-track-color: #333;
+  /* 暗色下 -light 系列用「品牌主色半透明」叠深色容器，避免继承浅色设定的亮底导致卡片 hover 泛白；
+     dark 模式品牌色阶会被 insertThemeStylesheet 反转（-1/-2 为亮色），故不能引用 -color-N，必须脱离色阶 */
+  --td-brand-color-light: color-mix(in srgb, var(--td-brand-color) 24%, transparent);
+  --td-warning-color-light: color-mix(in srgb, var(--td-warning-color) 24%, transparent);
+  --td-error-color-light: color-mix(in srgb, var(--td-error-color) 24%, transparent);
+  --td-success-color-light: color-mix(in srgb, var(--td-success-color) 24%, transparent);
 }
 
 :root {

--- a/theme.css
+++ b/theme.css
@@ -266,7 +266,7 @@
 #app .t-default-menu .t-menu__item .t-icon,
 #app .t-default-menu .t-submenu__title .t-icon {
   flex-shrink: 0;
-  color: currentColor;
+  color: currentcolor;
 }
 
 #app *,
@@ -317,7 +317,7 @@
   width: 1em;
   height: 1em;
   box-sizing: border-box;
-  border: 2px solid currentColor;
+  border: 2px solid currentcolor;
   border-top-color: transparent;
   border-radius: 50% !important;
   animation: tura-button-loading-spin 0.8s linear infinite;
@@ -548,7 +548,7 @@
   height: 4px;
   margin-top: -2px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
 }
 
 /* 二级终端菜单选中：灰色背景（排除子菜单父级） */


### PR DESCRIPTION
包含以下 7 个提交：

## 新增
- **smapi 聚合实名认证插件**（适配当前插件体系，含测试）
- 用户控制台**暗色模式**（明亮/深色/跟随系统，入口迁移至个人设置→显示设置）
- 站点设置新增**邮件/短信通知总开关**

## 修复
- ZJMF 批量对接上游商品支持**点击商品卡片**切换选中
- 暗色模式下品牌色 -light 的卡片 hover 不再泛白
- CodeRabbit 审查意见：商品彻底删除事务、上游 WAF 重试防重放、价格换算分单位等

## 重构
- 通知模板默认种子纳入 SettingsSeeder，修复部署后模板缺失
- 运维部署文档补充说明