### PR TITLE
fix: Docker 部署下定时任务与队列从未执行（cron PATH 缺 /usr/local/bin）

### DIFF
--- a/deploy/docker/backend/entrypoint.sh
+++ b/deploy/docker/backend/entrypoint.sh
@@ -161,7 +161,14 @@ chown -R www-data:www-data storage bootstrap/cache
 # ---------------------------------------------------------------------------
 # 6. crontab（每分钟 schedule:run，驱动心跳与队列消费；与宝塔口径一致）
 # ---------------------------------------------------------------------------
-echo '* * * * * cd /var/www/backend && php artisan schedule:run >> /dev/null 2>&1' \
+# cron 的默认 PATH 只有 /usr/bin:/bin，而官方 PHP 镜像把二进制装在 /usr/local/bin/php，
+# 裸 php 在 cron 环境下必然 command not found；再叠加 >> /dev/null 2>&1 把错误全部丢弃，
+# 结果是 crond 正常运行但 schedule:run 从未成功执行一次，且没有任何日志线索——
+# 心跳与 queue:drain 永不触发，/api/ready 始终 scheduler=false，队列永不消费。
+# 因此显式声明 PATH 并使用绝对路径（printf 保证结尾换行，否则 crontab 拒绝安装）。
+printf '%s\n%s\n' \
+  'PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin' \
+  '* * * * * cd /var/www/backend && /usr/local/bin/php artisan schedule:run >> /dev/null 2>&1' \
   | crontab -u www-data -
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 变更内容

修复 Docker 部署下**整个定时任务体系与队列消费从未执行**的问题。

`deploy/docker/backend/entrypoint.sh` 为 `www-data` 安装的 crontab 使用**裸 `php`** 调用 artisan：

```
* * * * * cd /var/www/backend && php artisan schedule:run >> /dev/null 2>&1
```

cron 的默认 PATH 只有 `/usr/bin:/bin`，而官方 PHP 镜像的二进制位于 `/usr/local/bin/php`，
因此每分钟的 `schedule:run` 必然 `command not found`。又因命令尾部 `>> /dev/null 2>&1`
丢弃了全部输出，这个失败**没有任何日志线索**：`supervisorctl status cron` 始终显示
`RUNNING`，容器日志干净，看不出任何异常。

### 影响范围

Docker 是 README 推荐的一键部署路径，受影响的是全新部署的默认状态：

- `scheduler:heartbeat` 从未派发 `CoreScheduledTaskProvider` 中的 16 个核心任务
- **`queue:drain` 从未执行，队列永不消费**。开通走 `provision` 队列，因此实例可以
  正常下单、支付、生成账单，但**服务永远不会被开通**
- 资金兜底任务全部失效：`service-auto-renew`（自动续费）、`reconcile-account-balance`
  （余额对账）、`audit-ledger-consistency`（流水一致性审计）、
  `compensate-recharge-invoices`（充值补偿）、`provision-retry-failed`（开通失败重试）、
  `service-lifecycle-maintenance`（到期暂停/释放）
- `/api/ready` 恒为 `scheduler=false` / `scheduler_liveness=false`，返回 `50300`。
  而 README「常用命令」一节让运维以 `curl /api/ready` 作为就绪门禁，
  该端点永远不会变绿

### 修复

crontab 中显式声明 `PATH`，并改用 `/usr/local/bin/php` 绝对路径（两者互为兜底）。

改用 `printf '%s\n%s\n'` 生成内容：原先的 `echo` 单行可用，但多行内容若结尾缺换行，
`crontab` 会以 `new crontab file is missing newline before EOF, can't install` 拒绝安装。

仅改动 `deploy/docker/backend/entrypoint.sh` 一处，8 行，不涉及应用代码、
不涉及数据库、不改变非 Docker（宝塔）部署路径的行为。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 重构/性能优化
- [ ] 其他（请说明）

## 检查清单

- [x] 已阅读 [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] 已运行相关 lint 与静态检查 —— 本次仅改动 shell 脚本，已通过
      `bash -n deploy/docker/backend/entrypoint.sh`；未触及 PHP / 前端代码，
      `composer format:check` 与 `npm run lint:frontends` 不适用于本 diff
- [x] 数据库变更通过新增 migration 实现，未改动 `database/schema/mysql-schema.sql` 基线
      —— 本次无数据库变更
- [x] 未提交任何敏感信息（密钥、`.env`、真实域名等）

## 测试说明

环境：全新 Ubuntu 22.04 + Docker 29.7.2 / Compose v5.5.0，按 README「快速开始（Docker 部署）」
的混合模式部署（`docker compose pull app` + `docker compose build frontends`）。

### 1. 复现（修复前）

四个容器全部 healthy，`/api/health` 正常，管理员 `cerbo` 正常创建，三个前端均返回 200。
但静默观察 250 秒，零干预：

```
$ SELECT COUNT(*), MAX(triggered_at) FROM schedule_ticks;
1    2026-08-20 22:25:09     <- T0
（等待 250 秒）
1    2026-08-20 22:25:09     <- T1，无任何增长

$ curl -s http://127.0.0.1:8080/api/ready
{"code":50300,"message":"服务未就绪","data":{"status":"not_ready","checks":{
  "database":true,"cache":true,"storage":true,
  "scheduler":false,"scheduler_liveness":false,
  "task_readiness":true,"queue":true}}}
```

### 2. 定位

最小 cron 探针可以正常执行，证明 crond 本身与 PAM 均无问题，失败点在 artisan 命令：

```
$ crontab -u www-data -   # * * * * * /bin/date >> /tmp/cron-probe.log 2>&1
$ cat /tmp/cron-probe.log
Thu Aug 20 14:44:01 UTC 2026
Thu Aug 20 14:45:01 UTC 2026
```

以 cron 的默认 PATH 模拟执行，A/B 对照：

```
$ docker exec turaidc-app env -i PATH=/usr/bin:/bin sh -c 'cd /var/www/backend && php artisan schedule:run'
sh: 1: php: not found

$ docker exec turaidc-app env -i PATH=/usr/local/bin:/usr/bin:/bin sh -c 'cd /var/www/backend && php artisan schedule:run'
  2026-08-20 22:35:18 Running ['artisan' scheduler:heartbeat] .. 404.67ms DONE
  2026-08-20 22:35:19 Running ['artisan' queue:drain] in background  1.34ms DONE

$ docker exec turaidc-app which php
/usr/local/bin/php
```

### 3. 验证（修复后）

应用本 PR 的 diff，`docker compose build app` 从源码重建镜像，
`docker compose up -d --force-recreate app` 以**全新容器**启动，全程零手动干预：

```
$ docker exec turaidc-app crontab -l -u www-data
PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
* * * * * cd /var/www/backend && /usr/local/bin/php artisan schedule:run >> /dev/null 2>&1

# 容器启动约 40 秒后
$ SELECT MAX(triggered_at) FROM schedule_ticks;
2026-08-20 22:54:02
（继续静默观察）
2026-08-20 22:57:01     <- 持续自行推进

$ curl -s http://127.0.0.1:8080/api/ready
{"code":0,"message":"ok","data":{"status":"ready","checks":{
  "database":true,"cache":true,"storage":true,
  "scheduler":true,"scheduler_liveness":true,
  "task_readiness":true,"queue":true}}}
```

心跳确实派发了任务，`schedule_task_runs` 全部 `success`：

```
task_key                        status    created_at
compensate-recharge-invoices    success   2026-08-20 22:47:02
reconcile-account-balance       success   2026-08-20 22:47:02
coupon-campaign-dispatch        success   2026-08-20 22:47:02
site-cache-warmup               success   2026-08-20 22:47:02
service-auto-renew              success   2026-08-20 22:47:02
service-status-sync             success   2026-08-20 22:47:02
referral-release-rewards        success   2026-08-20 22:47:02
refresh-hosting-panel-auth      success   2026-08-20 22:47:02
provision-retry-failed          success   2026-08-20 22:47:02
```

## 补充信息

排查过程中有两个假设**已被证伪**，记录在此以免后续重复排查：

1. **`/etc/pam.d/cron` 的 `session required pam_loginuid.so`** —— 容器内
   `/proc/self/loginuid` 为 `4294967295` 且写入需要 `CAP_AUDIT_CONTROL`，看起来非常
   像根因。但 `sed -i '/pam_loginuid\.so/d'` 后重启 cron，`schedule_ticks` 仍无增长；
   而上文最小 cron 探针在 `pam_loginuid` **保持原样**的情况下可以正常执行。
   该模块不是本问题的原因，无需改动。

2. **把 cron 输出重定向到 `/proc/1/fd/1` 以便进入容器日志** —— PID 1 是以 root 运行的
   supervisord，`www-data` 无权写入该 fd，重定向失败会导致整条 cron 命令不执行，
   表现为「修复无效」。因此本 PR 保留 `>> /dev/null 2>&1` 未动。

关于「失败静默」本身：`>> /dev/null 2>&1` 让这类问题完全不可观测，是本 bug 藏了很久的
直接原因。是否把输出改到 `www-data` 可写的位置（例如
`storage/logs/schedule.log`，需配套轮转），或改用 supervisor 托管
`php artisan schedule:work` 取代 cron（容器原生做法，输出天然进 stdout），
倾向于交由维护者裁决，故未纳入本 PR，以保持最小改动。
