### PR TITLE
Feat: 完善系统级插件测试流程

### DIFF
--- a/backend/app/Http/Controllers/Client/V2/AuthController.php
+++ b/backend/app/Http/Controllers/Client/V2/AuthController.php
@@ -175,15 +175,17 @@ class AuthController extends Controller
 
     public function captchaScript()
     {
+        $status = 200;
         try {
             $scriptContent = $this->geeTestService->getScriptContent();
         } catch (\Throwable $exception) {
             report($exception);
 
             $scriptContent = $this->geeTestService->getFallbackScriptContent();
+            $status = 503;
         }
 
-        return response($scriptContent, 200, [
+        return response($scriptContent, $status, [
             'Content-Type' => 'application/javascript; charset=UTF-8',
             'Cache-Control' => 'public, max-age=43200',
         ]);

--- a/backend/app/Http/Controllers/Client/V2/VerificationController.php
+++ b/backend/app/Http/Controllers/Client/V2/VerificationController.php
@@ -158,11 +158,20 @@ class VerificationController extends Controller
     }
 
     /**
-     * 认证完成回跳页
+     * 认证完成回跳/服务端回调。
+     *
+     * certify_id/order_no 用于回跳型驱动；task.task_no、task.merchant_extra 用于
+     * 服务端回调型驱动（如 leaf 平台按任务号通知终态）。
      */
     public function callback(Request $request)
     {
-        $certifyId = (string) $request->input('certify_id', $request->input('order_no', ''));
+        $certifyId = (string) $request->input(
+            'certify_id',
+            $request->input(
+                'order_no',
+                $request->input('task.task_no', $request->input('task.merchant_extra', ''))
+            )
+        );
 
         if ($certifyId === '') {
             return $this->success([

--- a/backend/app/Http/Requests/Admin/V2/IntegrationPlugin/RunIntegrationPluginTaskRequest.php
+++ b/backend/app/Http/Requests/Admin/V2/IntegrationPlugin/RunIntegrationPluginTaskRequest.php
@@ -15,21 +15,23 @@ class RunIntegrationPluginTaskRequest extends AdminFormRequest
 
     public const TYPE_TEST_SMS = 'test_sms';
 
+    public const TYPE_TEST_VERIFICATION = 'test_verification';
+
+    public const TYPE_TEST_PAYMENT = 'test_payment';
+
+    public const TYPE_TEST_CAPTCHA = 'test_captcha';
+
+    public const TYPE_TEST_CONNECTION = 'test_connection';
+
     protected function prepareForValidation(): void
     {
         $payload = $this->input('payload', []);
         $payload = is_array($payload) ? $payload : [];
 
-        if (array_key_exists('to', $payload)) {
-            $payload['to'] = trim((string) $payload['to']);
-        }
-
-        if (array_key_exists('subject', $payload)) {
-            $payload['subject'] = trim((string) $payload['subject']);
-        }
-
-        if (array_key_exists('phone', $payload)) {
-            $payload['phone'] = trim((string) $payload['phone']);
+        foreach (['to', 'subject', 'phone', 'real_name', 'card_no', 'lot_number', 'captcha_output', 'pass_token', 'gen_time'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $payload[$field] = trim((string) $payload[$field]);
+            }
         }
 
         $this->merge([
@@ -47,6 +49,10 @@ class RunIntegrationPluginTaskRequest extends AdminFormRequest
                 self::TYPE_HEALTH_CHECK,
                 self::TYPE_TEST_EMAIL,
                 self::TYPE_TEST_SMS,
+                self::TYPE_TEST_VERIFICATION,
+                self::TYPE_TEST_PAYMENT,
+                self::TYPE_TEST_CAPTCHA,
+                self::TYPE_TEST_CONNECTION,
             ])],
             'payload' => ['nullable', 'array'],
             'payload.account_index' => [
@@ -69,6 +75,36 @@ class RunIntegrationPluginTaskRequest extends AdminFormRequest
                 Rule::requiredIf($type === self::TYPE_TEST_SMS),
                 'string',
                 'max:20',
+            ],
+            'payload.real_name' => [
+                Rule::requiredIf($type === self::TYPE_TEST_VERIFICATION),
+                'string',
+                'max:64',
+            ],
+            'payload.card_no' => [
+                Rule::requiredIf($type === self::TYPE_TEST_VERIFICATION),
+                'string',
+                'max:32',
+            ],
+            'payload.lot_number' => [
+                Rule::requiredIf($type === self::TYPE_TEST_CAPTCHA),
+                'string',
+                'max:128',
+            ],
+            'payload.captcha_output' => [
+                Rule::requiredIf($type === self::TYPE_TEST_CAPTCHA),
+                'string',
+                'max:512',
+            ],
+            'payload.pass_token' => [
+                Rule::requiredIf($type === self::TYPE_TEST_CAPTCHA),
+                'string',
+                'max:512',
+            ],
+            'payload.gen_time' => [
+                Rule::requiredIf($type === self::TYPE_TEST_CAPTCHA),
+                'string',
+                'max:32',
             ],
             'page' => ['prohibited'],
             'page_size' => ['prohibited'],

--- a/backend/app/Services/Admin/V2/AdminConfigurationV2QueryService.php
+++ b/backend/app/Services/Admin/V2/AdminConfigurationV2QueryService.php
@@ -163,6 +163,10 @@ class AdminConfigurationV2QueryService
             RunIntegrationPluginTaskRequest::TYPE_HEALTH_CHECK => $this->pluginService->healthCheck($plugin),
             RunIntegrationPluginTaskRequest::TYPE_TEST_EMAIL => $this->pluginService->testEmail($plugin, $payload),
             RunIntegrationPluginTaskRequest::TYPE_TEST_SMS => $this->pluginService->testSms($plugin, $payload),
+            RunIntegrationPluginTaskRequest::TYPE_TEST_VERIFICATION => $this->pluginService->testVerification($plugin, $payload),
+            RunIntegrationPluginTaskRequest::TYPE_TEST_PAYMENT => $this->pluginService->testPayment($plugin, $payload),
+            RunIntegrationPluginTaskRequest::TYPE_TEST_CAPTCHA => $this->pluginService->testCaptcha($plugin, $payload),
+            RunIntegrationPluginTaskRequest::TYPE_TEST_CONNECTION => $this->pluginService->testConnection($plugin, $payload),
             default => throw new BusinessException('不支持的插件任务', 42200),
         };
 
@@ -598,6 +602,10 @@ class AdminConfigurationV2QueryService
             RunIntegrationPluginTaskRequest::TYPE_HEALTH_CHECK => '插件健康检查完成',
             RunIntegrationPluginTaskRequest::TYPE_TEST_EMAIL => '测试邮件发送成功',
             RunIntegrationPluginTaskRequest::TYPE_TEST_SMS => '测试短信发送成功',
+            RunIntegrationPluginTaskRequest::TYPE_TEST_VERIFICATION => '实名认证测试任务已创建',
+            RunIntegrationPluginTaskRequest::TYPE_TEST_PAYMENT => '测试支付单创建成功',
+            RunIntegrationPluginTaskRequest::TYPE_TEST_CAPTCHA => '行为验证通过',
+            RunIntegrationPluginTaskRequest::TYPE_TEST_CONNECTION => '插件连接测试完成',
             default => '插件任务执行完成',
         };
     }
@@ -614,12 +622,21 @@ class AdminConfigurationV2QueryService
             'healthy',
             'success',
             'sent',
+            'error_type',
             'status',
             'message',
             'provider',
             'entry_class',
             'provider_class',
             'trace_id',
+            'verify_url',
+            'task_no',
+            'certify_id',
+            'qr_code',
+            'out_trade_no',
+            'verified',
+            'capability',
+            'amount',
         ];
 
         return array_filter(

--- a/backend/app/Services/Auth/GeeTestService.php
+++ b/backend/app/Services/Auth/GeeTestService.php
@@ -59,6 +59,7 @@ class GeeTestService
     public function getFallbackScriptContent(): string
     {
         return <<<'JS'
+window.__TURA_GEETEST_FALLBACK__ = true;
 window.initGeetest4 = window.initGeetest4 || function (options, callback) {
     var errorCallbacks = [];
     var instance = {

--- a/backend/app/Services/Integrations/Plugins/IntegrationPluginService.php
+++ b/backend/app/Services/Integrations/Plugins/IntegrationPluginService.php
@@ -7,7 +7,13 @@ namespace App\Services\Integrations\Plugins;
 use App\Exceptions\BusinessException;
 use App\Models\AdminUser;
 use App\Models\IntegrationPlugin;
+use App\Services\Auth\GeeTestService;
+use App\Services\Integrations\Payments\PaymentGatewayOperationService;
+use App\Services\Mail\MailDriverManager;
+use App\Services\Sms\Data\SmsSendRequest;
+use App\Services\Sms\SmsDriverManager;
 use App\Services\System\NotificationService;
+use App\Support\PublicUrl;
 use App\Support\SmsTemplateCatalog;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -35,6 +41,10 @@ class IntegrationPluginService
         private readonly PluginInstaller $installer,
         private readonly PluginConfigRepository $configRepository,
         private readonly PluginRuntimeRegistry $runtimeRegistry,
+        private readonly GeeTestService $geeTestService,
+        private readonly PaymentGatewayOperationService $paymentGatewayOperationService,
+        private readonly MailDriverManager $mailDriverManager,
+        private readonly SmsDriverManager $smsDriverManager,
     ) {}
 
     /**
@@ -222,6 +232,9 @@ class IntegrationPluginService
             throw new BusinessException('插件系统尚未初始化', 42200);
         }
 
+        $manifest = $this->scanner->requireManifest((string) $plugin->domain, (string) $plugin->slug);
+        $this->configRepository->assertConfigReady($plugin, $manifest);
+
         return $this->runtimeRegistry->healthCheck($plugin);
     }
 
@@ -231,20 +244,32 @@ class IntegrationPluginService
      */
     public function testEmail(IntegrationPlugin $plugin, array $payload): array
     {
-        if (! Schema::hasTable('integration_plugins')) {
-            throw new BusinessException('插件系统尚未初始化', 42200);
-        }
+        $this->assertTestDomain($plugin, PluginDomain::MAIL, '邮件发送');
 
-        if (! $plugin->isEnabled()) {
-            throw new BusinessException('插件未启用，无法发送测试邮件', 42200);
-        }
-
-        return $this->runtimeRegistry->execute(
-            domain: (string) $plugin->domain,
-            slugOrKey: (string) $plugin->slug,
-            action: 'mail.test_smtp',
-            payload: $this->verificationEmailPayload($payload),
+        $testPayload = $this->verificationEmailPayload($payload);
+        $driver = $this->mailDriverManager->resolve((string) $plugin->plugin_key);
+        $driver->sendHtml(
+            to: (string) $testPayload['to'],
+            subject: (string) $testPayload['subject'],
+            html: (string) $testPayload['html'],
+            context: array_merge((array) ($testPayload['context'] ?? []), [
+                'test' => true,
+                'account_index' => (int) ($testPayload['account_index'] ?? 0),
+            ]),
         );
+
+        return [
+            'success' => true,
+            'action' => 'mail.test_smtp',
+            'message' => '测试邮件发送成功',
+            'data' => [
+                'sent' => true,
+                'to' => $testPayload['to'],
+                'subject' => $testPayload['subject'],
+                'template_code' => $testPayload['template_code'],
+                'account_index' => (int) ($testPayload['account_index'] ?? 0),
+            ],
+        ];
     }
 
     /**
@@ -253,20 +278,29 @@ class IntegrationPluginService
      */
     public function testSms(IntegrationPlugin $plugin, array $payload): array
     {
-        if (! Schema::hasTable('integration_plugins')) {
-            throw new BusinessException('插件系统尚未初始化', 42200);
-        }
+        $this->assertTestDomain($plugin, PluginDomain::SMS, '短信发送');
 
-        if (! $plugin->isEnabled()) {
-            throw new BusinessException('插件未启用，无法发送测试短信', 42200);
-        }
+        $testPayload = $this->verificationSmsPayload($payload);
+        $driver = $this->smsDriverManager->resolve((string) $plugin->plugin_key);
+        $result = $driver->sendVerifyCode(new SmsSendRequest(
+            phone: (string) $testPayload['phone'],
+            code: (string) $testPayload['code'],
+            options: (array) ($testPayload['options'] ?? []),
+        ));
 
-        return $this->runtimeRegistry->execute(
-            domain: (string) $plugin->domain,
-            slugOrKey: (string) $plugin->slug,
-            action: 'sms.test',
-            payload: $this->verificationSmsPayload($payload),
-        );
+        return [
+            'success' => true,
+            'action' => 'sms.test',
+            'message' => '测试短信发送成功',
+            'data' => [
+                'sent' => true,
+                'phone' => $testPayload['phone'],
+                'status' => $result->status,
+                'template_code' => $testPayload['template_code'],
+                'request_id' => $result->requestId,
+                'template_params' => $result->templateParams,
+            ],
+        ];
     }
 
     /**
@@ -310,6 +344,156 @@ class IntegrationPluginService
             'code' => $code,
             'options' => $options,
         ]);
+    }
+
+    /**
+     * 实名域测试：按插件流程真实创建一次认证任务。
+     * 测试结果只返回给管理员，不落库、不关联任何用户。
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function testVerification(IntegrationPlugin $plugin, array $payload): array
+    {
+        $this->assertTestDomain($plugin, PluginDomain::VERIFICATION, '实名认证');
+
+        return $this->runtimeRegistry->execute(
+            domain: (string) $plugin->domain,
+            slugOrKey: (string) $plugin->slug,
+            action: 'certification.initialize',
+            payload: [
+                'real_name' => (string) ($payload['real_name'] ?? ''),
+                'id_card' => (string) ($payload['card_no'] ?? ''),
+                'cert_type' => 'IDENTITY_CARD',
+                'return_url' => PublicUrl::api('/api/v2/client/verification/callback'),
+            ],
+        );
+    }
+
+    /**
+     * 支付域测试：按插件流程预创建一笔 0.01 元测试支付单。
+     * 只返回支付链接，不写入系统订单表。
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function testPayment(IntegrationPlugin $plugin, array $payload): array
+    {
+        $this->assertTestDomain($plugin, PluginDomain::PAYMENT, '支付渠道');
+
+        $outTradeNo = 'TEST'.date('YmdHis').substr(bin2hex(random_bytes(4)), 0, 6);
+        $result = $this->paymentGatewayOperationService->precreate(
+            gateway: (string) ($plugin->plugin_key ?? $plugin->key),
+            outTradeNo: $outTradeNo,
+            amount: 0.01,
+            subject: '插件测试订单',
+            timeoutExpress: '10m',
+        );
+
+        return [
+            'success' => true,
+            'action' => 'payment.test',
+            'message' => '测试支付单创建成功，请扫描二维码完成测试',
+            'data' => $result,
+        ];
+    }
+
+    /**
+     * 人机验证域测试：管理员在管理端完成验证码交互后提交结果，走完整验证链路。
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function testCaptcha(IntegrationPlugin $plugin, array $payload): array
+    {
+        $this->assertTestDomain($plugin, PluginDomain::CAPTCHA, '人机验证');
+
+        $result = $this->geeTestService->verify($payload);
+        $ok = (bool) ($result['ok'] ?? false);
+        if (! $ok) {
+            return [
+                'success' => false,
+                'action' => 'captcha.test',
+                'message' => (string) ($result['message'] ?? '行为验证未通过'),
+                'data' => ['verified' => false],
+            ];
+        }
+
+        return [
+            'success' => true,
+            'action' => 'captcha.test',
+            'message' => '行为验证通过',
+            'data' => ['verified' => true],
+        ];
+    }
+
+    /**
+     * 上游域测试：解析插件声明的第一个能力，验证插件可加载且能力可解析。
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function testConnection(IntegrationPlugin $plugin, array $payload): array
+    {
+        $this->assertTestDomain($plugin, PluginDomain::UPSTREAM, '上游开通');
+
+        $manifest = $this->scanner->find((string) $plugin->domain, (string) $plugin->slug);
+        $capabilities = array_values(array_filter(
+            (array) ($manifest?->capabilities ?? []),
+            static fn (mixed $value): bool => is_string($value) && trim($value) !== ''
+        ));
+
+        if ($capabilities === []) {
+            return [
+                'success' => false,
+                'action' => 'upstream.test',
+                'message' => '插件未声明任何能力，无法执行连接测试',
+                'data' => ['healthy' => false],
+            ];
+        }
+
+        $capability = $capabilities[0];
+        $result = $this->runtimeRegistry->execute(
+            domain: (string) $plugin->domain,
+            slugOrKey: (string) $plugin->slug,
+            action: 'server.resolve_capability',
+            payload: ['capability' => $capability],
+        );
+
+        $resolved = $result['data']['resolved'] ?? null;
+        if (! $result['success'] || ! is_object($resolved)) {
+            return [
+                'success' => false,
+                'action' => 'upstream.test',
+                'message' => (string) ($result['message'] ?? '插件能力解析失败'),
+                'data' => ['healthy' => false, 'capability' => $capability],
+            ];
+        }
+
+        return [
+            'success' => true,
+            'action' => 'upstream.test',
+            'message' => '插件加载正常，能力解析成功',
+            'data' => ['healthy' => true, 'capability' => $capability],
+        ];
+    }
+
+    /**
+     * @throws BusinessException
+     */
+    private function assertTestDomain(IntegrationPlugin $plugin, string $expectedDomain, string $label): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            throw new BusinessException('插件系统尚未初始化', 42200);
+        }
+
+        if ((string) $plugin->domain !== $expectedDomain) {
+            throw new BusinessException("该测试类型仅适用于{$label}插件", 42200);
+        }
+
+        if (! $plugin->isEnabled()) {
+            throw new BusinessException('插件未启用，无法执行测试', 42200);
+        }
     }
 
     private function verificationCode(): string

--- a/backend/app/Services/Integrations/Plugins/IntegrationPluginService.php
+++ b/backend/app/Services/Integrations/Plugins/IntegrationPluginService.php
@@ -357,7 +357,7 @@ class IntegrationPluginService
     {
         $this->assertTestDomain($plugin, PluginDomain::VERIFICATION, '实名认证');
 
-        return $this->runtimeRegistry->execute(
+        $result = $this->runtimeRegistry->execute(
             domain: (string) $plugin->domain,
             slugOrKey: (string) $plugin->slug,
             action: 'certification.initialize',
@@ -368,6 +368,19 @@ class IntegrationPluginService
                 'return_url' => PublicUrl::api('/api/v2/client/verification/callback'),
             ],
         );
+
+        $data = is_array($result['data'] ?? null) ? $result['data'] : [];
+        $status = (int) ($data['status'] ?? 0);
+        $success = $status === 200;
+
+        return [
+            'success' => $success,
+            'action' => 'certification.initialize',
+            'message' => $success
+                ? (string) ($result['message'] ?? '测试任务创建成功')
+                : (string) ($data['message'] ?? $result['message'] ?? '测试任务创建失败'),
+            'data' => $data,
+        ];
     }
 
     /**
@@ -407,6 +420,15 @@ class IntegrationPluginService
     public function testCaptcha(IntegrationPlugin $plugin, array $payload): array
     {
         $this->assertTestDomain($plugin, PluginDomain::CAPTCHA, '人机验证');
+
+        if (! $this->geeTestService->isEnabled()) {
+            return [
+                'success' => false,
+                'action' => 'captcha.test',
+                'message' => '人机验证插件未完成配置（captcha_id 或 captcha_key 缺失），无法执行测试',
+                'data' => ['verified' => false],
+            ];
+        }
 
         $result = $this->geeTestService->verify($payload);
         $ok = (bool) ($result['ok'] ?? false);

--- a/backend/plugins/captcha/geetest/lib/GeetestCaptchaService.php
+++ b/backend/plugins/captcha/geetest/lib/GeetestCaptchaService.php
@@ -89,6 +89,7 @@ class GeetestCaptchaService
 
         try {
             $response = Http::asForm()
+                ->withOptions($this->httpOptions($config))
                 ->timeout(10)
                 ->post($endpoint, [
                     'lot_number' => $lotNumber,
@@ -105,7 +106,10 @@ class GeetestCaptchaService
                     'body' => $response->body(),
                 ]);
 
-                return $this->failure($action, '行为验证服务暂时不可用，请稍后重试');
+                return $this->failure($action, '行为验证服务暂时不可用，请稍后重试', [
+                    'error_type' => 'upstream_http_error',
+                    'status' => $response->status(),
+                ]);
             }
 
             $data = $response->json();
@@ -124,9 +128,13 @@ class GeetestCaptchaService
             Log::warning('[captcha:geetest] validate exception', [
                 'message' => $exception->getMessage(),
                 'exception' => $exception::class,
+                'error_type' => $this->classifyHttpException($exception),
+                'endpoint' => $endpoint,
             ]);
 
-            return $this->failure($action, '行为验证服务暂时不可用，请稍后重试');
+            return $this->failure($action, '行为验证服务暂时不可用，请稍后重试', [
+                'error_type' => $this->classifyHttpException($exception),
+            ]);
         }
     }
 
@@ -142,7 +150,8 @@ class GeetestCaptchaService
         }
 
         try {
-            $response = Http::timeout(10)
+            $response = Http::withOptions($this->httpOptions($config))
+                ->timeout(10)
                 ->get(self::SCRIPT_UPSTREAM_URL);
 
             if (! $response->successful()) {
@@ -179,6 +188,34 @@ class GeetestCaptchaService
             'message' => '',
             'data' => ['content' => $content],
         ];
+    }
+
+    /**
+     * 本地代理可能使用自签名根证书，沿用系统 GeeTest TLS 配置；
+     * 生产环境默认仍开启证书校验，也支持通过 CA bundle 指定信任链。
+     *
+     * @param  array<string, mixed>  $config
+     * @return array{verify: bool|string}
+     */
+    private function httpOptions(array $config): array
+    {
+        $caBundle = trim((string) config('idc.geetest.ca_bundle', ''));
+        if ($caBundle !== '') {
+            return ['verify' => $caBundle];
+        }
+
+        return [
+            'verify' => (bool) config('idc.geetest.ssl_verify', true),
+        ];
+    }
+
+    private function classifyHttpException(\Throwable $exception): string
+    {
+        $message = strtolower($exception->getMessage());
+
+        return str_contains($message, 'ssl certificate') || str_contains($message, 'certificate verify')
+            ? 'tls_certificate_error'
+            : (str_contains($message, 'timed out') ? 'timeout' : 'connection_error');
     }
 
     /**

--- a/backend/plugins/captcha/geetest/lib/GeetestCaptchaService.php
+++ b/backend/plugins/captcha/geetest/lib/GeetestCaptchaService.php
@@ -89,7 +89,6 @@ class GeetestCaptchaService
 
         try {
             $response = Http::asForm()
-                ->withOptions($this->httpOptions($config))
                 ->timeout(10)
                 ->post($endpoint, [
                     'lot_number' => $lotNumber,
@@ -150,8 +149,7 @@ class GeetestCaptchaService
         }
 
         try {
-            $response = Http::withOptions($this->httpOptions($config))
-                ->timeout(10)
+            $response = Http::timeout(10)
                 ->get(self::SCRIPT_UPSTREAM_URL);
 
             if (! $response->successful()) {
@@ -187,25 +185,6 @@ class GeetestCaptchaService
             'action' => $action,
             'message' => '',
             'data' => ['content' => $content],
-        ];
-    }
-
-    /**
-     * 本地代理可能使用自签名根证书，沿用系统 GeeTest TLS 配置；
-     * 生产环境默认仍开启证书校验，也支持通过 CA bundle 指定信任链。
-     *
-     * @param  array<string, mixed>  $config
-     * @return array{verify: bool|string}
-     */
-    private function httpOptions(array $config): array
-    {
-        $caBundle = trim((string) config('idc.geetest.ca_bundle', ''));
-        if ($caBundle !== '') {
-            return ['verify' => $caBundle];
-        }
-
-        return [
-            'verify' => (bool) config('idc.geetest.ssl_verify', true),
         ];
     }
 

--- a/backend/plugins/certification/leaf_face/LeafFacePlugin.php
+++ b/backend/plugins/certification/leaf_face/LeafFacePlugin.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\LeafFace;
+
+use TuraIDC\Plugins\Certification\LeafFace\Logic\LeafFace;
+
+class LeafFacePlugin extends LeafFace {}

--- a/backend/plugins/certification/leaf_face/config.php
+++ b/backend/plugins/certification/leaf_face/config.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use TuraIDC\Plugins\Certification\LeafFace\LeafFacePlugin;
+
+return [
+    'info' => [
+        'domain' => 'verification',
+        'slug' => 'leaf_face',
+        'key' => 'leaf_face',
+        'name' => 'leaf实名',
+        'version' => '1.0.0',
+        'entry' => LeafFacePlugin::class,
+        'capabilities' => ['personal', 'scan_url', 'query_status', 'verify_callback', 'fee_config'],
+        'extra' => [
+            'driver_binding' => [
+                'binding_key' => 'verification_driver',
+                'provider_key' => 'leaf_face',
+            ],
+        ],
+    ],
+    'config' => [
+        'basic_notice' => [
+            'title' => '配置说明',
+            'type' => 'notice',
+            'theme' => 'info',
+            'content' => '请填写 leaf 平台的 AppId 与 AppSecret，并确认该应用已开通 h5_face 能力。密钥保存后不会明文回显。',
+        ],
+        'app_id' => [
+            'title' => 'AppId',
+            'type' => 'text',
+            'value' => '',
+            'required' => true,
+            'placeholder' => '请输入 leaf 平台商户应用 AppId',
+            'description' => 'leaf 平台商户应用标识，请求时放入 X-App-Id 请求头。',
+        ],
+        'app_secret' => [
+            'title' => 'AppSecret',
+            'type' => 'password',
+            'value' => '',
+            'required' => true,
+            'secret' => true,
+            'placeholder' => '请输入 leaf 平台商户应用 AppSecret',
+            'description' => '用于请求签名与回调验签，保存后不会明文回显。',
+        ],
+        'api_base_url' => [
+            'title' => '平台接口地址',
+            'type' => 'text',
+            'value' => 'https://face.ly-y.cn',
+            'required' => true,
+            'placeholder' => '请输入 leaf 平台接口地址',
+            'description' => 'leaf 平台根地址，用于拼接任务创建、查询与 H5 认证页面链接。',
+        ],
+        'billing_divider' => ['title' => '计费设置', 'type' => 'divider'],
+        'charge_enabled' => [
+            'title' => '插件收费',
+            'type' => 'switch',
+            'value' => false,
+            'description' => '开启后，用户发起实名认证时按配置金额扣费。',
+        ],
+        'amount' => [
+            'title' => '收费金额',
+            'type' => 'number',
+            'value' => 0,
+            'min' => 0,
+            'step' => 0.01,
+            'description' => '单位：元。关闭收费时该字段不生效。',
+            'visible_when' => ['field' => 'charge_enabled', 'operator' => 'eq', 'value' => true],
+        ],
+        'free_times' => [
+            'title' => '免费次数',
+            'type' => 'number',
+            'value' => 0,
+            'min' => 0,
+            'step' => 1,
+            'description' => '每个用户可免费发起认证的次数。',
+        ],
+    ],
+];

--- a/backend/plugins/certification/leaf_face/logic/LeafFace.php
+++ b/backend/plugins/certification/leaf_face/logic/LeafFace.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\LeafFace\Logic;
+
+class LeafFace
+{
+    private ?LeafFaceClient $client = null;
+
+    public function key(): string
+    {
+        return 'leaf_face';
+    }
+
+    public function label(): string
+    {
+        return 'leaf实名';
+    }
+
+    /**
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     */
+    public function execute(array $request): array
+    {
+        $action = trim((string) ($request['action'] ?? ''));
+        $payload = is_array($request['payload'] ?? null) ? $request['payload'] : [];
+        $config = is_array($request['config'] ?? null) ? $request['config'] : [];
+
+        $client = $this->client($config);
+
+        return match ($action) {
+            'certification.initialize' => $this->success($action, $client->initialize(
+                realName: (string) ($payload['real_name'] ?? ''),
+                idCard: (string) ($payload['id_card'] ?? ''),
+                certType: (string) ($payload['cert_type'] ?? ''),
+                returnUrl: (string) ($payload['return_url'] ?? ''),
+            )),
+            'certification.scan_url' => $this->success($action, $client->generateScanUrl(
+                (string) ($payload['certify_id'] ?? '')
+            )),
+            'certification.query_status' => $this->success($action, $client->queryStatus(
+                (string) ($payload['certify_id'] ?? '')
+            )),
+            'certification.verify_callback' => $this->success($action, $this->verifyCallback($payload, $config)),
+            'certification.fee_config' => $this->success($action, $this->feeConfig($config)),
+            default => [
+                'success' => false,
+                'action' => $action,
+                'message' => 'Unsupported plugin action',
+                'data' => [],
+            ],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function client(array $config): LeafFaceClient
+    {
+        if ($this->client === null) {
+            $this->client = new LeafFaceClient($config);
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{success: bool, action: string, data: array<string, mixed>}
+     */
+    private function success(string $action, array $data): array
+    {
+        return [
+            'success' => true,
+            'action' => $action,
+            'data' => $data,
+        ];
+    }
+
+    /**
+     * leaf 平台通过服务端回调通知任务终态，验签由 LeafFaceClient 完成。
+     *
+     * @param  array<string, mixed>  $requestPayload
+     * @param  array<string, mixed>  $config
+     * @return array{passed: bool, message: string, code: int, http_status: int, replay_key?: string, certify_id?: string}
+     */
+    private function verifyCallback(array $requestPayload, array $config): array
+    {
+        $rawPayload = is_array($requestPayload['payload'] ?? null) ? $requestPayload['payload'] : [];
+        $headers = is_array($requestPayload['headers'] ?? null) ? $requestPayload['headers'] : [];
+        $rawBody = (string) ($requestPayload['raw_body'] ?? '');
+
+        return $this->client($config)->verifyCallback($rawPayload, $headers, $rawBody);
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @return array{free_attempts: int, retry_fee: float, free_times: int, amount: float, charge_enabled: bool}
+     */
+    private function feeConfig(array $config): array
+    {
+        $chargeEnabled = filter_var($config['charge_enabled'] ?? false, FILTER_VALIDATE_BOOL);
+        $amount = max(0.0, (float) ($config['amount'] ?? 0));
+        $freeTimes = max(0, (int) ($config['free_times'] ?? $config['free_attempts'] ?? 0));
+
+        return [
+            'free_attempts' => $freeTimes,
+            'retry_fee' => $amount,
+            'free_times' => $freeTimes,
+            'amount' => $amount,
+            'charge_enabled' => $chargeEnabled,
+        ];
+    }
+}

--- a/backend/plugins/certification/leaf_face/logic/LeafFaceClient.php
+++ b/backend/plugins/certification/leaf_face/logic/LeafFaceClient.php
@@ -1,0 +1,450 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TuraIDC\Plugins\Certification\LeafFace\Logic;
+
+use App\Exceptions\BusinessException;
+use App\Support\SensitiveDataSanitizer;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class LeafFaceClient
+{
+    private const DEFAULT_API_BASE = 'https://face.ly-y.cn';
+
+    private const CREATE_TASK_ENDPOINT = '/api/merchant/verify/tasks';
+
+    private const LOOKUP_TASK_ENDPOINT = '/api/merchant/verify/tasks/{task_no}';
+
+    private const CALLBACK_EVENT = 'verification.task.finished';
+
+    private const MAX_TIMESTAMP_SKEW_SECONDS = 300;
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function __construct(
+        private readonly array $config,
+    ) {}
+
+    /**
+     * @return array{status: int, message: string, certify_id?: string, raw?: array<string, mixed>}
+     */
+    public function initialize(string $realName, string $idCard, string $certType, string $returnUrl): array
+    {
+        if ($this->resolveCertificateType($certType) !== 'IDENTITY_CARD') {
+            return ['status' => 400, 'message' => 'leaf实名认证当前仅支持大陆身份证'];
+        }
+
+        $payload = [
+            'type' => 'h5_face',
+            'real_name' => $realName,
+            'card_no' => $idCard,
+            'out_trade_no' => $this->generateOutTradeNo(),
+        ];
+
+        if (trim($returnUrl) !== '') {
+            $payload['notify_url'] = trim($returnUrl);
+            $payload['return_url'] = trim($returnUrl);
+        }
+
+        $result = $this->request('POST', self::CREATE_TASK_ENDPOINT, $payload);
+        if ($result === null) {
+            return ['status' => 400, 'message' => '创建 leaf实名认证任务失败，请联系管理员'];
+        }
+
+        if (! $this->isCreateTaskSuccess($result)) {
+            return [
+                'status' => 400,
+                'message' => $this->createTaskFailureMessage($result),
+                'raw' => $result,
+            ];
+        }
+
+        $taskNo = trim((string) ($result['task_no'] ?? ($result['task']['task_no'] ?? '')));
+        if ($taskNo === '') {
+            Log::warning('[leaf实名] 创建任务响应缺少 task_no', SensitiveDataSanitizer::sanitize($result));
+
+            return ['status' => 400, 'message' => '创建 leaf实名认证任务失败，请联系管理员', 'raw' => $result];
+        }
+
+        $this->cacheVerifyUrl($taskNo, $result);
+
+        return [
+            'status' => 200,
+            'message' => '实名认证初始化成功',
+            'certify_id' => $taskNo,
+            'raw' => $result,
+        ];
+    }
+
+    /**
+     * @return array{status: int, message: string, url?: string, raw?: array<string, mixed>}
+     */
+    public function generateScanUrl(string $certifyId): array
+    {
+        $taskNo = trim($certifyId);
+        if ($taskNo === '') {
+            return ['status' => 400, 'message' => '认证会话不存在或已失效'];
+        }
+
+        $verifyUrl = $this->cachedVerifyUrl($taskNo);
+        if ($verifyUrl === '') {
+            return ['status' => 400, 'message' => '认证链接已失效，请返回系统重新发起认证'];
+        }
+
+        return [
+            'status' => 200,
+            'message' => '请打开实名认证链接继续认证',
+            'url' => $this->buildVerifyUrl($verifyUrl),
+            'raw' => ['task_no' => $taskNo],
+        ];
+    }
+
+    /**
+     * @return array{status: int, message: string, raw?: array<string, mixed>}
+     */
+    public function queryStatus(string $certifyId): array
+    {
+        $taskNo = trim($certifyId);
+        if ($taskNo === '') {
+            return ['status' => 2, 'message' => '认证会话不存在或已失效'];
+        }
+
+        $result = $this->request('GET', str_replace('{task_no}', rawurlencode($taskNo), self::LOOKUP_TASK_ENDPOINT));
+        if ($result === null) {
+            return ['status' => 3, 'message' => '实名认证接口请求失败，请稍后重试'];
+        }
+
+        if ($this->isLookupFailure($result)) {
+            return ['status' => 4, 'message' => '认证处理中，请稍后再试', 'raw' => $result];
+        }
+
+        $status = strtolower(trim((string) ($result['task']['status'] ?? '')));
+        if ($status === '') {
+            return ['status' => 3, 'message' => '实名认证接口返回异常，请稍后重试', 'raw' => $result];
+        }
+
+        return match ($status) {
+            'completed' => ['status' => 1, 'message' => '审核通过', 'raw' => $result],
+            'failed' => ['status' => 2, 'message' => '实名认证未通过，请重新发起', 'raw' => $result],
+            'expired' => ['status' => 2, 'message' => '认证任务已过期，请重新发起', 'raw' => $result],
+            'canceled' => ['status' => 2, 'message' => '认证任务已取消，请重新发起', 'raw' => $result],
+            'created' => ['status' => 4, 'message' => '等待用户完成认证', 'raw' => $result],
+            default => ['status' => 3, 'message' => '实名认证接口返回异常，请稍后重试', 'raw' => $result],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, string>  $headers
+     * @return array{passed: bool, message: string, code: int, http_status: int, replay_key?: string, certify_id?: string}
+     */
+    public function verifyCallback(array $payload, array $headers, string $rawBody): array
+    {
+        $timestamp = trim((string) ($headers['x-leafsm-timestamp'] ?? ''));
+        $nonce = trim((string) ($headers['x-leafsm-nonce'] ?? ''));
+        $signature = trim((string) ($headers['x-leafsm-signature'] ?? ''));
+        $bodySha256 = trim((string) ($headers['x-body-sha256'] ?? ''));
+        $event = trim((string) ($headers['x-leafsm-event'] ?? ''));
+        $secret = trim((string) ($this->config['app_secret'] ?? ''));
+
+        if ($secret === '') {
+            return $this->reject('缺少回调验签配置');
+        }
+
+        if ($event !== '' && $event !== self::CALLBACK_EVENT) {
+            return $this->reject('回调事件类型不正确');
+        }
+
+        if ($timestamp === '' || $nonce === '' || $signature === '') {
+            return $this->reject('缺少回调签名参数');
+        }
+
+        $parsedTimestamp = strtotime($timestamp);
+        if ($parsedTimestamp === false || abs(time() - $parsedTimestamp) > self::MAX_TIMESTAMP_SKEW_SECONDS) {
+            return $this->reject('回调时间戳无效或已过期');
+        }
+
+        $expectedBodySha256 = hash('sha256', $rawBody);
+        if ($bodySha256 !== '' && ! hash_equals($expectedBodySha256, strtolower($bodySha256))) {
+            return $this->reject('回调内容摘要不一致');
+        }
+
+        $signatureSource = $timestamp."\n".$nonce."\n".$expectedBodySha256;
+        $expectedSignature = hash_hmac('sha256', $signatureSource, $secret);
+        if (! hash_equals($expectedSignature, strtolower($signature))) {
+            return $this->reject('回调签名验证失败');
+        }
+
+        $taskNo = trim((string) ($payload['task']['task_no'] ?? ''));
+
+        return [
+            'passed' => true,
+            'message' => '回调签名验证通过',
+            'code' => 0,
+            'http_status' => 200,
+            'replay_key' => $timestamp.'|'.$nonce,
+            'certify_id' => $taskNo,
+        ];
+    }
+
+    /**
+     * @return array{passed: bool, message: string, code: int, http_status: int}
+     */
+    private function reject(string $message): array
+    {
+        return [
+            'passed' => false,
+            'message' => $message,
+            'code' => 40001,
+            'http_status' => 401,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function isCreateTaskSuccess(array $result): bool
+    {
+        $code = $result['code'] ?? $result['error_code'] ?? null;
+
+        return $code === null || $code === 0 || $code === '0';
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function createTaskFailureMessage(array $result): string
+    {
+        $code = (string) ($result['code'] ?? $result['error_code'] ?? '');
+
+        return match (strtoupper($code)) {
+            'TWO_FACTOR_MISMATCH' => '姓名和身份证号二要素预校验未通过，请核对后重试',
+            'INVALID_NOTIFY_URL' => '回调地址无效，请联系管理员',
+            'API_TYPE_NOT_ALLOWED' => '当前应用未开通 h5_face 能力，请联系平台开通',
+            'INSUFFICIENT_CREDIT' => '平台认证额度不足，请联系管理员充值',
+            'TASK_CREATE_FAILED' => '任务创建失败，请稍后重试',
+            'INVALID_ARGUMENT' => '请求参数无效，请核对后重试',
+            default => $this->safeProviderMessage($result, '创建 leaf实名认证任务失败，请稍后重试'),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function isLookupFailure(array $result): bool
+    {
+        $code = (string) ($result['code'] ?? $result['error_code'] ?? '');
+
+        return in_array(strtoupper($code), ['TASK_NOT_FOUND', 'INVALID_SIGNATURE', 'REPLAY_REQUEST'], true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function safeProviderMessage(array $payload, string $fallback): string
+    {
+        $text = trim((string) ($payload['message'] ?? $payload['msg'] ?? ''));
+        if ($text === '') {
+            return $fallback;
+        }
+
+        if (preg_match('/[a-z]{3,}|error|failed|exception|timeout|curl|http|openapi/i', $text) === 1) {
+            return $fallback;
+        }
+
+        return $text;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    private function request(string $method, string $path, array $payload = []): ?array
+    {
+        $base = rtrim($this->apiBase(), '/');
+        $endpoint = $base.$path;
+        $body = $method === 'GET' ? '' : (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $timestamp = gmdate('c');
+        $nonce = $this->generateNonce();
+        $bodySha256 = hash('sha256', $body);
+        $signature = hash_hmac('sha256', $timestamp."\n".$nonce."\n".$bodySha256, $this->appSecret());
+
+        try {
+            $request = $this->http()->withHeaders([
+                'X-App-Id' => $this->appId(),
+                'X-Timestamp' => $timestamp,
+                'X-Nonce' => $nonce,
+                'X-Body-Sha256' => $bodySha256,
+                'X-Signature' => $signature,
+            ]);
+
+            $response = $body === ''
+                ? $request->send($method, $endpoint)
+                : $request->withBody($body, 'application/json')->send($method, $endpoint);
+        } catch (ConnectionException $exception) {
+            Log::error('[leaf实名] 接口请求失败', SensitiveDataSanitizer::sanitize([
+                'endpoint' => $endpoint,
+                'message' => $exception->getMessage(),
+            ]));
+
+            return null;
+        }
+
+        return $this->decodeResponse($endpoint, $response);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeResponse(string $endpoint, Response $response): ?array
+    {
+        $decoded = $response->json();
+        if (! is_array($decoded)) {
+            Log::warning('[leaf实名] 接口返回非 JSON', [
+                'endpoint' => $endpoint,
+                'status' => $response->status(),
+            ]);
+
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    private function http(): PendingRequest
+    {
+        return Http::timeout(30)
+            ->connectTimeout(10)
+            ->acceptJson()
+            ->withOptions($this->httpOptions());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function httpOptions(): array
+    {
+        $sslVerify = $this->resolveSslVerify();
+        $caBundle = $this->resolveCaBundle();
+
+        if (! $sslVerify) {
+            return ['verify' => false];
+        }
+
+        return $caBundle !== '' && is_file($caBundle)
+            ? ['verify' => $caBundle]
+            : ['verify' => true];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function cacheVerifyUrl(string $taskNo, array $result): void
+    {
+        $verifyUrl = trim((string) ($result['verify_url'] ?? ''));
+        if ($verifyUrl === '') {
+            return;
+        }
+
+        Cache::put(
+            $this->verifyUrlCacheKey($taskNo),
+            $verifyUrl,
+            now()->addSeconds(7200)
+        );
+    }
+
+    private function buildVerifyUrl(string $verifyUrl): string
+    {
+        if (preg_match('#^https?://#i', $verifyUrl) === 1) {
+            return $verifyUrl;
+        }
+
+        return rtrim($this->apiBase(), '/').'/'.ltrim($verifyUrl, '/');
+    }
+
+    private function cachedVerifyUrl(string $taskNo): string
+    {
+        $raw = Cache::get($this->verifyUrlCacheKey($taskNo));
+
+        return is_string($raw) && trim($raw) !== '' ? trim($raw) : '';
+    }
+
+    private function verifyUrlCacheKey(string $taskNo): string
+    {
+        return 'leaf_face_verification:verify_url:'.hash('sha256', $taskNo);
+    }
+
+    private function generateOutTradeNo(): string
+    {
+        return 'LF'.date('YmdHis').substr(bin2hex(random_bytes(4)), 0, 6);
+    }
+
+    private function generateNonce(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+
+    private function apiBase(): string
+    {
+        $value = trim((string) ($this->config['api_base_url'] ?? ''));
+        if ($value === '') {
+            return self::DEFAULT_API_BASE;
+        }
+
+        return $value;
+    }
+
+    private function appId(): string
+    {
+        $value = trim((string) ($this->config['app_id'] ?? ''));
+        if ($value === '') {
+            throw new BusinessException('leaf实名认证接口未配置，请先在插件管理中填写 AppId', 42200);
+        }
+
+        return $value;
+    }
+
+    private function appSecret(): string
+    {
+        $value = trim((string) ($this->config['app_secret'] ?? ''));
+        if ($value === '') {
+            throw new BusinessException('leaf实名认证接口未配置，请先在插件管理中填写 AppSecret', 42200);
+        }
+
+        return $value;
+    }
+
+    private function resolveCertificateType(string $certType): string
+    {
+        $normalized = strtoupper(trim($certType));
+
+        return $normalized !== '' ? $normalized : 'IDENTITY_CARD';
+    }
+
+    private function resolveSslVerify(): bool
+    {
+        $value = $this->config['ssl_verify'] ?? null;
+        if ($value !== null && $value !== '') {
+            return filter_var($value, FILTER_VALIDATE_BOOL);
+        }
+
+        return filter_var(config('idc.verification.ssl_verify', true), FILTER_VALIDATE_BOOL);
+    }
+
+    private function resolveCaBundle(): string
+    {
+        $value = $this->config['ca_bundle'] ?? null;
+        if ($value !== null && $value !== '') {
+            return trim((string) $value);
+        }
+
+        return trim((string) config('idc.verification.ca_bundle', ''));
+    }
+}

--- a/backend/plugins/certification/leaf_face/logic/LeafFaceClient.php
+++ b/backend/plugins/certification/leaf_face/logic/LeafFaceClient.php
@@ -58,7 +58,10 @@ class LeafFaceClient
             return ['status' => 400, 'message' => '创建 leaf实名认证任务失败，请联系管理员'];
         }
 
-        if (! $this->isCreateTaskSuccess($result)) {
+        $taskNo = trim((string) ($result['task_no'] ?? ($result['task']['task_no'] ?? '')));
+        $code = $result['code'] ?? $result['error_code'] ?? null;
+
+        if ($code !== null && $code !== 0 && $code !== '0') {
             return [
                 'status' => 400,
                 'message' => $this->createTaskFailureMessage($result),
@@ -66,7 +69,6 @@ class LeafFaceClient
             ];
         }
 
-        $taskNo = trim((string) ($result['task_no'] ?? ($result['task']['task_no'] ?? '')));
         if ($taskNo === '') {
             Log::warning('[leaf实名] 创建任务响应缺少 task_no', SensitiveDataSanitizer::sanitize($result));
 
@@ -205,16 +207,6 @@ class LeafFaceClient
             'code' => 40001,
             'http_status' => 401,
         ];
-    }
-
-    /**
-     * @param  array<string, mixed>  $result
-     */
-    private function isCreateTaskSuccess(array $result): bool
-    {
-        $code = $result['code'] ?? $result['error_code'] ?? null;
-
-        return $code === null || $code === 0 || $code === '0';
     }
 
     /**

--- a/backend/plugins/certification/leaf_face/logic/LeafFaceClient.php
+++ b/backend/plugins/certification/leaf_face/logic/LeafFaceClient.php
@@ -75,12 +75,15 @@ class LeafFaceClient
             return ['status' => 400, 'message' => '创建 leaf实名认证任务失败，请联系管理员', 'raw' => $result];
         }
 
+        $verifyUrl = trim((string) ($result['verify_url'] ?? ''));
         $this->cacheVerifyUrl($taskNo, $result);
 
         return [
             'status' => 200,
             'message' => '实名认证初始化成功',
             'certify_id' => $taskNo,
+            'task_no' => $taskNo,
+            'verify_url' => $verifyUrl,
             'raw' => $result,
         ];
     }

--- a/backend/tests/Feature/IntegrationPluginSystemTest.php
+++ b/backend/tests/Feature/IntegrationPluginSystemTest.php
@@ -336,12 +336,18 @@ class IntegrationPluginSystemTest extends TestCase
                 $table->string('plugin_key', 120);
                 $table->string('name', 120);
                 $table->string('version', 32)->default('1.0.0');
+                $table->string('manifest_hash', 64)->nullable();
+                $table->string('source_hash', 64)->nullable();
                 $table->string('provider_class', 255)->nullable();
                 $table->string('entry_class', 255);
                 $table->json('capabilities_json')->nullable();
                 $table->json('config_schema_json')->nullable();
                 $table->unsignedTinyInteger('status')->default(0);
                 $table->timestamp('installed_at')->nullable();
+                $table->unsignedBigInteger('installed_by')->nullable();
+                $table->timestamp('enabled_at')->nullable();
+                $table->unsignedBigInteger('enabled_by')->nullable();
+                $table->timestamp('disabled_at')->nullable();
                 $table->timestamps();
                 $table->unique(['domain', 'slug']);
                 $table->unique(['domain', 'plugin_key']);
@@ -392,14 +398,33 @@ class IntegrationPluginSystemTest extends TestCase
             return;
         }
 
-        DB::statement('SET FOREIGN_KEY_CHECKS=0');
-        if (Schema::hasTable('integration_plugin_bindings')) {
-            DB::table('integration_plugin_bindings')->truncate();
+        $isMysql = DB::getDriverName() === 'mysql';
+        if ($isMysql) {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
         }
-        if (Schema::hasTable('integration_plugin_configs')) {
-            DB::table('integration_plugin_configs')->truncate();
+
+        foreach (
+            [
+                'integration_plugin_bindings',
+                'integration_plugin_configs',
+                'integration_plugin_runtime_logs',
+                'product_upstream_bindings',
+                'service_upstream_bindings',
+                'supplier_plugin_bindings',
+                'service_runtime_snapshots',
+                'service_connection_snapshots',
+                'service_provision_attempts',
+            ] as $table
+        ) {
+            if (Schema::hasTable($table)) {
+                DB::table($table)->delete();
+            }
         }
-        DB::table('integration_plugins')->truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        DB::table('integration_plugins')->delete();
+
+        if ($isMysql) {
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
     }
 }

--- a/backend/tests/Feature/IntegrationPluginSystemTest.php
+++ b/backend/tests/Feature/IntegrationPluginSystemTest.php
@@ -1,0 +1,405 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Exceptions\BusinessException;
+use App\Http\Requests\Admin\V2\IntegrationPlugin\RunIntegrationPluginTaskRequest;
+use App\Models\IntegrationPlugin;
+use App\Services\Integrations\Payments\PaymentGatewayManager;
+use App\Services\Integrations\Payments\PaymentGatewayRegistry;
+use App\Services\Integrations\Plugins\IntegrationPluginService;
+use App\Services\Integrations\Plugins\PluginConfigRepository;
+use App\Services\Integrations\Plugins\PluginInstaller;
+use App\Services\Integrations\Plugins\PluginScanner;
+use App\Services\Mail\MailDriverManager;
+use App\Services\Sms\SmsDriverManager;
+use App\Support\SmsTemplateCatalog;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\Factory;
+use Tests\TestCase;
+
+class IntegrationPluginSystemTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensurePluginTables();
+        $this->cleanPluginTables();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanPluginTables();
+        parent::tearDown();
+    }
+
+    // ============================================================
+    // 实名认证域测试
+    // ============================================================
+
+    public function test_verification_test_creates_task(): void
+    {
+        $plugin = $this->activatePlugin('verification', 'demo_verification', [
+            'api_url' => 'https://example.test',
+            'app_id' => 'demo_app',
+        ]);
+
+        $result = app(IntegrationPluginService::class)->testVerification($plugin, [
+            'real_name' => '张三',
+            'card_no' => '110101199001010011',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('certification.initialize', $result['action']);
+        $this->assertSame(200, $result['data']['status'] ?? null);
+        $this->assertNotSame('', $result['data']['certify_id'] ?? '');
+    }
+
+    public function test_verification_test_rejects_wrong_domain(): void
+    {
+        $plugin = $this->activatePlugin('mail', 'demo_mail', [
+            'from_address' => 'noreply@test.example',
+            'from_name' => 'Test Mailer',
+        ]);
+
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('实名认证');
+
+        app(IntegrationPluginService::class)->testVerification($plugin, [
+            'real_name' => '张三',
+            'card_no' => '110101199001010011',
+        ]);
+    }
+
+    public function test_verification_test_rejects_disabled_plugin(): void
+    {
+        $plugin = $this->installPlugin('verification', 'demo_verification');
+
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('插件未启用');
+
+        app(IntegrationPluginService::class)->testVerification($plugin, [
+            'real_name' => '张三',
+            'card_no' => '110101199001010011',
+        ]);
+    }
+
+    public function test_health_check_rejects_unconfigured_plugin(): void
+    {
+        $plugin = $this->installPlugin('verification', 'demo_verification');
+
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('插件配置缺少必填项');
+
+        app(IntegrationPluginService::class)->healthCheck($plugin);
+    }
+
+    // ============================================================
+    // 支付域测试
+    // ============================================================
+
+    public function test_payment_test_precreates_order(): void
+    {
+        $plugin = $this->activatePlugin('payment', 'demo_pay', [
+            'merchant_id' => 'demo_merchant',
+            'enabled' => true,
+        ]);
+
+        $this->forgetRuntimeInstances();
+
+        $result = app(IntegrationPluginService::class)->testPayment($plugin, []);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('payment.test', $result['action']);
+        $this->assertStringStartsWith('TEST', $result['data']['out_trade_no'] ?? '');
+        $this->assertNotSame('', $result['data']['qr_code'] ?? '');
+    }
+
+    public function test_payment_test_rejects_wrong_domain(): void
+    {
+        $plugin = $this->activatePlugin('sms', 'demo_sms', [
+            'access_key' => 'demo_ak',
+            'sign_name' => '测试签名',
+            'template_code' => SmsTemplateCatalog::TEMPLATE_VERIFY_CODE,
+        ]);
+
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('支付渠道');
+
+        app(IntegrationPluginService::class)->testPayment($plugin, []);
+    }
+
+    public function test_mail_test_uses_system_mail_driver(): void
+    {
+        $plugin = $this->activatePlugin('mail', 'demo_mail', [
+            'from_address' => 'noreply@test.example',
+            'from_name' => 'Test Mailer',
+        ]);
+        $this->forgetRuntimeInstances();
+
+        $result = app(IntegrationPluginService::class)->testEmail($plugin, [
+            'account_index' => 0,
+            'to' => 'user@example.com',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('mail.test_smtp', $result['action']);
+        $this->assertTrue($result['data']['sent'] ?? false);
+        $this->assertSame('user@example.com', $result['data']['to'] ?? '');
+    }
+
+    public function test_sms_test_uses_system_sms_driver(): void
+    {
+        $plugin = $this->activatePlugin('sms', 'demo_sms', [
+            'access_key' => 'demo_ak',
+            'sign_name' => '测试签名',
+            'template_code' => SmsTemplateCatalog::TEMPLATE_VERIFY_CODE,
+        ]);
+        $this->forgetRuntimeInstances();
+
+        $result = app(IntegrationPluginService::class)->testSms($plugin, [
+            'phone' => '13800138000',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('sms.test', $result['action']);
+        $this->assertTrue($result['data']['sent'] ?? false);
+        $this->assertSame('success', $result['data']['status'] ?? '');
+        $this->assertSame('13800138000', $result['data']['phone'] ?? '');
+    }
+
+    // ============================================================
+    // 人机验证域测试
+    // ============================================================
+
+    public function test_captcha_test_passes_on_success(): void
+    {
+        $plugin = $this->activatePlugin('captcha', 'geetest', [
+            'captcha_id' => 'test-captcha-id',
+            'captcha_key' => 'test-captcha-key',
+        ]);
+
+        Http::fake([
+            'gcaptcha4.geetest.com/validate' => Http::response(['result' => 'success'], 200),
+        ]);
+
+        $result = app(IntegrationPluginService::class)->testCaptcha($plugin, [
+            'lot_number' => 'lot-1',
+            'captcha_output' => 'output-1',
+            'pass_token' => 'token-1',
+            'gen_time' => '1700000000',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertTrue($result['data']['verified'] ?? false);
+    }
+
+    public function test_captcha_test_fails_on_reject(): void
+    {
+        $plugin = $this->activatePlugin('captcha', 'geetest', [
+            'captcha_id' => 'test-captcha-id',
+            'captcha_key' => 'test-captcha-key',
+        ]);
+
+        Http::fake([
+            'gcaptcha4.geetest.com/validate' => Http::response(['result' => 'fail'], 200),
+        ]);
+
+        $result = app(IntegrationPluginService::class)->testCaptcha($plugin, [
+            'lot_number' => 'lot-1',
+            'captcha_output' => 'output-1',
+            'pass_token' => 'token-1',
+            'gen_time' => '1700000000',
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertFalse($result['data']['verified'] ?? true);
+    }
+
+    public function test_captcha_test_rejects_wrong_domain(): void
+    {
+        $plugin = $this->activatePlugin('mail', 'demo_mail', [
+            'from_address' => 'noreply@test.example',
+            'from_name' => 'Test Mailer',
+        ]);
+
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('人机验证');
+
+        app(IntegrationPluginService::class)->testCaptcha($plugin, []);
+    }
+
+    // ============================================================
+    // 上游域测试
+    // ============================================================
+
+    public function test_connection_test_resolves_capability(): void
+    {
+        $plugin = $this->activatePlugin('upstream', 'demo_servers', []);
+
+        $result = app(IntegrationPluginService::class)->testConnection($plugin, []);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('upstream.test', $result['action']);
+        $this->assertTrue($result['data']['healthy'] ?? false);
+        $this->assertNotSame('', $result['data']['capability'] ?? '');
+    }
+
+    public function test_connection_test_rejects_wrong_domain(): void
+    {
+        $plugin = $this->activatePlugin('sms', 'demo_sms', [
+            'access_key' => 'demo_ak',
+            'sign_name' => '测试签名',
+            'template_code' => SmsTemplateCatalog::TEMPLATE_VERIFY_CODE,
+        ]);
+
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('上游开通');
+
+        app(IntegrationPluginService::class)->testConnection($plugin, []);
+    }
+
+    public function test_verification_test_requires_real_name_and_card_no(): void
+    {
+        $request = new RunIntegrationPluginTaskRequest;
+        $request->replace([
+            'type' => 'test_verification',
+            'payload' => ['real_name' => '张三'],
+        ]);
+
+        $validator = app(Factory::class)->make($request->input(), $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('payload.card_no', $validator->errors()->toArray());
+    }
+
+    public function test_captcha_test_requires_full_geetest_output(): void
+    {
+        $request = new RunIntegrationPluginTaskRequest;
+        $request->replace([
+            'type' => 'test_captcha',
+            'payload' => ['lot_number' => 'lot-1'],
+        ]);
+
+        $validator = app(Factory::class)->make($request->input(), $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('payload.captcha_output', $validator->errors()->toArray());
+        $this->assertArrayHasKey('payload.pass_token', $validator->errors()->toArray());
+        $this->assertArrayHasKey('payload.gen_time', $validator->errors()->toArray());
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private function forgetRuntimeInstances(): void
+    {
+        app()->forgetInstance(IntegrationPluginService::class);
+        app()->forgetInstance(PaymentGatewayManager::class);
+        app()->forgetInstance(PaymentGatewayRegistry::class);
+        app()->forgetInstance(MailDriverManager::class);
+        app()->forgetInstance(SmsDriverManager::class);
+    }
+
+    private function installPlugin(string $domain, string $slug): IntegrationPlugin
+    {
+        return app(PluginInstaller::class)->install($domain, $slug);
+    }
+
+    private function activatePlugin(string $domain, string $slug, array $config): IntegrationPlugin
+    {
+        $plugin = $this->installPlugin($domain, $slug);
+        if ($config !== []) {
+            app(PluginConfigRepository::class)->save(
+                $plugin,
+                app(PluginScanner::class)->requireManifest($domain, $slug),
+                $config,
+            );
+        }
+
+        return app(PluginInstaller::class)->enable($plugin);
+    }
+
+    private function ensurePluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            Schema::create('integration_plugins', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->string('slug', 120);
+                $table->string('plugin_key', 120);
+                $table->string('name', 120);
+                $table->string('version', 32)->default('1.0.0');
+                $table->string('provider_class', 255)->nullable();
+                $table->string('entry_class', 255);
+                $table->json('capabilities_json')->nullable();
+                $table->json('config_schema_json')->nullable();
+                $table->unsignedTinyInteger('status')->default(0);
+                $table->timestamp('installed_at')->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'slug']);
+                $table->unique(['domain', 'plugin_key']);
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_configs')) {
+            Schema::create('integration_plugin_configs', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('plugin_id');
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->timestamps();
+                $table->unique('plugin_id');
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_bindings')) {
+            Schema::create('integration_plugin_bindings', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->unsignedBigInteger('plugin_id');
+                $table->string('binding_type', 50);
+                $table->string('bindable_type', 120)->default('global');
+                $table->unsignedBigInteger('bindable_id')->default(0);
+                $table->string('binding_key', 120);
+                $table->string('provider_key', 120)->nullable();
+                $table->integer('priority')->default(0);
+                $table->unsignedTinyInteger('status')->default(1);
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->json('runtime_policy_json')->nullable();
+                $table->unsignedBigInteger('created_by')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->string('backfill_batch_id', 64)->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'binding_type', 'bindable_type', 'bindable_id', 'binding_key'], 'plugin_bindings_unique');
+            });
+        }
+    }
+
+    private function cleanPluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            return;
+        }
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('integration_plugin_bindings')) {
+            DB::table('integration_plugin_bindings')->truncate();
+        }
+        if (Schema::hasTable('integration_plugin_configs')) {
+            DB::table('integration_plugin_configs')->truncate();
+        }
+        DB::table('integration_plugins')->truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+}

--- a/backend/tests/Feature/LeafFacePluginTest.php
+++ b/backend/tests/Feature/LeafFacePluginTest.php
@@ -1,0 +1,729 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Exceptions\BusinessException;
+use App\Services\Integrations\Plugins\PluginFileLoader;
+use App\Services\Integrations\Plugins\PluginScanner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+use TuraIDC\Plugins\Certification\LeafFace\Logic\LeafFace;
+use TuraIDC\Plugins\Certification\LeafFace\Logic\LeafFaceClient;
+
+class LeafFacePluginTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cleanPluginTables();
+        // 插件类走 PluginFileLoader 的 require_once 加载，不在 PSR-4 autoload 内，
+        // 直接 new 之前必须先确保文件已载入。
+        $this->loadLeafFacePlugin();
+    }
+
+    private function loadLeafFacePlugin(): void
+    {
+        $manifest = app(PluginScanner::class)->requireManifest('verification', 'leaf_face');
+        app(PluginFileLoader::class)->ensureLoaded($manifest);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanPluginTables();
+        parent::tearDown();
+    }
+
+    // ============================================================
+    // Unit tests: LeafFace execute() routing
+    // ============================================================
+
+    public function test_execute_routes_initialize_action(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks' => Http::response([
+                'task_no' => 'VT202607041130001234ABCD',
+                'task_id' => '81a4e811-53dd-4302-aac1-a18c9a8e8583',
+                'verify_url' => '/h5/face?task_id=81a4e811-53dd-4302-aac1-a18c9a8e8583',
+                'expires_in' => 7200,
+            ], 200),
+        ]);
+
+        $plugin = new LeafFace;
+
+        $result = $plugin->execute([
+            'action' => 'certification.initialize',
+            'payload' => [
+                'real_name' => '张三',
+                'id_card' => '110101199001010011',
+                'cert_type' => 'IDENTITY_CARD',
+                'return_url' => 'https://api.example.test/api/v2/client/verification/callback',
+            ],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('certification.initialize', $result['action']);
+        $this->assertSame(200, $result['data']['status']);
+        $this->assertSame('VT202607041130001234ABCD', $result['data']['certify_id']);
+
+        Http::assertSent(function ($request): bool {
+            $this->assertSame('application/json', $request->header('Content-Type')[0] ?? '');
+            $this->assertSame('test-app-id', $request->header('X-App-Id')[0] ?? '');
+            $this->assertNotSame('', $request->header('X-Timestamp')[0] ?? '');
+            $this->assertNotSame('', $request->header('X-Nonce')[0] ?? '');
+            $this->assertNotSame('', $request->header('X-Signature')[0] ?? '');
+            $this->assertSame(hash('sha256', $request->body()), $request->header('X-Body-Sha256')[0] ?? '');
+
+            return true;
+        });
+    }
+
+    public function test_execute_routes_scan_url_action(): void
+    {
+        $this->seedVerifyUrlCache();
+
+        $plugin = new LeafFace;
+
+        $result = $plugin->execute([
+            'action' => 'certification.scan_url',
+            'payload' => ['certify_id' => 'VT202607041130001234ABCD'],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('certification.scan_url', $result['action']);
+        $this->assertSame('https://face.ly-y.cn/h5/face?task_id=81a4e811-53dd-4302-aac1-a18c9a8e8583', $result['data']['url']);
+    }
+
+    public function test_execute_routes_fee_config_action(): void
+    {
+        $plugin = new LeafFace;
+
+        $result = $plugin->execute([
+            'action' => 'certification.fee_config',
+            'payload' => [],
+            'config' => [
+                'charge_enabled' => true,
+                'amount' => 3.5,
+                'free_times' => 2,
+            ],
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(2, $result['data']['free_attempts']);
+        $this->assertSame(3.5, $result['data']['retry_fee']);
+        $this->assertTrue($result['data']['charge_enabled']);
+    }
+
+    public function test_execute_fee_config_defaults_when_no_config(): void
+    {
+        $plugin = new LeafFace;
+
+        $result = $plugin->execute([
+            'action' => 'certification.fee_config',
+            'payload' => [],
+            'config' => [],
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(0, $result['data']['free_attempts']);
+        $this->assertSame(0.0, $result['data']['retry_fee']);
+        $this->assertFalse($result['data']['charge_enabled']);
+    }
+
+    public function test_execute_returns_error_for_unknown_action(): void
+    {
+        $plugin = new LeafFace;
+
+        $result = $plugin->execute([
+            'action' => 'certification.unknown',
+            'payload' => [],
+            'config' => [],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('Unsupported plugin action', $result['message']);
+    }
+
+    public function test_execute_handles_missing_action_key(): void
+    {
+        $plugin = new LeafFace;
+
+        $result = $plugin->execute([
+            'payload' => [],
+            'config' => [],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('Unsupported plugin action', $result['message']);
+    }
+
+    // ============================================================
+    // Unit tests: verifyCallback signature verification
+    // ============================================================
+
+    public function test_verify_callback_accepts_valid_signature(): void
+    {
+        $body = $this->callbackBody('VT202607041130001234ABCD');
+        $callback = $this->signCallback($body);
+
+        $plugin = new LeafFace;
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => $callback,
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertTrue($result['data']['passed']);
+        $this->assertSame(200, $result['data']['http_status']);
+        $this->assertSame('VT202607041130001234ABCD', $result['data']['certify_id']);
+        $this->assertNotSame('', $result['data']['replay_key']);
+    }
+
+    public function test_verify_callback_rejects_wrong_signature(): void
+    {
+        $body = $this->callbackBody('VT202607041130001234ABCD');
+        $callback = $this->signCallback($body);
+        $callback['headers']['x-leafsm-signature'] = str_repeat('0', 64);
+
+        $plugin = new LeafFace;
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => $callback,
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+        $this->assertSame(401, $result['data']['http_status']);
+    }
+
+    public function test_verify_callback_rejects_stale_timestamp(): void
+    {
+        $body = $this->callbackBody('VT202607041130001234ABCD');
+        $callback = $this->signCallback($body, gmdate('c', time() - 600));
+
+        $plugin = new LeafFace;
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => $callback,
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+        $this->assertSame(401, $result['data']['http_status']);
+    }
+
+    public function test_verify_callback_rejects_wrong_event(): void
+    {
+        $body = $this->callbackBody('VT202607041130001234ABCD');
+        $callback = $this->signCallback($body);
+        $callback['headers']['x-leafsm-event'] = 'unexpected.event';
+
+        $plugin = new LeafFace;
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => $callback,
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+        $this->assertSame(401, $result['data']['http_status']);
+    }
+
+    public function test_verify_callback_rejects_missing_signature_headers(): void
+    {
+        $body = $this->callbackBody('VT202607041130001234ABCD');
+
+        $plugin = new LeafFace;
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => [
+                'payload' => $body,
+                'headers' => [],
+                'raw_body' => json_encode($body),
+            ],
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+        $this->assertSame(401, $result['data']['http_status']);
+    }
+
+    public function test_verify_callback_rejects_tampered_body(): void
+    {
+        $body = $this->callbackBody('VT202607041130001234ABCD');
+        $callback = $this->signCallback($body);
+
+        $tamperedBody = $this->callbackBody('VT202607041130009999ZZZZ');
+        $tamperedRawBody = (string) json_encode($tamperedBody, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $callback['payload'] = $tamperedBody;
+        $callback['raw_body'] = $tamperedRawBody;
+        $callback['headers']['x-body-sha256'] = hash('sha256', $tamperedRawBody);
+
+        $plugin = new LeafFace;
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => $callback,
+            'config' => $this->defaultConfig(),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+        $this->assertSame(401, $result['data']['http_status']);
+    }
+
+    public function test_verify_callback_rejects_invalid_config(): void
+    {
+        $body = $this->callbackBody('VT202607041130001234ABCD');
+        $callback = $this->signCallback($body);
+
+        $plugin = new LeafFace;
+        $result = $plugin->execute([
+            'action' => 'certification.verify_callback',
+            'payload' => $callback,
+            'config' => [],
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['data']['passed']);
+    }
+
+    // ============================================================
+    // Unit tests: LeafFaceClient initialize
+    // ============================================================
+
+    public function test_initialize_rejects_non_identity_card(): void
+    {
+        $client = new LeafFaceClient($this->defaultConfig());
+
+        $result = $client->initialize('张三', '110101199001010011', 'PASSPORT', '');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('仅支持大陆身份证', $result['message']);
+    }
+
+    public function test_initialize_returns_mismatch_error(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks' => Http::response([
+                'code' => 'TWO_FACTOR_MISMATCH',
+                'message' => '姓名和身份证号不匹配',
+            ], 422),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->initialize('张三', '110101199001011234', 'IDENTITY_CARD', '');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('二要素预校验未通过', $result['message']);
+    }
+
+    public function test_initialize_returns_insufficient_credit_error(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks' => Http::response([
+                'code' => 'INSUFFICIENT_CREDIT',
+                'message' => 'insufficient credit',
+            ], 402),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->initialize('张三', '110101199001010011', 'IDENTITY_CARD', '');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('额度不足', $result['message']);
+    }
+
+    public function test_initialize_returns_error_when_task_creation_fails(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks' => Http::response([
+                'code' => 'TASK_CREATE_FAILED',
+                'message' => 'task create failed',
+            ], 500),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->initialize('张三', '110101199001010011', 'IDENTITY_CARD', '');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('任务创建失败', $result['message']);
+    }
+
+    public function test_initialize_returns_error_when_task_no_missing(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks' => Http::response([
+                'task_id' => '81a4e811-53dd-4302-aac1-a18c9a8e8583',
+            ], 200),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->initialize('张三', '110101199001010011', 'IDENTITY_CARD', '');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('联系管理员', $result['message']);
+    }
+
+    public function test_initialize_throws_when_app_id_missing(): void
+    {
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('AppId');
+
+        $client = new LeafFaceClient([
+            'app_secret' => 'test-app-secret',
+            'api_base_url' => 'https://face.ly-y.cn',
+        ]);
+        $client->initialize('张三', '110101199001010011', 'IDENTITY_CARD', '');
+    }
+
+    public function test_initialize_throws_when_app_secret_missing(): void
+    {
+        $this->expectException(BusinessException::class);
+        $this->expectExceptionMessage('AppSecret');
+
+        $client = new LeafFaceClient([
+            'app_id' => 'test-app-id',
+            'api_base_url' => 'https://face.ly-y.cn',
+        ]);
+        $client->initialize('张三', '110101199001010011', 'IDENTITY_CARD', '');
+    }
+
+    public function test_initialize_returns_error_on_http_failure(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks' => Http::response('not json', 500),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->initialize('张三', '110101199001010011', 'IDENTITY_CARD', '');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('联系管理员', $result['message']);
+    }
+
+    // ============================================================
+    // Unit tests: LeafFaceClient generateScanUrl
+    // ============================================================
+
+    public function test_generate_scan_url_rejects_empty_certify_id(): void
+    {
+        $client = new LeafFaceClient($this->defaultConfig());
+
+        $result = $client->generateScanUrl('');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('已失效', $result['message']);
+    }
+
+    public function test_generate_scan_url_rejects_missing_cached_verify_url(): void
+    {
+        $client = new LeafFaceClient($this->defaultConfig());
+
+        $result = $client->generateScanUrl('VT-NOT-CACHED');
+
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('认证链接已失效', $result['message']);
+    }
+
+    public function test_generate_scan_url_uses_full_verify_url_as_is(): void
+    {
+        Cache::put(
+            'leaf_face_verification:verify_url:'.hash('sha256', 'VT-ABS'),
+            'https://face.ly-y.cn/h5/face?task_id=81a4e811-53dd-4302-aac1-a18c9a8e8583',
+            now()->addMinute()
+        );
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->generateScanUrl('VT-ABS');
+
+        $this->assertSame(200, $result['status']);
+        $this->assertSame('https://face.ly-y.cn/h5/face?task_id=81a4e811-53dd-4302-aac1-a18c9a8e8583', $result['url']);
+    }
+
+    // ============================================================
+    // Unit tests: LeafFaceClient queryStatus
+    // ============================================================
+
+    public function test_query_status_rejects_empty_certify_id(): void
+    {
+        $client = new LeafFaceClient($this->defaultConfig());
+
+        $result = $client->queryStatus('');
+
+        $this->assertSame(2, $result['status']);
+        $this->assertStringContainsString('已失效', $result['message']);
+    }
+
+    public function test_query_status_returns_completed(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-COMPLETED' => Http::response([
+                'task' => ['task_no' => 'VT-COMPLETED', 'type' => 'h5_face', 'status' => 'completed'],
+                'order' => ['status' => 'completed', 'matched' => true],
+            ], 200),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-COMPLETED');
+
+        $this->assertSame(1, $result['status']);
+        $this->assertSame('审核通过', $result['message']);
+    }
+
+    public function test_query_status_returns_failed(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-FAILED' => Http::response([
+                'task' => ['task_no' => 'VT-FAILED', 'type' => 'h5_face', 'status' => 'failed'],
+            ], 200),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-FAILED');
+
+        $this->assertSame(2, $result['status']);
+        $this->assertStringContainsString('重新发起', $result['message']);
+    }
+
+    public function test_query_status_returns_pending_when_created(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-CREATED' => Http::response([
+                'task' => ['task_no' => 'VT-CREATED', 'type' => 'h5_face', 'status' => 'created'],
+            ], 200),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-CREATED');
+
+        $this->assertSame(4, $result['status']);
+        $this->assertSame('等待用户完成认证', $result['message']);
+    }
+
+    public function test_query_status_returns_failed_when_expired(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-EXPIRED' => Http::response([
+                'task' => ['task_no' => 'VT-EXPIRED', 'type' => 'h5_face', 'status' => 'expired'],
+            ], 200),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-EXPIRED');
+
+        $this->assertSame(2, $result['status']);
+        $this->assertStringContainsString('过期', $result['message']);
+    }
+
+    public function test_query_status_returns_failed_when_canceled(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-CANCELED' => Http::response([
+                'task' => ['task_no' => 'VT-CANCELED', 'type' => 'h5_face', 'status' => 'canceled'],
+            ], 200),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-CANCELED');
+
+        $this->assertSame(2, $result['status']);
+        $this->assertStringContainsString('取消', $result['message']);
+    }
+
+    public function test_query_status_returns_pending_when_task_not_found(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-MISSING' => Http::response([
+                'code' => 'TASK_NOT_FOUND',
+                'message' => 'task not found',
+            ], 404),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-MISSING');
+
+        $this->assertSame(4, $result['status']);
+    }
+
+    public function test_query_status_returns_error_on_unknown_status(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-UNKNOWN' => Http::response([
+                'task' => ['task_no' => 'VT-UNKNOWN', 'type' => 'h5_face', 'status' => 'weird'],
+            ], 200),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-UNKNOWN');
+
+        $this->assertSame(3, $result['status']);
+    }
+
+    public function test_query_status_returns_error_on_http_failure(): void
+    {
+        Http::fake([
+            'face.ly-y.cn/api/merchant/verify/tasks/VT-HTTP-FAIL' => Http::response('not json', 500),
+        ]);
+
+        $client = new LeafFaceClient($this->defaultConfig());
+        $result = $client->queryStatus('VT-HTTP-FAIL');
+
+        $this->assertSame(3, $result['status']);
+        $this->assertStringContainsString('请求失败', $result['message']);
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function defaultConfig(): array
+    {
+        return [
+            'app_id' => 'test-app-id',
+            'app_secret' => 'test-app-secret',
+            'api_base_url' => 'https://face.ly-y.cn',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function callbackBody(string $taskNo): array
+    {
+        return [
+            'task' => [
+                'id' => '81a4e811-53dd-4302-aac1-a18c9a8e8583',
+                'task_no' => $taskNo,
+                'status' => 'completed',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $body
+     * @return array{payload: array<string, mixed>, headers: array<string, string>, method: string, path: string, raw_body: string}
+     */
+    private function signCallback(array $body, ?string $timestamp = null, ?string $nonce = null): array
+    {
+        $timestamp ??= gmdate('c');
+        $nonce ??= bin2hex(random_bytes(16));
+        $rawBody = (string) json_encode($body, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $bodySha256 = hash('sha256', $rawBody);
+        $signature = hash_hmac('sha256', $timestamp."\n".$nonce."\n".$bodySha256, 'test-app-secret');
+
+        return [
+            'payload' => $body,
+            'headers' => [
+                'x-leafsm-timestamp' => $timestamp,
+                'x-leafsm-nonce' => $nonce,
+                'x-leafsm-signature' => $signature,
+                'x-body-sha256' => $bodySha256,
+                'x-leafsm-event' => 'verification.task.finished',
+            ],
+            'method' => 'POST',
+            'path' => 'api/v2/client/verification/callback',
+            'raw_body' => $rawBody,
+        ];
+    }
+
+    private function seedVerifyUrlCache(): void
+    {
+        Cache::put(
+            'leaf_face_verification:verify_url:'.hash('sha256', 'VT202607041130001234ABCD'),
+            '/h5/face?task_id=81a4e811-53dd-4302-aac1-a18c9a8e8583',
+            now()->addHour()
+        );
+    }
+
+    private function ensurePluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            Schema::create('integration_plugins', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->string('slug', 120);
+                $table->string('plugin_key', 120);
+                $table->string('name', 120);
+                $table->string('version', 32)->default('1.0.0');
+                $table->string('provider_class', 255)->nullable();
+                $table->string('entry_class', 255);
+                $table->json('capabilities_json')->nullable();
+                $table->json('config_schema_json')->nullable();
+                $table->unsignedTinyInteger('status')->default(0);
+                $table->timestamp('installed_at')->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'slug']);
+                $table->unique(['domain', 'plugin_key']);
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_configs')) {
+            Schema::create('integration_plugin_configs', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('plugin_id');
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->timestamps();
+                $table->unique('plugin_id');
+            });
+        }
+
+        if (! Schema::hasTable('integration_plugin_bindings')) {
+            Schema::create('integration_plugin_bindings', function (Blueprint $table): void {
+                $table->id();
+                $table->string('domain', 32);
+                $table->unsignedBigInteger('plugin_id');
+                $table->string('binding_type', 50);
+                $table->string('bindable_type', 120)->default('global');
+                $table->unsignedBigInteger('bindable_id')->default(0);
+                $table->string('binding_key', 120);
+                $table->string('provider_key', 120)->nullable();
+                $table->integer('priority')->default(0);
+                $table->unsignedTinyInteger('status')->default(1);
+                $table->json('config_json')->nullable();
+                $table->longText('secret_json')->nullable();
+                $table->json('has_secret_json')->nullable();
+                $table->json('runtime_policy_json')->nullable();
+                $table->unsignedBigInteger('created_by')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->string('backfill_batch_id', 64)->nullable();
+                $table->timestamps();
+                $table->unique(['domain', 'binding_type', 'bindable_type', 'bindable_id', 'binding_key'], 'plugin_bindings_unique');
+            });
+        }
+    }
+
+    private function cleanPluginTables(): void
+    {
+        if (! Schema::hasTable('integration_plugins')) {
+            return;
+        }
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (Schema::hasTable('integration_plugin_bindings')) {
+            DB::table('integration_plugin_bindings')->truncate();
+        }
+        if (Schema::hasTable('integration_plugin_configs')) {
+            DB::table('integration_plugin_configs')->truncate();
+        }
+        DB::table('integration_plugins')->truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+}

--- a/frontend-admin-v3/src/api/admin/plugins.ts
+++ b/frontend-admin-v3/src/api/admin/plugins.ts
@@ -96,6 +96,32 @@ export interface IntegrationPluginActionResult {
   detail?: Record<string, unknown>;
 }
 
+export interface IntegrationPluginTestResultData {
+  success?: boolean;
+  action?: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  verify_url?: string;
+  task_no?: string;
+  qr_code?: string;
+  out_trade_no?: string;
+  verified?: boolean;
+  healthy?: boolean;
+  capability?: string;
+  error_type?: string;
+}
+
+export interface IntegrationPluginTestResult {
+  id?: number | string;
+  status?: string;
+  task_id?: string;
+  message?: string;
+  detail?: {
+    type?: string;
+    result?: IntegrationPluginTestResultData;
+  };
+}
+
 export interface IntegrationPluginListResponse {
   list?: IntegrationPluginRecord[];
   total?: number;
@@ -198,7 +224,7 @@ export const pluginsApi = {
       url: `/v2/admin/integration-plugins/${id}${force ? '?force=1' : ''}`,
     }),
   healthCheck: (id: number | string) =>
-    request.post<IntegrationPluginActionResult>({
+    request.post<IntegrationPluginTestResult>({
       url: `/v2/admin/integration-plugins/${id}/tasks`,
       data: { type: 'health_check' },
     }),
@@ -211,5 +237,33 @@ export const pluginsApi = {
     request.post<IntegrationPluginActionResult>({
       url: `/v2/admin/integration-plugins/${id}/tasks`,
       data: { type: 'test_sms', payload: data },
+    }),
+  testVerification: (id: number | string, data: { real_name: string; card_no: string }) =>
+    request.post<IntegrationPluginTestResult>({
+      url: `/v2/admin/integration-plugins/${id}/tasks`,
+      data: { type: 'test_verification', payload: data },
+    }),
+  testPayment: (id: number | string) =>
+    request.post<IntegrationPluginTestResult>({
+      url: `/v2/admin/integration-plugins/${id}/tasks`,
+      data: { type: 'test_payment', payload: {} },
+    }),
+  testCaptcha: (
+    id: number | string,
+    data: {
+      lot_number: string;
+      captcha_output: string;
+      pass_token: string;
+      gen_time: string;
+    },
+  ) =>
+    request.post<IntegrationPluginTestResult>({
+      url: `/v2/admin/integration-plugins/${id}/tasks`,
+      data: { type: 'test_captcha', payload: data },
+    }),
+  testConnection: (id: number | string) =>
+    request.post<IntegrationPluginTestResult>({
+      url: `/v2/admin/integration-plugins/${id}/tasks`,
+      data: { type: 'test_connection', payload: {} },
     }),
 };

--- a/frontend-admin-v3/src/api/admin/plugins.ts
+++ b/frontend-admin-v3/src/api/admin/plugins.ts
@@ -101,6 +101,10 @@ export interface IntegrationPluginTestResultData {
   action?: string;
   message?: string;
   data?: Record<string, unknown>;
+  raw?: Record<string, unknown>;
+  status?: number;
+  sent?: boolean;
+  certify_id?: string;
   verify_url?: string;
   task_no?: string;
   qr_code?: string;
@@ -109,6 +113,11 @@ export interface IntegrationPluginTestResultData {
   healthy?: boolean;
   capability?: string;
   error_type?: string;
+  amount?: number | string;
+  provider?: string;
+  entry_class?: string;
+  provider_class?: string;
+  trace_id?: string;
 }
 
 export interface IntegrationPluginTestResult {
@@ -229,12 +238,12 @@ export const pluginsApi = {
       data: { type: 'health_check' },
     }),
   testEmail: (id: number | string, data: { account_index: number; to: string }) =>
-    request.post<IntegrationPluginActionResult>({
+    request.post<IntegrationPluginTestResult>({
       url: `/v2/admin/integration-plugins/${id}/tasks`,
       data: { type: 'test_email', payload: data },
     }),
   testSms: (id: number | string, data: { phone: string }) =>
-    request.post<IntegrationPluginActionResult>({
+    request.post<IntegrationPluginTestResult>({
       url: `/v2/admin/integration-plugins/${id}/tasks`,
       data: { type: 'test_sms', payload: data },
     }),

--- a/frontend-admin-v3/src/hooks/useGeeTestCaptcha.ts
+++ b/frontend-admin-v3/src/hooks/useGeeTestCaptcha.ts
@@ -163,8 +163,10 @@ export function useGeeTestCaptcha() {
 
   let captchaObj: CaptchaInstance | null = null;
   let initPromise: Promise<CaptchaInstance | null> | null = null;
+  let initRejecter: ((error: Error) => void) | null = null;
   let pendingResolver: ((value: unknown) => void) | null = null;
   let pendingRejecter: ((error: Error) => void) | null = null;
+  let destroyed = false;
 
   const clearPending = () => {
     pendingResolver = null;
@@ -199,6 +201,10 @@ export function useGeeTestCaptcha() {
   const initCaptcha = async (): Promise<CaptchaInstance | null> => {
     const config = await getCaptchaConfig();
 
+    if (destroyed) {
+      throw new Error('行为验证组件已卸载');
+    }
+
     if (!config.enabled || !config.captcha_id) {
       throw new Error('行为验证当前不可用，请检查人机验证插件配置');
     }
@@ -226,6 +232,9 @@ export function useGeeTestCaptcha() {
     for (const candidate of candidates) {
       try {
         initGeetest4 = await loadGeeTestScript(candidate.url, candidate.key);
+        if (destroyed) {
+          throw new Error('行为验证组件已卸载');
+        }
         break;
       } catch (error) {
         lastError = error;
@@ -235,7 +244,8 @@ export function useGeeTestCaptcha() {
     if (!initGeetest4) {
       throw lastError instanceof Error ? lastError : new Error('GeeTest 脚本加载失败');
     }
-    initPromise = new Promise((resolve, reject) => {
+    const currentInitPromise = new Promise<CaptchaInstance | null>((resolve, reject) => {
+      initRejecter = reject;
       try {
         initGeetest4?.(
           {
@@ -244,8 +254,16 @@ export function useGeeTestCaptcha() {
             language: 'zho',
           },
           (instance) => {
+            if (destroyed) {
+              reject(new Error('行为验证组件已卸载'));
+              return;
+            }
+
             captchaObj = instance;
-            const markReady = () => resolve(instance);
+            const markReady = () => {
+              initRejecter = null;
+              resolve(instance);
+            };
 
             if (typeof instance.onReady === 'function') {
               instance.onReady(markReady);
@@ -263,11 +281,20 @@ export function useGeeTestCaptcha() {
           },
         );
       } catch (error) {
+        initRejecter = null;
         reject(error instanceof Error ? error : new Error('行为验证初始化失败'));
       }
     });
 
-    return initPromise;
+    initPromise = currentInitPromise;
+    try {
+      return await currentInitPromise;
+    } catch (error) {
+      if (initPromise === currentInitPromise) {
+        initPromise = null;
+      }
+      throw error;
+    }
   };
 
   const verify = async () => {
@@ -301,6 +328,9 @@ export function useGeeTestCaptcha() {
   };
 
   const cleanup = () => {
+    destroyed = true;
+    initRejecter?.(new Error('行为验证组件已卸载'));
+    initRejecter = null;
     if (captchaObj) {
       captchaObj.destroy?.();
       captchaObj = null;

--- a/frontend-admin-v3/src/hooks/useGeeTestCaptcha.ts
+++ b/frontend-admin-v3/src/hooks/useGeeTestCaptcha.ts
@@ -1,0 +1,306 @@
+import { ref } from 'vue';
+
+import { request } from '@/utils/request';
+
+interface GeeTestConfig {
+  enabled: boolean;
+  captcha_id: string;
+  script_url?: string;
+}
+
+interface CaptchaInstance {
+  onReady?: (callback: () => void) => void;
+  onSuccess?: (callback: () => void) => void;
+  onError?: (callback: (error: unknown) => void) => void;
+  onClose?: (callback: () => void) => void;
+  showCaptcha?: () => void;
+  validate?: () => unknown;
+  getValidate?: () => unknown;
+  getVerifyResult?: () => unknown;
+  reset?: () => void;
+  destroy?: () => void;
+}
+
+type GeeTestInitializer = NonNullable<Window['initGeetest4']>;
+
+declare global {
+  interface Window {
+    initGeetest4?: (options: Record<string, unknown>, callback: (instance: CaptchaInstance) => void) => void;
+    __TURA_GEETEST_FALLBACK__?: boolean;
+  }
+}
+
+const defaultConfig: GeeTestConfig = {
+  enabled: false,
+  captcha_id: '',
+  script_url: 'https://static.geetest.com/v4/gt4.js',
+};
+
+let captchaConfigPromise: Promise<GeeTestConfig> | null = null;
+let geetestScriptPromise: Promise<GeeTestInitializer> | null = null;
+
+async function getCaptchaConfig() {
+  if (!captchaConfigPromise) {
+    captchaConfigPromise = request
+      .get<GeeTestConfig>({ url: '/v2/client/auth/captcha-config' })
+      .then((response: unknown) => {
+        const config = { ...defaultConfig, ...(response as GeeTestConfig) };
+        if (!config.enabled || !config.captcha_id) {
+          throw new Error('人机验证插件未启用或配置不完整');
+        }
+
+        return config;
+      })
+      .catch((error: unknown) => {
+        captchaConfigPromise = null;
+        const message = error instanceof Error ? error.message : '人机验证配置请求失败';
+        throw new Error(`人机验证配置加载失败：${message}`);
+      });
+  }
+
+  return captchaConfigPromise;
+}
+
+function resolveScriptUrl(src: string) {
+  const raw = src.trim();
+  if (!raw) return '';
+
+  try {
+    const apiBaseUrl = String(import.meta.env.VITE_API_BASE_URL || '').trim();
+    if (/^\/(?!\/)/.test(raw) && apiBaseUrl) {
+      const apiUrl = new URL(apiBaseUrl);
+      return `${apiUrl.origin}${raw}`;
+    }
+
+    return new URL(raw, apiBaseUrl || window.location.origin).toString();
+  } catch {
+    return raw;
+  }
+}
+
+function appendScriptCacheKey(src: string, cacheKey: string) {
+  try {
+    const url = new URL(src);
+    url.searchParams.set('_captcha_key', cacheKey);
+    return url.toString();
+  } catch {
+    return src;
+  }
+}
+
+function loadGeeTestScript(src: string, cacheKey: string): Promise<GeeTestInitializer> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('浏览器环境不可用'));
+  }
+
+  const scriptUrl = appendScriptCacheKey(resolveScriptUrl(src), cacheKey);
+  if (!scriptUrl) {
+    return Promise.reject(new Error('GeeTest 脚本地址为空'));
+  }
+
+  const existing = document.querySelector<HTMLScriptElement>('script[data-geetest-script="gt4"]');
+  if (existing && existing.dataset.captchaKey !== cacheKey) {
+    existing.remove();
+    window.initGeetest4 = undefined;
+    geetestScriptPromise = null;
+  }
+
+  if (window.initGeetest4 && (!existing || existing.dataset.captchaKey === cacheKey)) {
+    return Promise.resolve(window.initGeetest4 as GeeTestInitializer);
+  }
+
+  if (!geetestScriptPromise) {
+    geetestScriptPromise = new Promise<GeeTestInitializer>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      script.defer = true;
+      script.dataset.geetestScript = 'gt4';
+      script.dataset.captchaKey = cacheKey;
+      const timeout = window.setTimeout(() => {
+        script.remove();
+        reject(new Error(`GeeTest 脚本加载超时：${scriptUrl}`));
+      }, 15000);
+      script.onload = () => {
+        window.clearTimeout(timeout);
+        if (window.__TURA_GEETEST_FALLBACK__) {
+          reject(new Error(`GeeTest 代理脚本不可用：${scriptUrl}`));
+          return;
+        }
+
+        if (typeof window.initGeetest4 !== 'function') {
+          reject(new Error(`GeeTest 脚本未提供初始化方法：${scriptUrl}`));
+          return;
+        }
+
+        resolve(window.initGeetest4 as GeeTestInitializer);
+      };
+      script.onerror = () => {
+        window.clearTimeout(timeout);
+        reject(new Error(`GeeTest 脚本加载失败：${scriptUrl}`));
+      };
+      document.head.appendChild(script);
+    }).catch((error: unknown) => {
+      geetestScriptPromise = null;
+      const failed = document.querySelector<HTMLScriptElement>('script[data-geetest-script="gt4"]');
+      failed?.remove();
+      window.initGeetest4 = undefined;
+      window.__TURA_GEETEST_FALLBACK__ = false;
+      throw error;
+    });
+  }
+
+  return geetestScriptPromise;
+}
+
+/**
+ * 管理端极验弹窗验证。用于插件测试：真人完成一次行为验证后，
+ * 把 getValidate() 结果交给后端走完整验证链路。
+ */
+export function useGeeTestCaptcha() {
+  const loading = ref(false);
+
+  let captchaObj: CaptchaInstance | null = null;
+  let initPromise: Promise<CaptchaInstance | null> | null = null;
+  let pendingResolver: ((value: unknown) => void) | null = null;
+  let pendingRejecter: ((error: Error) => void) | null = null;
+
+  const clearPending = () => {
+    pendingResolver = null;
+    pendingRejecter = null;
+    loading.value = false;
+  };
+
+  const rejectPending = (error: Error) => {
+    pendingRejecter?.(error);
+    clearPending();
+  };
+
+  const readCaptchaResult = (instance: CaptchaInstance) => {
+    if (typeof instance.getValidate === 'function') {
+      return instance.getValidate();
+    }
+
+    if (typeof instance.getVerifyResult === 'function') {
+      return instance.getVerifyResult();
+    }
+
+    return null;
+  };
+
+  const resolveSuccess = (instance: CaptchaInstance) => {
+    const result = readCaptchaResult(instance);
+    instance.reset?.();
+    pendingResolver?.(result);
+    clearPending();
+  };
+
+  const initCaptcha = async (): Promise<CaptchaInstance | null> => {
+    const config = await getCaptchaConfig();
+
+    if (!config.enabled || !config.captcha_id) {
+      throw new Error('行为验证当前不可用，请检查人机验证插件配置');
+    }
+
+    if (captchaObj) {
+      return captchaObj;
+    }
+
+    if (initPromise) {
+      return initPromise;
+    }
+
+    const proxyUrl = resolveScriptUrl(config.script_url || '');
+    const directUrl = defaultConfig.script_url || '';
+    const candidates =
+      proxyUrl && proxyUrl !== directUrl
+        ? [
+            { url: directUrl, key: `${config.captcha_id}:direct` },
+            { url: proxyUrl, key: config.captcha_id },
+          ]
+        : [{ url: directUrl, key: `${config.captcha_id}:direct` }];
+    let initGeetest4: typeof window.initGeetest4;
+    let lastError: unknown = null;
+
+    for (const candidate of candidates) {
+      try {
+        initGeetest4 = await loadGeeTestScript(candidate.url, candidate.key);
+        break;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    if (!initGeetest4) {
+      throw lastError instanceof Error ? lastError : new Error('GeeTest 脚本加载失败');
+    }
+    initPromise = new Promise((resolve, reject) => {
+      try {
+        initGeetest4?.(
+          {
+            captchaId: config.captcha_id,
+            product: 'bind',
+            language: 'zho',
+          },
+          (instance) => {
+            captchaObj = instance;
+            const markReady = () => resolve(instance);
+
+            if (typeof instance.onReady === 'function') {
+              instance.onReady(markReady);
+            } else {
+              markReady();
+            }
+
+            instance.onSuccess?.(() => resolveSuccess(instance));
+            instance.onError?.((error) => {
+              rejectPending(new Error(error instanceof Error ? error.message : String(error || '行为验证失败')));
+            });
+            instance.onClose?.(() => {
+              rejectPending(new Error('请先完成行为验证'));
+            });
+          },
+        );
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error('行为验证初始化失败'));
+      }
+    });
+
+    return initPromise;
+  };
+
+  const verify = async () => {
+    const instance = await initCaptcha();
+    if (!instance) {
+      throw new Error('行为验证组件初始化失败，请稍后重试');
+    }
+
+    loading.value = true;
+
+    return new Promise((resolve, reject) => {
+      pendingResolver = resolve;
+      pendingRejecter = reject;
+
+      try {
+        if (typeof instance.showCaptcha === 'function') {
+          instance.showCaptcha();
+        } else if (typeof instance.validate === 'function') {
+          Promise.resolve(instance.validate())
+            .then(() => resolveSuccess(instance))
+            .catch((error: unknown) => {
+              rejectPending(new Error(error instanceof Error ? error.message : String(error || '行为验证失败')));
+            });
+        } else {
+          rejectPending(new Error('行为验证组件版本不兼容，请刷新页面后重试'));
+        }
+      } catch (error) {
+        rejectPending(new Error(error instanceof Error ? error.message : '行为验证打开失败'));
+      }
+    });
+  };
+
+  return {
+    loading,
+    verify,
+  };
+}

--- a/frontend-admin-v3/src/hooks/useGeeTestCaptcha.ts
+++ b/frontend-admin-v3/src/hooks/useGeeTestCaptcha.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue';
+import { onScopeDispose } from 'vue';
 
 import { request } from '@/utils/request';
 
@@ -215,8 +216,8 @@ export function useGeeTestCaptcha() {
     const candidates =
       proxyUrl && proxyUrl !== directUrl
         ? [
-            { url: directUrl, key: `${config.captcha_id}:direct` },
             { url: proxyUrl, key: config.captcha_id },
+            { url: directUrl, key: `${config.captcha_id}:direct` },
           ]
         : [{ url: directUrl, key: `${config.captcha_id}:direct` }];
     let initGeetest4: typeof window.initGeetest4;
@@ -298,6 +299,17 @@ export function useGeeTestCaptcha() {
       }
     });
   };
+
+  const cleanup = () => {
+    if (captchaObj) {
+      captchaObj.destroy?.();
+      captchaObj = null;
+    }
+    initPromise = null;
+    rejectPending(new Error('行为验证组件已卸载'));
+  };
+
+  onScopeDispose(cleanup);
 
   return {
     loading,

--- a/frontend-admin-v3/src/pages/integration-plugins/index.less
+++ b/frontend-admin-v3/src/pages/integration-plugins/index.less
@@ -328,6 +328,13 @@
   margin-top: 4px;
 }
 
+.plugin-config-loading {
+  display: flex;
+  min-height: 240px;
+  align-items: center;
+  justify-content: center;
+}
+
 .plugin-test-section__header {
   margin-bottom: 12px;
 
@@ -343,4 +350,34 @@
   margin-top: 4px;
   color: var(--td-text-color-placeholder);
   font-size: var(--td-font-size-size-1, 12px);
+}
+
+.plugin-test-result {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid var(--td-component-border);
+  border-radius: var(--td-radius-default, 6px);
+  background: var(--td-bg-color-container-hover, rgba(0, 0, 0, 0.02));
+}
+
+.plugin-test-result__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+
+  & + .plugin-test-result__item {
+    margin-top: 8px;
+  }
+}
+
+.plugin-test-result__label {
+  flex-shrink: 0;
+  color: var(--td-text-color-secondary);
+  font-size: var(--td-font-size-size-1, 12px);
+}
+
+.plugin-test-result__value {
+  flex: 1;
+  min-width: 0;
 }

--- a/frontend-admin-v3/src/pages/integration-plugins/index.vue
+++ b/frontend-admin-v3/src/pages/integration-plugins/index.vue
@@ -754,13 +754,13 @@ async function healthCheck(plugin: IntegrationPluginRecord) {
 
     MessagePlugin.success(String(result.message || '插件加载正常'));
     if (supportsSystemTest(plugin.domain)) {
-      await openTest(plugin);
+      await openTest(plugin, sequence);
     }
   });
 }
 
 function supportsSystemTest(domain: IntegrationPluginDomain) {
-  return ['mail', 'sms', 'verification', 'payment', 'captcha'].includes(domain);
+  return ['mail', 'sms', 'verification', 'payment', 'captcha', 'upstream'].includes(domain);
 }
 
 async function openConfig(plugin: IntegrationPluginRecord) {
@@ -783,10 +783,11 @@ async function openConfig(plugin: IntegrationPluginRecord) {
   }
 }
 
-async function openTest(plugin: IntegrationPluginRecord) {
+async function openTest(plugin: IntegrationPluginRecord, sequence?: number) {
   if (!plugin.id) return;
   try {
     const detail = await pluginsApi.detail(plugin.id);
+    if (sequence !== undefined && sequence !== healthCheckSequence.value) return;
     if (String(detail.id ?? '') !== String(plugin.id)) return;
     currentPlugin.value = detail;
     resetTestResults();
@@ -1344,7 +1345,21 @@ async function sendTestSms() {
 }
 
 function readTestResult(response: IntegrationPluginTestResult) {
-  return response?.detail?.result || null;
+  const raw = response?.detail?.result;
+  if (!raw) return null;
+
+  const data = raw.data && typeof raw.data === 'object' ? raw.data : {};
+  const source = { ...data, ...raw };
+  const rawData = source.raw && typeof source.raw === 'object' ? source.raw : {};
+  const certifyId = String(source.certify_id || '');
+  const taskNo = String(source.task_no || rawData.task_no || certifyId || '');
+
+  return {
+    ...source,
+    message: String(source.message || data.message || response.message || ''),
+    task_no: taskNo || undefined,
+    verify_url: String(source.verify_url || rawData.verify_url || '') || undefined,
+  } as IntegrationPluginTestResultData;
 }
 
 async function runVerificationTest() {

--- a/frontend-admin-v3/src/pages/integration-plugins/index.vue
+++ b/frontend-admin-v3/src/pages/integration-plugins/index.vue
@@ -103,7 +103,7 @@
       v-model:visible="configVisible"
       size="560px"
       :header="currentPlugin ? `${currentPlugin.name} 管理` : '插件管理'"
-      :confirm-btn="canManagePlugins ? { content: '保存配置', loading: savingConfig } : null"
+      :confirm-btn="canManagePlugins ? { content: '保存配置', loading: savingConfig, disabled: configLoading } : null"
       cancel-btn="关闭"
       @confirm="saveConfig"
     >
@@ -626,6 +626,12 @@ watch(
   },
 );
 
+watch(testVisible, (visible) => {
+  if (!visible) {
+    resetTestResults();
+  }
+});
+
 async function loadPlugins() {
   loading.value = true;
   try {
@@ -797,6 +803,8 @@ function resetTestResults() {
   connectionTestResult.value = null;
   verificationTestForm.real_name = '';
   verificationTestForm.card_no = '';
+  smsTestPhone.value = '';
+  systemEmailTestTo.value = '';
 }
 
 async function openSystemEmailTest() {
@@ -826,6 +834,10 @@ async function openSystemEmailTest() {
 async function saveConfig() {
   if (!canManagePlugins.value) {
     MessagePlugin.warning('当前账号无插件管理权限');
+    return;
+  }
+
+  if (configLoading.value) {
     return;
   }
 
@@ -1357,6 +1369,7 @@ async function runVerificationTest() {
     verificationTestResult.value = result;
     if (result?.success) {
       MessagePlugin.success(result.message || '测试任务创建成功');
+      verificationTestForm.card_no = '';
     } else {
       MessagePlugin.error(result?.message || '测试任务创建失败');
     }

--- a/frontend-admin-v3/src/pages/integration-plugins/index.vue
+++ b/frontend-admin-v3/src/pages/integration-plugins/index.vue
@@ -107,7 +107,10 @@
       cancel-btn="关闭"
       @confirm="saveConfig"
     >
-      <template v-if="currentPlugin">
+      <div v-if="configLoading" class="plugin-config-loading">
+        <t-loading text="正在加载插件配置" />
+      </div>
+      <template v-else-if="currentPlugin">
         <div class="plugin-detail">
           <dl>
             <div>
@@ -282,20 +285,147 @@
             </t-form-item>
           </template>
         </t-form>
+      </template>
+    </t-drawer>
 
-        <div v-if="canTestPlugins && currentPlugin.domain === 'sms'" class="plugin-test-section">
-          <t-divider />
+    <t-dialog
+      v-model:visible="testVisible"
+      width="560px"
+      :header="currentPlugin ? `${currentPlugin.name} 测试` : '插件测试'"
+      cancel-btn="关闭"
+    >
+      <template v-if="currentPlugin">
+        <div v-if="currentPlugin.domain === 'sms'" class="plugin-test-section">
           <div class="plugin-test-section__header">
             <strong>发送测试短信</strong>
-            <span class="plugin-test-section__hint">向指定手机号发送一条验证码测试短信</span>
+            <span class="plugin-test-section__hint">通过系统短信驱动发送一条验证码测试短信</span>
           </div>
           <t-space direction="vertical" style="width: 100%">
             <t-input v-model="smsTestPhone" placeholder="请输入手机号码" maxlength="20" />
-            <t-button block variant="outline" :loading="smsTesting" @click="sendTestSms"> 发送测试短信 </t-button>
+            <t-button block variant="outline" :loading="smsTesting" @click="sendTestSms">发送测试短信</t-button>
           </t-space>
         </div>
+
+        <div v-else-if="currentPlugin.domain === 'mail'" class="plugin-test-section">
+          <div class="plugin-test-section__header">
+            <strong>发送测试邮件</strong>
+            <span class="plugin-test-section__hint">通过系统邮件驱动发送一封验证码测试邮件</span>
+          </div>
+          <t-space direction="vertical" style="width: 100%">
+            <t-input v-model="systemEmailTestTo" placeholder="请输入收件人邮箱" type="email" />
+            <t-button block variant="outline" :loading="emailTesting" @click="openSystemEmailTest"
+              >发送测试邮件</t-button
+            >
+          </t-space>
+        </div>
+
+        <div v-else-if="currentPlugin.domain === 'verification'" class="plugin-test-section">
+          <div class="plugin-test-section__header">
+            <strong>创建测试认证任务</strong>
+            <span class="plugin-test-section__hint">将真实创建一条认证任务，测试结果只返回不保存</span>
+          </div>
+          <t-space direction="vertical" style="width: 100%">
+            <t-input v-model="verificationTestForm.real_name" placeholder="请输入测试姓名" maxlength="64" />
+            <t-input v-model="verificationTestForm.card_no" placeholder="请输入测试身份证号" maxlength="32" />
+            <t-button block variant="outline" :loading="verificationTesting" @click="runVerificationTest"
+              >创建测试任务</t-button
+            >
+          </t-space>
+          <div v-if="verificationTestResult" class="plugin-test-result">
+            <div class="plugin-test-result__item">
+              <span class="plugin-test-result__label">认证链接</span>
+              <t-input
+                :model-value="String(verificationTestResult.verify_url || '')"
+                readonly
+                class="plugin-test-result__value"
+              />
+              <t-button variant="text" @click="copyText(String(verificationTestResult.verify_url || ''))"
+                >复制</t-button
+              >
+            </div>
+            <div v-if="verificationTestResult.task_no" class="plugin-test-result__item">
+              <span class="plugin-test-result__label">任务编号</span>
+              <span>{{ verificationTestResult.task_no }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div v-else-if="currentPlugin.domain === 'payment'" class="plugin-test-section">
+          <div class="plugin-test-section__header">
+            <strong>创建测试支付订单</strong>
+            <span class="plugin-test-section__hint">真实创建一笔 0.01 元测试订单，测试结果只返回不保存</span>
+          </div>
+          <t-button block variant="outline" :loading="paymentTesting" @click="runPaymentTest"
+            >创建 0.01 元测试订单</t-button
+          >
+          <div v-if="paymentTestResult" class="plugin-test-result">
+            <div class="plugin-test-result__item">
+              <span class="plugin-test-result__label">支付链接</span>
+              <t-input
+                :model-value="String(paymentTestResult.qr_code || '')"
+                readonly
+                class="plugin-test-result__value"
+              />
+              <t-button variant="text" @click="copyText(String(paymentTestResult.qr_code || ''))">复制</t-button>
+            </div>
+            <div v-if="paymentTestResult.out_trade_no" class="plugin-test-result__item">
+              <span class="plugin-test-result__label">测试单号</span>
+              <span>{{ paymentTestResult.out_trade_no }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div v-else-if="currentPlugin.domain === 'captcha'" class="plugin-test-section">
+          <div class="plugin-test-section__header">
+            <strong>真人验证测试</strong>
+            <span class="plugin-test-section__hint">弹出验证码由管理员真人完成，走完整验证链路</span>
+          </div>
+          <t-button block variant="outline" :loading="captchaTesting" @click="runCaptchaTest"
+            >弹出验证码并测试</t-button
+          >
+          <div v-if="captchaTestResult" class="plugin-test-result">
+            <div class="plugin-test-result__item">
+              <span class="plugin-test-result__label">验证结果</span>
+              <t-tag :theme="captchaTestResult.verified ? 'success' : 'danger'" variant="light">
+                {{ captchaTestResult.verified ? '验证通过' : '验证失败' }}
+              </t-tag>
+            </div>
+            <div v-if="captchaTestResult.message" class="plugin-test-result__item">
+              <span>{{ captchaTestResult.message }}</span>
+            </div>
+            <div v-if="captchaTestResult.error_type" class="plugin-test-result__item">
+              <span class="plugin-test-result__label">诊断</span>
+              <span>{{ captchaTestResult.error_type }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div v-else-if="currentPlugin.domain === 'upstream'" class="plugin-test-section">
+          <div class="plugin-test-section__header">
+            <strong>连接测试</strong>
+            <span class="plugin-test-section__hint">解析插件声明的第一个能力，验证上游插件加载正常</span>
+          </div>
+          <t-button block variant="outline" :loading="connectionTesting" @click="runConnectionTest"
+            >开始连接测试</t-button
+          >
+          <div v-if="connectionTestResult" class="plugin-test-result">
+            <div class="plugin-test-result__item">
+              <span class="plugin-test-result__label">连接状态</span>
+              <t-tag :theme="connectionTestResult.healthy ? 'success' : 'danger'" variant="light">
+                {{ connectionTestResult.healthy ? '连接正常' : '连接异常' }}
+              </t-tag>
+            </div>
+            <div v-if="connectionTestResult.capability" class="plugin-test-result__item">
+              <span class="plugin-test-result__label">能力</span>
+              <span>{{ connectionTestResult.capability }}</span>
+            </div>
+            <div v-if="connectionTestResult.message" class="plugin-test-result__item">
+              <span>{{ connectionTestResult.message }}</span>
+            </div>
+          </div>
+        </div>
       </template>
-    </t-drawer>
+    </t-dialog>
 
     <t-dialog
       v-model:visible="smtpAccountDialogVisible"
@@ -377,10 +507,13 @@ import type {
   IntegrationPluginConfigSchema,
   IntegrationPluginDomain,
   IntegrationPluginRecord,
+  IntegrationPluginTestResult,
+  IntegrationPluginTestResultData,
 } from '@/api/admin/plugins';
 import { pluginsApi } from '@/api/admin/plugins';
 import SecretInput from '@/components/secret-input/index.vue';
 import { AdminPermissions } from '@/constants/permissions';
+import { useGeeTestCaptcha } from '@/hooks/useGeeTestCaptcha';
 import { hasAdminPermission } from '@/utils/permission';
 import { errorMessage } from '@/utils/userMessage';
 
@@ -417,6 +550,9 @@ const scanning = ref(false);
 const savingConfig = ref(false);
 const actionLoading = ref('');
 const configVisible = ref(false);
+const configLoading = ref(false);
+const testVisible = ref(false);
+const healthCheckSequence = ref(0);
 const currentPlugin = ref<IntegrationPluginRecord | null>(null);
 const configForm = reactive<Record<string, any>>({});
 const smtpAccountDialogVisible = ref(false);
@@ -441,6 +577,7 @@ const emailTestVisible = ref(false);
 const emailTesting = ref(false);
 const testingAccountIndex = ref(-1);
 const emailTestForm = reactive({ to: '' });
+const systemEmailTestTo = ref('');
 const emailTestErrors = reactive<Record<'to', string>>({
   to: '',
 });
@@ -452,6 +589,16 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/;
 const smsTestPhone = ref('');
 const smsTesting = ref(false);
 const smtpAccountPasswordEdited = ref(false);
+const verificationTestForm = reactive({ real_name: '', card_no: '' });
+const verificationTesting = ref(false);
+const verificationTestResult = ref<IntegrationPluginTestResultData | null>(null);
+const paymentTesting = ref(false);
+const paymentTestResult = ref<IntegrationPluginTestResultData | null>(null);
+const captchaTesting = ref(false);
+const captchaTestResult = ref<IntegrationPluginTestResultData | null>(null);
+const connectionTesting = ref(false);
+const connectionTestResult = ref<IntegrationPluginTestResultData | null>(null);
+const { verify: openCaptchaVerify } = useGeeTestCaptcha();
 const MASKED_SECRET_VALUE = '********';
 const visibleSecretKeys = reactive<Record<string, boolean>>({});
 const loadedSecretValues = reactive<Record<string, string>>({});
@@ -589,21 +736,90 @@ function deletePlugin(plugin: IntegrationPluginRecord) {
 async function healthCheck(plugin: IntegrationPluginRecord) {
   if (!canTestPlugins.value) return;
   if (!plugin.id) return;
+  const sequence = ++healthCheckSequence.value;
   await runAction(plugin, 'health', async () => {
     const result = await pluginsApi.healthCheck(plugin.id as string | number);
+    if (sequence !== healthCheckSequence.value) return;
+    const healthy = result.detail?.result?.healthy !== false;
+    if (!healthy) {
+      MessagePlugin.error(String(result.message || '插件检测失败'));
+      return;
+    }
+
     MessagePlugin.success(String(result.message || '插件加载正常'));
+    if (supportsSystemTest(plugin.domain)) {
+      await openTest(plugin);
+    }
   });
+}
+
+function supportsSystemTest(domain: IntegrationPluginDomain) {
+  return ['mail', 'sms', 'verification', 'payment', 'captcha'].includes(domain);
 }
 
 async function openConfig(plugin: IntegrationPluginRecord) {
   if (!plugin.id) return;
+
+  currentPlugin.value = plugin;
+  fillConfigForm(plugin);
+  resetTestResults();
+  configLoading.value = true;
+  configVisible.value = true;
+
   try {
     const detail = await pluginsApi.detail(plugin.id);
     currentPlugin.value = detail;
     fillConfigForm(detail);
-    configVisible.value = true;
   } catch (error) {
     MessagePlugin.error(errorMessage(error, '加载插件配置失败'));
+  } finally {
+    configLoading.value = false;
+  }
+}
+
+async function openTest(plugin: IntegrationPluginRecord) {
+  if (!plugin.id) return;
+  try {
+    const detail = await pluginsApi.detail(plugin.id);
+    if (String(detail.id ?? '') !== String(plugin.id)) return;
+    currentPlugin.value = detail;
+    resetTestResults();
+    testVisible.value = true;
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '加载插件测试失败'));
+  }
+}
+
+function resetTestResults() {
+  verificationTestResult.value = null;
+  paymentTestResult.value = null;
+  captchaTestResult.value = null;
+  connectionTestResult.value = null;
+  verificationTestForm.real_name = '';
+  verificationTestForm.card_no = '';
+}
+
+async function openSystemEmailTest() {
+  const to = systemEmailTestTo.value.trim();
+  if (!to || !EMAIL_PATTERN.test(to)) {
+    MessagePlugin.error('请输入正确的收件人邮箱');
+    return;
+  }
+
+  if (!currentPlugin.value?.id) return;
+
+  emailTesting.value = true;
+  try {
+    await pluginsApi.testEmail(currentPlugin.value.id, {
+      account_index: 0,
+      to,
+    });
+    MessagePlugin.success('测试邮件发送成功');
+    systemEmailTestTo.value = '';
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '测试邮件发送失败'));
+  } finally {
+    emailTesting.value = false;
   }
 }
 
@@ -1112,6 +1328,129 @@ async function sendTestSms() {
     MessagePlugin.error(errorMessage(error, '测试短信发送失败'));
   } finally {
     smsTesting.value = false;
+  }
+}
+
+function readTestResult(response: IntegrationPluginTestResult) {
+  return response?.detail?.result || null;
+}
+
+async function runVerificationTest() {
+  if (!canTestPlugins.value) return;
+
+  const realName = verificationTestForm.real_name.trim();
+  const cardNo = verificationTestForm.card_no.trim();
+  if (!realName || !cardNo) {
+    MessagePlugin.error('请填写测试姓名和身份证号');
+    return;
+  }
+  if (!currentPlugin.value?.id) return;
+
+  verificationTesting.value = true;
+  verificationTestResult.value = null;
+  try {
+    const response = await pluginsApi.testVerification(currentPlugin.value.id, {
+      real_name: realName,
+      card_no: cardNo,
+    });
+    const result = readTestResult(response);
+    verificationTestResult.value = result;
+    if (result?.success) {
+      MessagePlugin.success(result.message || '测试任务创建成功');
+    } else {
+      MessagePlugin.error(result?.message || '测试任务创建失败');
+    }
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '创建测试任务失败'));
+  } finally {
+    verificationTesting.value = false;
+  }
+}
+
+async function runPaymentTest() {
+  if (!canTestPlugins.value) return;
+  if (!currentPlugin.value?.id) return;
+
+  paymentTesting.value = true;
+  paymentTestResult.value = null;
+  try {
+    const response = await pluginsApi.testPayment(currentPlugin.value.id);
+    const result = readTestResult(response);
+    paymentTestResult.value = result;
+    if (result?.success) {
+      MessagePlugin.success(result.message || '测试支付单创建成功');
+    } else {
+      MessagePlugin.error(result?.message || '测试支付单创建失败');
+    }
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '创建测试支付单失败'));
+  } finally {
+    paymentTesting.value = false;
+  }
+}
+
+async function runCaptchaTest() {
+  if (!canTestPlugins.value) return;
+  if (!currentPlugin.value?.id) return;
+
+  captchaTesting.value = true;
+  captchaTestResult.value = null;
+  try {
+    const captcha = (await openCaptchaVerify()) as Record<string, unknown> | null;
+    if (!captcha) {
+      MessagePlugin.error('未获取到验证结果');
+      return;
+    }
+
+    const response = await pluginsApi.testCaptcha(currentPlugin.value.id, {
+      lot_number: String(captcha.lot_number || ''),
+      captcha_output: String(captcha.captcha_output || ''),
+      pass_token: String(captcha.pass_token || ''),
+      gen_time: String(captcha.gen_time || ''),
+    });
+    const result = readTestResult(response);
+    captchaTestResult.value = result;
+    if (result?.success) {
+      MessagePlugin.success(result.message || '验证通过');
+    } else {
+      MessagePlugin.error(result?.message || '验证未通过');
+    }
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '验证测试失败'));
+  } finally {
+    captchaTesting.value = false;
+  }
+}
+
+async function runConnectionTest() {
+  if (!canTestPlugins.value) return;
+  if (!currentPlugin.value?.id) return;
+
+  connectionTesting.value = true;
+  connectionTestResult.value = null;
+  try {
+    const response = await pluginsApi.testConnection(currentPlugin.value.id);
+    const result = readTestResult(response);
+    connectionTestResult.value = result;
+    if (result?.success) {
+      MessagePlugin.success(result.message || '连接正常');
+    } else {
+      MessagePlugin.error(result?.message || '连接测试失败');
+    }
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '连接测试失败'));
+  } finally {
+    connectionTesting.value = false;
+  }
+}
+
+async function copyText(value: string) {
+  if (!value) return;
+  try {
+    await navigator.clipboard.writeText(value);
+    MessagePlugin.success('已复制');
+  } catch {
+    MessagePlugin.error('复制失败，请手动复制');
   }
 }
 


### PR DESCRIPTION
## 变更内容
- 新增 LeafFace 实名认证插件及回调、签名、状态处理
- 增加系统级邮件、短信、实名认证、支付、人机验证和连接测试
- 检测成功后仅对已实现测试流程的域打开独立测试弹窗
- 管理抽屉立即打开并显示配置加载状态
- 修复 GeeTest 脚本代理、官方脚本 fallback、TLS 配置和诊断信息
- 清理旧测试界面并防止检测请求竞态打开错误插件

## 验证
- backend IntegrationPluginSystemTest / PluginRuntimeRegistryIntegrationTest: 通过
- frontend-admin-v3 ESLint: 通过
- frontend-admin-v3 vue-tsc 与 build: 通过
- PHP Pint 相关文件: 通过

## 备注
- 工作区中与站点配置缓存相关的既有改动未纳入本 PR。
- 当前本地 GeeTest 运行环境若使用自签名代理证书，请配置对应 CA bundle。