### PR TITLE
fix: 仅tag或核心文件变更时触发Docker镜像构建

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,10 @@
 # TuraIDC Docker 镜像构建与推送
 #
 # 触发：
-#   - push 到 main / master
-#   - push 任意 tag
-#   - 手动触发（workflow_dispatch）
+#   - push 任意版本 tag（无条件构建）
+#   - 手动触发（workflow_dispatch，无条件构建）
+#   - push 到 main / master 且变更涉及核心文件（backend/、前端三端、shared/、
+#     deploy/、根构建清单等）；纯文档类变更（docs/、docs-web/、*.md 等）不构建
 #
 # 产物（推送到 GHCR，镜像名全部小写）：
 #   ghcr.io/<owner>/turaidc-app         后端（PHP-FPM + Nginx + Cron + VNC Relay）
@@ -34,8 +35,57 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  changes:
+    name: 判断是否需要构建
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # 需要完整历史才能对 before..after 做文件级 diff
+          fetch-depth: 0
+
+      - name: 判断是否需要构建
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          # tag 推送与手动触发：无条件构建
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$GIT_REF" == refs/tags/* ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 新分支/异常事件拿不到基线提交时，保守起见执行构建
+          if [[ ! "$BEFORE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 强推等场景 before 可能不在当前历史中，diff 失败则视为需要构建
+          CHANGED="$(git diff --name-only "$BEFORE" "$AFTER" || echo backend/)"
+          echo "本次变更文件："
+          echo "$CHANGED"
+
+          # 核心文件：后端、前端三端、共享层、部署与镜像定义、根构建清单、本工作流
+          CORE_PATTERN='^(backend/|frontend-admin-v3/|frontend-user-v3-www/|frontend-user-v4-console/|shared/|deploy/|docker-compose.*\.ya?ml$|Dockerfile$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig\.base\.json$|\.github/workflows/docker-image\.yml$)'
+
+          if echo "$CHANGED" | grep -Eq "$CORE_PATTERN"; then
+            echo "检测到核心文件变更，执行镜像构建"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "仅文档等非核心文件变更，跳过镜像构建"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   backend:
     name: Build & push turaidc-app
+    needs: changes
+    if: needs.changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -89,6 +139,8 @@ jobs:
 
   frontends:
     name: Build & push turaidc-frontends
+    needs: changes
+    if: needs.changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -71,8 +71,9 @@ jobs:
           echo "本次变更文件："
           echo "$CHANGED"
 
-          # 核心文件：后端、前端三端、共享层、部署与镜像定义、根构建清单、本工作流
-          CORE_PATTERN='^(backend/|frontend-admin-v3/|frontend-user-v3-www/|frontend-user-v4-console/|shared/|deploy/|docker-compose.*\.ya?ml$|Dockerfile$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig\.base\.json$|\.github/workflows/docker-image\.yml$)'
+          # 核心文件：会被编译进前后端镜像的内容——后端代码、前端三端、
+          # 共享层、镜像构建定义（deploy/ 含 Dockerfile）、根构建清单
+          CORE_PATTERN='^(backend/|frontend-admin-v3/|frontend-user-v3-www/|frontend-user-v4-console/|shared/|deploy/|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig\.base\.json$)'
 
           if echo "$CHANGED" | grep -Eq "$CORE_PATTERN"; then
             echo "检测到核心文件变更，执行镜像构建"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,8 +72,9 @@ jobs:
           echo "$CHANGED"
 
           # 核心文件：会被编译进前后端镜像的内容——后端代码、前端三端、
-          # 共享层、镜像构建定义（deploy/ 含 Dockerfile）、根构建清单
-          CORE_PATTERN='^(backend/|frontend-admin-v3/|frontend-user-v3-www/|frontend-user-v4-console/|shared/|deploy/|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig\.base\.json$)'
+          # 共享层、镜像构建定义（deploy/ 含 Dockerfile）、根构建清单、
+          # 被前端镜像 COPY 的根公共静态资产（theme.css / logo.png / favicon.png）
+          CORE_PATTERN='^(backend/|frontend-admin-v3/|frontend-user-v3-www/|frontend-user-v4-console/|shared/|deploy/|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig\.base\.json$|theme\.css$|logo\.png$|favicon\.png$)'
 
           if echo "$CHANGED" | grep -Eq "$CORE_PATTERN"; then
             echo "检测到核心文件变更，执行镜像构建"


### PR DESCRIPTION
## 背景

此前 `Docker Image Build & Push` 在每次 push 到 main/master 时都会重新构建并推送镜像，仅修改文档（docs/、*.md 等）也会触发完整的前后端镜像编译，浪费 CI 资源。

## 变更内容

- 新增 `changes` 前置判断 job，两个镜像构建 job（backend / frontends）通过 `needs + if` 依赖其输出决定是否执行。
- **无条件构建**：push 任意版本 tag、手动触发（workflow_dispatch）。
- **按变更判断**：push 到 main/master 时，基于 `github.event.before..github.sha` 做 `git diff --name-only`，命中核心文件才构建。

### 核心文件范围（会被编译进镜像的内容）

- `backend/`
- `frontend-admin-v3/`、`frontend-user-v3-www/`、`frontend-user-v4-console/`
- `shared/`
- `deploy/`（含前后端 Dockerfile）
- 根构建清单：`package.json`、`pnpm-lock.yaml`、`pnpm-workspace.yaml`、`tsconfig.base.json`

其余（docs/、docs-web/、*.md、工作流自身、编排配置等）不再触发构建。

## 实现说明

- 未采用原生 `on.push.paths` 过滤器：它对 tag 推送同样生效，会导致「文档提交后打的 tag 不触发构建」；改为显式判断后保证 tag 必构建。
- 兜底策略：新分支首次推送拿不到基线提交（before 为全零）、或强推导致 diff 失败时，保守执行构建。

## 验证

- 本地用相同正则对文档类与核心类共 13 类典型路径模拟匹配，结果符合预期（docs/*.md → SKIP，backend/前端/shared/deploy/根清单 → BUILD）。
- 已在 GitHub Actions 实际验证：仅修改 workflow 文件的 push 未触发镜像构建；核心文件或 tag 推送正常触发。