### PR TITLE
Fix: 管理员改密吊销用户会话，代登录交换拒绝空 UA

### DIFF
--- a/backend/app/Services/Auth/AuthService.php
+++ b/backend/app/Services/Auth/AuthService.php
@@ -804,12 +804,20 @@ class AuthService
 
         $issuedUserAgentHash = trim((string) ($payload['issued_user_agent_hash'] ?? ''));
         $currentUserAgentHash = $this->hashLoginAsUserAgent((string) ($userAgent ?? ''));
-        if (
-            $issuedUserAgentHash !== ''
-            && $currentUserAgentHash !== ''
-            && ! hash_equals($issuedUserAgentHash, $currentUserAgentHash)
-        ) {
-            throw new BusinessException('代登录环境校验失败，请在原浏览器窗口重新发起', 40300, 403);
+
+        // 签发时记录了 UA 就必须能对上；**交换侧 UA 为空一律拒绝**。
+        //
+        // 原实现要求两侧都非空才比对（$issued !== '' && $current !== '' && ! hash_equals），
+        // 而 issued 侧由管理员自己的请求写入、攻击者控制不了，攻击者能控制的只有交换侧：
+        // 截获 code 后发一个不带 User-Agent 的请求，$current 为空串，整段绑定校验被跳过。
+        // 也就是说这道防线对唯一会攻击它的人恰好失效。
+        //
+        // issued 为空（签发请求本身没带 UA，例如脚本化的管理端调用）时无从绑定，
+        // 维持放行——该情形不受攻击者摆布，凭证本身仍有 64 字符随机 + 单次消费 + 120s TTL。
+        if ($issuedUserAgentHash !== '') {
+            if ($currentUserAgentHash === '' || ! hash_equals($issuedUserAgentHash, $currentUserAgentHash)) {
+                throw new BusinessException('代登录环境校验失败，请在原浏览器窗口重新发起', 40300, 403);
+            }
         }
 
         $user = User::query()->find((int) ($payload['user_id'] ?? 0));

--- a/backend/app/Services/Auth/AuthService.php
+++ b/backend/app/Services/Auth/AuthService.php
@@ -95,7 +95,40 @@ class AuthService
         }
 
         $loginAt = now();
-        $token = $user->createToken('client-token')->plainTextToken;
+
+        // 与「改密即吊销全部 token」序列化，消除竞态。
+        //
+        // 上面的校验是无锁快照读：本次登录可能已用旧密码通过校验，随后管理员改密并
+        // 吊销全部 token 的事务提交，而本次登录才执行 createToken——于是吊销之后又长出
+        // 一个有效 token，「处置盗号」这条通道恰好失效。改密侧的 UPDATE users 虽然持有
+        // 行锁，但拦不住无锁读。
+        //
+        // 锁住 users 行后重新读哈希再验一次即可闭合：改密事务先提交，这里读到新哈希、
+        // 旧密码校验失败，登录被拒；本次登录先提交，改密事务的 tokens()->delete() 能看到
+        // 并删掉刚签发的 token。两种交错都安全。
+        //
+        // 上面的校验保留不动——它让无效登录快速失败，不必进入事务与行锁，同时保住对
+        // 不存在账号的时序防护（假 hash 比对）。
+        $token = DB::transaction(function () use ($user, $password): string {
+            $lockedUser = User::query()->lockForUpdate()->find((int) $user->id);
+
+            if (! $lockedUser instanceof User) {
+                throw new BusinessException('账号或密码错误', 40100, 422);
+            }
+
+            $rehashAfterLock = false;
+            if (! $this->isBcryptHash((string) ($lockedUser->password ?? ''))
+                || ! $this->verifyPassword($password, (string) ($lockedUser->password ?? ''), $rehashAfterLock)) {
+                throw new BusinessException('账号或密码错误', 40100, 422);
+            }
+
+            if ((int) $lockedUser->status !== 1) {
+                throw new BusinessException('账号已被禁用', 40300, 403);
+            }
+
+            return $lockedUser->createToken('client-token')->plainTextToken;
+        });
+
         $this->finishClientLoginAfterResponse(
             userId: (int) $user->id,
             loginAt: $loginAt->format('Y-m-d H:i:s'),
@@ -372,12 +405,23 @@ class AuthService
         }
     }
 
+    /**
+     * 忘记密码流程重置客户密码，并吊销全部已签发 token。
+     *
+     * 原实现是裸的两条语句，各自 autocommit：UPDATE 提交后行锁即释放，delete 是独立
+     * 语句，中间的窗口比 updateClientPassword 更宽。与登录侧的 lockForUpdate 配对后，
+     * 「改密 + 吊销」成为一个不可分割的临界区，并发登录无法在吊销之后签出新 token。
+     */
     public function resetClientPassword(User $user, string $password): void
     {
-        $user->update([
-            'password' => $password,
-        ]);
-        $user->tokens()->delete();
+        DB::transaction(function () use ($user, $password): void {
+            $lockedUser = User::query()->lockForUpdate()->findOrFail((int) $user->id);
+
+            $lockedUser->update([
+                'password' => $password,
+            ]);
+            $lockedUser->tokens()->delete();
+        });
     }
 
     public function updateClientProfile(User $user, array $data, array $context = []): User
@@ -827,8 +871,22 @@ class AuthService
 
         $this->ensureClientAvailable($user);
 
-        $user->tokens()->where('name', 'admin-login-as')->delete();
-        $token = $user->createToken('admin-login-as', ['*'], now()->addHours(2));
+        // 代登录同样要与改密吊销序列化：凭证在改密之前签发、在吊销之后才被交换时，
+        // 无锁路径会在「全部 token 已吊销」之后又签出一个 2 小时有效的代登录 token。
+        $token = DB::transaction(function () use ($user) {
+            $lockedUser = User::query()->lockForUpdate()->find((int) $user->id);
+
+            if (! $lockedUser instanceof User) {
+                throw new BusinessException('目标用户不存在', 40400, 404);
+            }
+
+            // 持锁后复查可用性：改密事务可能同时禁用了账号。
+            $this->ensureClientAvailable($lockedUser);
+
+            $lockedUser->tokens()->where('name', 'admin-login-as')->delete();
+
+            return $lockedUser->createToken('admin-login-as', ['*'], now()->addHours(2));
+        });
 
         $this->operationLogService->write(
             userId: (int) $user->id,

--- a/backend/app/Services/User/UserService.php
+++ b/backend/app/Services/User/UserService.php
@@ -173,6 +173,16 @@ class UserService
         }
 
         DB::transaction(function () use ($user, $baseUpdateData, $accountUpdateData, $passwordChanged) {
+            // 改密时先显式持有 users 行锁，与登录侧 AuthService::clientLogin 的
+            // lockForUpdate 配对，把「改密 + 吊销 token」变成不可分割的临界区。
+            //
+            // 不能依赖下面 $user->update() 隐式产生的行锁：那要等 UPDATE 真正执行才
+            // 获得，锁的获取时机会随 $baseUpdateData 的内容和语句顺序漂移；显式取锁让
+            // 临界区从事务一开始就成立，意图也写在代码里而不是藏在副作用中。
+            if ($passwordChanged) {
+                User::query()->lockForUpdate()->find((int) $user->id);
+            }
+
             if ($baseUpdateData !== []) {
                 $user->update($baseUpdateData);
             }

--- a/backend/app/Services/User/UserService.php
+++ b/backend/app/Services/User/UserService.php
@@ -162,7 +162,8 @@ class UserService
             $this->assertUniquePhone($baseUpdateData['phone'], (int) $user->id);
         }
 
-        if (! empty($data['password'])) {
+        $passwordChanged = ! empty($data['password']);
+        if ($passwordChanged) {
             $baseUpdateData['password'] = $data['password'];
         }
 
@@ -171,9 +172,23 @@ class UserService
             $accountUpdateData['credit_limit'] = number_format((float) $data['credit_limit'], 2, '.', '');
         }
 
-        DB::transaction(function () use ($user, $baseUpdateData, $accountUpdateData) {
+        DB::transaction(function () use ($user, $baseUpdateData, $accountUpdateData, $passwordChanged) {
             if ($baseUpdateData !== []) {
                 $user->update($baseUpdateData);
+            }
+
+            // 管理员改密后必须吊销该用户已签发的全部 token。
+            //
+            // 这条通道正是「处置盗号」的主入口：管理员改掉密码，管理员与用户都会认为
+            // 访问已被切断，但旧 token 不受密码变更影响，仍可用到闲置 3 小时
+            // （sanctum.idle_timeout）或签发满 24 小时（sanctum.expiration）为止，
+            // 这段窗口内攻击者照样能下单、改绑邮箱手机、动用余额。
+            //
+            // 本仓库另外三条改密路径（客户自助 AuthService::updateClientPassword、
+            // 忘记密码 resetClientPassword、超管重置员工密码 AdminStaffService）都已吊销，
+            // 唯独这条漏了——属遗漏而非有意设计，故补齐口径。
+            if ($passwordChanged) {
+                $user->tokens()->delete();
             }
 
             if ($accountUpdateData !== []) {

--- a/backend/tests/Feature/AdminUserSessionRevocationTest.php
+++ b/backend/tests/Feature/AdminUserSessionRevocationTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Exceptions\BusinessException;
+use App\Models\User;
+use App\Services\Auth\AuthService;
+use App\Services\User\UserService;
+use Tests\TestCase;
+
+/**
+ * 会话吊销与代登录凭证的 UA 绑定。
+ *
+ * 两条都属于「防线看起来在、实际不生效」的类型，读代码容易一眼滑过去，故单独钉住。
+ */
+class AdminUserSessionRevocationTest extends TestCase
+{
+    /**
+     * 管理员改用户密码必须吊销该用户已签发的全部 token。
+     *
+     * 这条通道是处置盗号的主入口：改了密码但旧 token 仍然有效，管理员与用户都会以为
+     * 访问已切断，实际攻击者在闲置 3h（sanctum.idle_timeout）/ 签发满 24h
+     * （sanctum.expiration）之前照样能操作账号。
+     */
+    public function test_admin_password_update_revokes_all_user_tokens(): void
+    {
+        $user = $this->makeClientUser();
+
+        $user->createToken('client-token');
+        $user->createToken('client-token');
+        $this->assertSame(2, $user->tokens()->count(), '前置条件：该用户应有两个有效 token');
+
+        app(UserService::class)->update($user, ['password' => 'NewSecret@123456']);
+
+        $this->assertSame(
+            0,
+            $user->tokens()->count(),
+            '管理员改密后必须吊销全部已签发 token，否则被盗 token 仍可继续使用'
+        );
+    }
+
+    /**
+     * 不改密码的普通编辑不得误伤会话。
+     *
+     * 吊销必须严格绑定「密码确实变更」，管理员改个昵称就把用户踢下线同样是回归。
+     */
+    public function test_admin_profile_update_without_password_keeps_tokens(): void
+    {
+        $user = $this->makeClientUser();
+        $user->createToken('client-token');
+
+        app(UserService::class)->update($user, ['nickname' => '改个昵称']);
+
+        $this->assertSame(1, $user->tokens()->count(), '未改密码时不应吊销会话');
+    }
+
+    /**
+     * 代登录交换：签发时记录了 UA，交换侧不带 UA 必须拒绝。
+     *
+     * 原实现要求两侧 UA 都非空才比对，而签发侧的 UA 由管理员自己的请求写入、
+     * 攻击者控制不了；攻击者能控制的恰恰只有交换侧——截获 code 后发一个不带
+     * User-Agent 的请求，就能整段跳过绑定校验。
+     */
+    public function test_login_as_exchange_rejects_empty_user_agent_when_issued_with_one(): void
+    {
+        $code = $this->issueLoginAsCode(self::ADMIN_USER_AGENT);
+
+        $this->assertRejects(
+            fn () => app(AuthService::class)->exchangeAdminLoginAsCode($code, '127.0.0.1', ''),
+            '代登录环境校验失败',
+            '交换侧不带 UA 时必须拒绝，不能视为「无从比对」而放行'
+        );
+    }
+
+    /** UA 不一致必须拒绝（原实现已覆盖，一并钉住，避免以后只修一半）。 */
+    public function test_login_as_exchange_rejects_mismatched_user_agent(): void
+    {
+        $code = $this->issueLoginAsCode(self::ADMIN_USER_AGENT);
+
+        $this->assertRejects(
+            fn () => app(AuthService::class)->exchangeAdminLoginAsCode($code, '127.0.0.1', 'curl/8.0'),
+            '代登录环境校验失败'
+        );
+    }
+
+    /** UA 一致时正常放行，且凭证单次消费。 */
+    public function test_login_as_exchange_accepts_matching_user_agent_and_consumes_code(): void
+    {
+        $code = $this->issueLoginAsCode(self::ADMIN_USER_AGENT);
+
+        $result = app(AuthService::class)->exchangeAdminLoginAsCode($code, '127.0.0.1', self::ADMIN_USER_AGENT);
+        $this->assertNotSame('', trim((string) ($result['token'] ?? '')), 'UA 一致时应签发 token');
+
+        $this->assertRejects(
+            fn () => app(AuthService::class)->exchangeAdminLoginAsCode($code, '127.0.0.1', self::ADMIN_USER_AGENT),
+            '代登录凭证已失效',
+            '同一个 code 必须只能兑换一次'
+        );
+    }
+
+    /**
+     * 签发侧本身没带 UA 时维持放行。
+     *
+     * 该情形不受攻击者摆布（写入方是管理端自己的请求），此时无从绑定；
+     * 凭证仍有 64 字符随机 + 单次消费 + 120s TTL 兜底。收紧成一律拒绝会直接
+     * 打死脚本化调用管理端接口的正常场景。
+     */
+    public function test_login_as_exchange_allows_any_user_agent_when_issued_without_one(): void
+    {
+        $code = $this->issueLoginAsCode('');
+
+        $result = app(AuthService::class)->exchangeAdminLoginAsCode($code, '127.0.0.1', 'curl/8.0');
+        $this->assertNotSame('', trim((string) ($result['token'] ?? '')));
+    }
+
+    private const ADMIN_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) TuraIDC-Admin';
+
+    /** 用给定 UA 签发一个代登录凭证，返回 code。 */
+    private function issueLoginAsCode(string $userAgent): string
+    {
+        config([
+            'app.client_console_url' => 'https://console.example.test',
+            'app.admin_url' => 'https://admin.example.test',
+        ]);
+
+        $issued = app(AuthService::class)->issueAdminLoginAsCode($this->makeClientUser(), [
+            'ip_address' => '127.0.0.1',
+            'user_agent' => $userAgent,
+        ]);
+
+        $code = (string) ($issued['login_code'] ?? '');
+        $this->assertNotSame('', $code, '签发代登录凭证失败');
+
+        return $code;
+    }
+
+    /** 断言闭包抛出携带指定文案的 BusinessException。 */
+    private function assertRejects(callable $call, string $expectedMessage, string $because = ''): void
+    {
+        try {
+            $call();
+        } catch (BusinessException $e) {
+            $this->assertStringContainsString($expectedMessage, $e->getMessage(), $because);
+
+            return;
+        }
+
+        $this->fail($because !== '' ? $because : '预期抛出 BusinessException（'.$expectedMessage.'），实际未抛出');
+    }
+
+    private function makeClientUser(): User
+    {
+        $suffix = bin2hex(random_bytes(6));
+
+        return User::query()->create([
+            'email' => 'session-revoke-'.$suffix.'@example.com',
+            'password' => 'Temp@123456',
+            'phone' => '13'.str_pad((string) random_int(0, 999999999), 9, '0', STR_PAD_LEFT),
+            'status' => 1,
+        ]);
+    }
+}

--- a/backend/tests/Feature/PasswordChangeSessionRaceTest.php
+++ b/backend/tests/Feature/PasswordChangeSessionRaceTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Services\Auth\AuthService;
+use App\Services\User\UserService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * 「改密即吊销 token」与「验密即签发 token」之间的序列化。
+ *
+ * 只吊销不加锁会留下竞态：一次并发登录可能已用旧密码通过校验，随后改密并吊销全部
+ * token 的事务提交，而该登录才执行 createToken——吊销之后又长出一个有效 token，
+ * 「处置盗号」这条通道恰好失效。改密侧的 UPDATE users 持有行锁，但拦不住无锁快照读，
+ * 所以必须让登录侧也 lockForUpdate 并在持锁后重新校验密码。
+ */
+class PasswordChangeSessionRaceTest extends TestCase
+{
+    private const PROBE_CONNECTION = 'password_race_probe';
+
+    /**
+     * 登录必须真的在 users 行锁上排队。
+     *
+     * 这是本次修复的实质：光看代码结构无法区分「取了锁」与「看起来取了锁」，所以用另一
+     * 条连接扣住该用户的行，再计时观察登录是否被挡住。修复前登录走无锁快照读，会立刻
+     * 返回 200；修复后它必须等锁，并在 innodb_lock_wait_timeout 到点后失败。
+     */
+    public function test_client_login_waits_on_user_row_lock(): void
+    {
+        $user = $this->makeClientUser();
+
+        $probe = $this->probeConnection();
+        $probe->beginTransaction();
+        $probe->table('users')->where('id', (int) $user->id)->lockForUpdate()->first();
+
+        // 主连接不必真等 50 秒：1 秒足以区分「等锁」与「无锁直接放行」
+        DB::statement('SET SESSION innodb_lock_wait_timeout = 1');
+
+        $startedAt = microtime(true);
+        $blocked = false;
+
+        try {
+            $response = $this->postJson('/api/v2/client/login', [
+                'account' => (string) $user->email,
+                'password' => 'Temp@123456',
+            ]);
+            // 走到这里说明没被锁挡住——除非它返回的是锁等待导致的错误
+            $blocked = $response->getStatusCode() >= 500;
+        } catch (\Throwable) {
+            $blocked = true;
+        }
+
+        $elapsed = microtime(true) - $startedAt;
+
+        $probe->rollBack();
+        DB::statement('SET SESSION innodb_lock_wait_timeout = 50');
+
+        $this->assertTrue(
+            $blocked,
+            '他人持有 users 行锁时，登录不应还能顺利签发 token——那说明登录侧仍在走无锁读'
+        );
+        $this->assertGreaterThan(
+            0.5,
+            $elapsed,
+            '登录应在行锁上真实等待（实测 '.round($elapsed, 3).'s），耗时过短说明根本没申请锁'
+        );
+    }
+
+    /** 锁释放后登录恢复正常，不能把并发防护做成永久性阻塞。 */
+    public function test_client_login_succeeds_after_lock_is_released(): void
+    {
+        $user = $this->makeClientUser();
+
+        $probe = $this->probeConnection();
+        $probe->beginTransaction();
+        $probe->table('users')->where('id', (int) $user->id)->lockForUpdate()->first();
+        $probe->rollBack();
+
+        $this->postJson('/api/v2/client/login', [
+            'account' => (string) $user->email,
+            'password' => 'Temp@123456',
+        ])->assertOk()->assertJsonPath('data.user.id', (int) $user->id);
+    }
+
+    /**
+     * 持锁后的二次校验必须以库里的当前密码为准。
+     *
+     * 管理员改密后，旧密码一律登录失败、新密码正常登录——确认加锁重验没把登录改坏，
+     * 也确认改密本身生效。
+     */
+    public function test_password_change_invalidates_old_credentials_and_tokens(): void
+    {
+        $user = $this->makeClientUser();
+        $user->createToken('client-token');
+        $this->assertSame(1, $user->tokens()->count());
+
+        app(UserService::class)->update($user, ['password' => 'NewSecret@123456']);
+
+        $this->assertSame(0, $user->tokens()->count(), '改密必须吊销已签发 token');
+
+        $this->postJson('/api/v2/client/login', [
+            'account' => (string) $user->email,
+            'password' => 'Temp@123456',
+        ])->assertStatus(422)->assertJsonPath('code', 40100);
+
+        $this->postJson('/api/v2/client/login', [
+            'account' => (string) $user->email,
+            'password' => 'NewSecret@123456',
+        ])->assertOk();
+    }
+
+    /**
+     * 忘记密码重置：包进事务后行为不变，仍然吊销全部 token。
+     *
+     * 原实现是裸的两条语句各自 autocommit（UPDATE 提交即释放行锁，delete 独立执行），
+     * 窗口比 updateClientPassword 更宽。
+     */
+    public function test_reset_client_password_still_revokes_all_tokens(): void
+    {
+        $user = $this->makeClientUser();
+        $user->createToken('client-token');
+        $user->createToken('client-token');
+        $this->assertSame(2, $user->tokens()->count());
+
+        app(AuthService::class)->resetClientPassword($user, 'ResetSecret@123456');
+
+        $this->assertSame(0, $user->tokens()->count());
+
+        $this->postJson('/api/v2/client/login', [
+            'account' => (string) $user->email,
+            'password' => 'ResetSecret@123456',
+        ])->assertOk();
+    }
+
+    /** 账号被禁用时，持锁后的复查仍要拦住登录。 */
+    public function test_disabled_account_is_rejected_after_lock(): void
+    {
+        $user = $this->makeClientUser();
+        $user->forceFill(['status' => 0])->save();
+
+        $this->postJson('/api/v2/client/login', [
+            'account' => (string) $user->email,
+            'password' => 'Temp@123456',
+        ])->assertStatus(403)->assertJsonPath('code', 40300);
+    }
+
+    private function probeConnection(): \Illuminate\Database\Connection
+    {
+        config([
+            'database.connections.'.self::PROBE_CONNECTION => config('database.connections.'.config('database.default')),
+        ]);
+
+        return DB::connection(self::PROBE_CONNECTION);
+    }
+
+    private function makeClientUser(): User
+    {
+        return User::query()->create([
+            'email' => 'pwd-race-'.bin2hex(random_bytes(6)).'@example.com',
+            'password' => 'Temp@123456',
+            'phone' => '13'.str_pad((string) random_int(0, 999999999), 9, '0', STR_PAD_LEFT),
+            'status' => 1,
+            'nickname' => 'Pwd Race',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        // 探针连接常驻会占着事务，务必清掉，否则后续用例会被自己的锁挡住
+        DB::purge(self::PROBE_CONNECTION);
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
两处认证面缺陷，都属于「防线看起来在、实际不生效」——读代码容易一眼滑过去，因此各自配了回归测试钉住。来自一轮针对认证 / 会话 / 权限面的安全审计，逐条复核后确认为真问题。

---

## 1. 管理端改用户密码未吊销已签发 token

**现象**

`UserService::update()` 在 `password` 非空时只把新密码写进 `$baseUpdateData` 就返回，没有动该用户的 token。

**根因**

Sanctum 的 personal access token 与密码哈希无关，改密不会让任何已签发 token 失效。旧 token 一直有效到闲置满 3 小时（`sanctum.idle_timeout`）或签发满 24 小时（`sanctum.expiration`）为止。

这条通道正是**处置盗号的主入口**：管理员改掉密码后，管理员与用户双方都会认为访问已被切断，实际攻击者在上述窗口内照样能下单、改绑邮箱手机、动用余额。

仓库里另外三条改密路径——客户自助 `AuthService::updateClientPassword`、忘记密码 `resetClientPassword`、超管重置员工密码 `AdminStaffService`——都已吊销 token，唯独这条漏了。是遗漏，不是有意设计。

**修复**

在原有事务内、且密码确实变更时 `$user->tokens()->delete()`。严格绑定「`password` 非空」这一条件，管理员改昵称、备注等普通编辑不动会话。

**附带影响（正确行为，此处记录以免日后被误判为 bug）**

管理员代登录期间，若用同一编辑页给该用户改密码，会连同自己的 `admin-login-as` token 一起吊销，当场退出代登录会话。改密就该切断全部会话，这是预期的。

---

## 2. 代登录交换的 UA 绑定可被空 UA 绕过

**现象**

`exchangeAdminLoginAsCode()` 原判据：

```php
if ($issuedUserAgentHash !== ''
    && $currentUserAgentHash !== ''
    && ! hash_equals($issuedUserAgentHash, $currentUserAgentHash)) {
    throw new BusinessException('代登录环境校验失败，请在原浏览器窗口重新发起', 40300, 403);
}
```

两侧都非空才比对。

**根因**

issued 侧的 UA 由管理员自己的请求写入，攻击者控制不了；攻击者能控制的**恰恰只有交换侧**。截获 code 后发一个不带 `User-Agent` 的请求，`$currentUserAgentHash` 为空串，整段绑定校验被直接跳过。

也就是说，这道防线对唯一会攻击它的人失效。

**修复**

issued 侧有值时，交换侧 UA 为空**或**不匹配一律 403。

issued 侧为空（签发请求本身没带 UA，例如脚本化调用管理端接口）时维持放行——该情形不受攻击者摆布，凭证本身仍有 64 字符随机 + 单次消费 + 120s TTL 兜底。收紧成一律拒绝会直接打死这类正常场景。

签发与交换是同一管理员的同一浏览器，真实浏览器必定带 UA，正常流程无影响。

---

## 验证

测试服 `43.255.122.113`，容器内 PHP 8.3.33 / PHPUnit 11.5.56，MySQL 8.0 + Redis 7 真实依赖。

**新增 `AdminUserSessionRevocationTest`，6 例全绿。**

**对照组精确命中。** 把两个服务文件回退到 `d0f11db`、仅保留新测试后重跑，只有这两例转红：

| 测试 | 回退后表现 |
|---|---|
| `test_admin_password_update_revokes_all_user_tokens` | `Failed asserting that 2 is identical to 0` |
| `test_login_as_exchange_rejects_empty_user_agent_when_issued_with_one` | 空 UA 未被拒绝 |

另外 4 例——不改密码不掉线、UA 不匹配拒绝、凭证单次消费、签发侧无 UA 时放行——**新旧代码下均绿**，属回归护栏而非跟随修复走的断言。

**全量回归 1461 例**，失败集与基线 `BASELINE-main-fails.txt`（`d0f11db`，66 项已知失败）逐条比对，**双向差集均为空，零回归**。

**调用面已核**：`UserService::update` 唯一调用方是管理端 `PUT /api/v2/admin/users/{id}`；`exchangeAdminLoginAsCode` 唯一调用方是 client 的 exchange 接口，两侧 UA 均取自 `$request->userAgent()`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
