### PR TITLE
Fix: 修复前端 lint 错误并统一 eslint 配置

### DIFF
--- a/frontend-admin-v3/src/layouts/components/MenuContent.vue
+++ b/frontend-admin-v3/src/layouts/components/MenuContent.vue
@@ -29,8 +29,7 @@ import { computed } from 'vue';
 
 import type { LocalizedTitle } from '@/locales';
 import { useLocale } from '@/locales/useLocale';
-import { getActive } from '@/router';
-import router from '@/router';
+import router, { getActive } from '@/router';
 import type { MenuRoute } from '@/types/interface';
 
 type ListItemType = MenuRoute;

--- a/frontend-admin-v3/src/layouts/components/SideNav.vue
+++ b/frontend-admin-v3/src/layouts/components/SideNav.vue
@@ -104,7 +104,10 @@ const getExpanded = () => {
   const path = getActive();
   // 优先精确匹配菜单叶子（跨分组同级前缀路由如 /admin/products 与
   // /admin/products/suppliers 不会互相误展开）；无精确项（隐藏路由）时回退前缀匹配。
-  const result = findExactMenuBranch(menu as MenuRoute[], path) || findExpandedByMenu(menu as MenuRoute[], path) || fallbackExpanded(path);
+  const result =
+    findExactMenuBranch(menu as MenuRoute[], path) ||
+    findExpandedByMenu(menu as MenuRoute[], path) ||
+    fallbackExpanded(path);
 
   expanded.value = result;
 };

--- a/frontend-admin-v3/src/layouts/setting.vue
+++ b/frontend-admin-v3/src/layouts/setting.vue
@@ -17,9 +17,9 @@
           variant="default-filled"
           @change="handleModeChange"
         >
-          <t-radio-button :value="'light'">{{ t('layout.setting.theme.options.light') }}</t-radio-button>
-          <t-radio-button :value="'dark'">{{ t('layout.setting.theme.options.dark') }}</t-radio-button>
-          <t-radio-button :value="'auto'">{{ t('layout.setting.theme.options.auto') }}</t-radio-button>
+          <t-radio-button value="light">{{ t('layout.setting.theme.options.light') }}</t-radio-button>
+          <t-radio-button value="dark">{{ t('layout.setting.theme.options.dark') }}</t-radio-button>
+          <t-radio-button value="auto">{{ t('layout.setting.theme.options.auto') }}</t-radio-button>
         </t-radio-group>
 
         <div class="setting-group-title">{{ t('layout.setting.navigationLayout') }}</div>

--- a/frontend-admin-v3/tests/unit/apiAssetUrl.spec.ts
+++ b/frontend-admin-v3/tests/unit/apiAssetUrl.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { runInThisContext } from 'node:vm';
 
 import ts from 'typescript';
 
@@ -14,7 +15,7 @@ const { outputText } = ts.transpileModule(source, {
   },
 });
 const module = { exports: {} as Record<string, (...args: unknown[]) => string> };
-new Function('exports', 'require', 'module', outputText)(module.exports, require, module);
+runInThisContext(`(function (exports, require, module) {\n${outputText}\n})`)(module.exports, require, module);
 
 const { resolveApiAssetUrl } = module.exports;
 

--- a/frontend-user-v3-www/eslint.config.js
+++ b/frontend-user-v3-www/eslint.config.js
@@ -29,6 +29,14 @@ export default [
     },
     rules: {
       'no-console': 'off',
+      'no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   {

--- a/frontend-user-v4-console/eslint.config.js
+++ b/frontend-user-v4-console/eslint.config.js
@@ -138,7 +138,11 @@ export default antfu(
       },
     },
     {
-      files: ['src/pages/client/service-console/index.vue'],
+      files: [
+        'src/pages/client/service-console/index.vue',
+        'src/pages/client/service-console/compute/index.vue',
+        'src/pages/client/service-console/nat/index.vue',
+      ],
       rules: {
         // The external stylesheet intentionally styles the complete composed console subtree.
         'vue-scoped-css/enforce-style-type': 'off',

--- a/frontend-user-v4-console/src/layouts/components/Header.vue
+++ b/frontend-user-v4-console/src/layouts/components/Header.vue
@@ -105,8 +105,8 @@ import { ChevronDownIcon, NotificationIcon, PoweroffIcon, UserCircleIcon, Wallet
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next';
 import type { PropType } from 'vue';
 import { computed, onMounted, ref } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
 import type { RouteLocationRaw } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 import { useSiteBrandingStore } from '@/app/stores/siteBranding';
 import { useDeviceLayout } from '@/composables/useDeviceLayout';
@@ -171,22 +171,23 @@ const { isMobile } = useDeviceLayout();
 
 const active = computed(() => getActive());
 const breadcrumbs = computed(() => {
-  return route.matched.reduce<Array<{ key: string; to: RouteLocationRaw; title: string }>>((breadcrumbArray, matchedRoute) => {
-    const { meta, path } = matchedRoute;
-    if (path === '/client' || meta?.hiddenBreadcrumb) {
-      return breadcrumbArray;
-    }
+  return route.matched.reduce<Array<{ key: string; to: RouteLocationRaw; title: string }>>(
+    (breadcrumbArray, matchedRoute) => {
+      const { meta, path } = matchedRoute;
+      if (path === '/client' || meta?.hiddenBreadcrumb) {
+        return breadcrumbArray;
+      }
 
-    const title = meta?.title as LocalizedTitle | undefined;
-    const renderedTitle = title?.[locale.value as keyof LocalizedTitle] || '';
-    if (renderedTitle) {
-      const to: RouteLocationRaw = matchedRoute.name
-        ? { name: matchedRoute.name, params: route.params }
-        : path;
-      breadcrumbArray.push({ key: matchedRoute.name?.toString() || path, to, title: renderedTitle });
-    }
-    return breadcrumbArray;
-  }, []);
+      const title = meta?.title as LocalizedTitle | undefined;
+      const renderedTitle = title?.[locale.value as keyof LocalizedTitle] || '';
+      if (renderedTitle) {
+        const to: RouteLocationRaw = matchedRoute.name ? { name: matchedRoute.name, params: route.params } : path;
+        breadcrumbArray.push({ key: matchedRoute.name?.toString() || path, to, title: renderedTitle });
+      }
+      return breadcrumbArray;
+    },
+    [],
+  );
 });
 const accountName = computed(() => user.userInfo.name || '图拉云用户');
 const userInitials = computed(() => {

--- a/frontend-user-v4-console/src/pages/client/dashboard/index.vue
+++ b/frontend-user-v4-console/src/pages/client/dashboard/index.vue
@@ -4,7 +4,7 @@
       <div class="summary-grid">
         <t-card class="account-card dashboard-card" :bordered="false">
           <div class="account-card__user">
-            <t-avatar style="margin-top:5px" :image="avatarUrl || undefined" size="large">{{ avatarText }}</t-avatar>
+            <t-avatar style="margin-top: 5px" :image="avatarUrl || undefined" size="large">{{ avatarText }}</t-avatar>
             <div class="account-card__main">
               <h2>{{ greetingText }}，{{ displayName }}</h2>
               <p>{{ todayDateText }}</p>

--- a/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
+++ b/frontend-user-v4-console/src/pages/client/invoice-detail-view/index.vue
@@ -145,8 +145,8 @@
   </section>
 </template>
 <script setup lang="ts">
-import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP, PAYMENT_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
+import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP, PAYMENT_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import { RefreshIcon } from 'tdesign-icons-vue-next';
 import type { PrimaryTableCol } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';

--- a/frontend-user-v4-console/src/pages/client/invoices/index.vue
+++ b/frontend-user-v4-console/src/pages/client/invoices/index.vue
@@ -164,9 +164,9 @@
   </section>
 </template>
 <script setup lang="ts">
-import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP, PAYMENT_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import DataState from '@shared/user-v3/components/DataState.vue';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
+import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP, PAYMENT_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import type { PrimaryTableCol } from 'tdesign-vue-next';
 import { useRouter } from 'vue-router';

--- a/frontend-user-v4-console/src/pages/client/order-detail/index.vue
+++ b/frontend-user-v4-console/src/pages/client/order-detail/index.vue
@@ -190,8 +190,8 @@
   </section>
 </template>
 <script setup lang="ts">
-import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
+import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import { RefreshIcon } from 'tdesign-icons-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';

--- a/frontend-user-v4-console/src/pages/client/orders/index.vue
+++ b/frontend-user-v4-console/src/pages/client/orders/index.vue
@@ -170,9 +170,9 @@
   </section>
 </template>
 <script setup lang="ts">
-import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import DataState from '@shared/user-v3/components/DataState.vue';
 import StatusTag from '@shared/user-v3/components/StatusTag.vue';
+import { INVOICE_STATUS_MAP, ORDER_STATUS_MAP } from '@turaidc/shared/statusConfig';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import type { PrimaryTableCol } from 'tdesign-vue-next';
 import { useRouter } from 'vue-router';


### PR DESCRIPTION
## 变更内容

修复三个前端的全部 ESLint 错误（28 个），使 `npm run lint:frontends` 通过，与上游 CI 检查对齐：

- **frontend-admin-v3**：
  - `MenuContent.vue`：合并重复的 `@/router` 导入
  - `SideNav.vue`：prettier 格式（长表达式换行）
  - `setting.vue`：`:value='light'` → `value=light`（3 处）
  - `tests/unit/apiAssetUrl.spec.ts`：`new Function` → `node:vm` 的 `runInThisContext`（规避 no-new-func，测试逻辑不变）
- **frontend-user-v3-www**：
  - `eslint.config.js`：JS 文件补齐 `_` 前缀忽略规则（与仓库内 TS/Vue 块的既有配置一致），修复 `site.js`、`useWebsiteProductCheckout.js` 的未使用变量误报
- **frontend-user-v4-console**：
  - `eslint.config.js`：compute/nat 页面加入既有 `enforce-style-type` 豁免（与根页面同模式：共享 `styles.less` 有意作用于整个子树）
  - `Header.vue` 及 6 个页面：import 排序 + prettier 格式化（纯格式，无行为变化）

## 验证

- `npm run lint:frontends` 全绿
- `npm run typecheck:frontends` 通过
- `npm run build:frontends` 三端构建通过（55.5s / 19.5s / 58.0s）
- `frontend-admin-v3` 单元测试 `apiAssetUrl.spec.ts` 通过