### PR TITLE
Feat:新增 Web 安装向导与 app:install 安装命令

### DIFF
--- a/backend/app/Console/Commands/InstallCommand.php
+++ b/backend/app/Console/Commands/InstallCommand.php
@@ -146,13 +146,23 @@ final class InstallCommand extends Command
             $payload['db_password'] = (string) $this->secret('数据库密码（可为空）');
         }
 
-        $test = $installer->testDatabase($payload);
+        $test = $installer->testDatabase([
+            'host' => (string) $payload['db_host'],
+            'port' => (int) $payload['db_port'],
+            'database' => (string) $payload['db_database'],
+            'username' => (string) $payload['db_username'],
+            'password' => (string) $payload['db_password'],
+        ]);
         $this->line('数据库检测：'.$test['message']);
         if (! $test['ok']) {
             throw new InstallException($test['message']);
         }
 
-        $redisTest = $installer->testRedis($payload);
+        $redisTest = $installer->testRedis([
+            'host' => (string) $payload['redis_host'],
+            'port' => (int) $payload['redis_port'],
+            'password' => (string) $payload['redis_password'],
+        ]);
         $this->line('Redis 检测：'.$redisTest['message']);
         if (! $redisTest['ok']) {
             throw new InstallException($redisTest['message']);

--- a/backend/app/Console/Commands/InstallCommand.php
+++ b/backend/app/Console/Commands/InstallCommand.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Install\InstallException;
+use App\Services\Install\InstallService;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * 交互式安装命令：php artisan app:install
+ *
+ * 与 Web 向导（/install）共用 InstallService，行为完全一致。
+ * 支持非交互模式（CI / 脚本）：显式传入全部必要选项。
+ */
+final class InstallCommand extends Command
+{
+    protected $signature = 'app:install
+        {--app-url= : 后端 API 公开地址}
+        {--frontend-url= : 官网门户地址}
+        {--console-url= : 用户控制台地址}
+        {--admin-url= : 管理端地址}
+        {--db-host=127.0.0.1 : 数据库主机}
+        {--db-port=3306 : 数据库端口}
+        {--db-database= : 数据库名}
+        {--db-username= : 数据库用户名}
+        {--db-password= : 数据库密码}
+        {--redis-host=127.0.0.1 : Redis 主机}
+        {--redis-port=6379 : Redis 端口}
+        {--redis-password= : Redis 密码}
+        {--admin-username= : 管理员用户名}
+        {--admin-email= : 管理员邮箱}
+        {--admin-password= : 管理员密码（至少 12 位）}';
+
+    protected $description = '交互式安装 TuraIDC（生成 .env、导入数据库、创建管理员）';
+
+    public function handle(InstallService $installer): int
+    {
+        if ($installer->isInstalled()) {
+            $this->components->error('系统已安装。如需重装，请先手动删除 storage/app/'.InstallService::LOCK_FILE.' 并清理数据库。');
+
+            return self::FAILURE;
+        }
+
+        $this->info('=== TuraIDC 安装程序（CLI）===');
+        $this->newLine();
+
+        // 环境检测。
+        $failed = [];
+        $rows = [];
+        foreach ($installer->requirements() as $item) {
+            $rows[] = [$item['name'], $item['passed'] ? '通过' : '未通过', $item['message']];
+            if ($item['required'] && ! $item['passed']) {
+                $failed[] = $item['name'];
+            }
+        }
+        $this->table(['检测项', '结果', '说明'], $rows);
+        $this->newLine();
+
+        if ($failed !== []) {
+            $this->components->error('环境检测未通过：'.implode('；', $failed));
+
+            return self::FAILURE;
+        }
+
+        try {
+            $payload = $this->collectPayload($installer);
+        } catch (Throwable $exception) {
+            $this->components->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if (! $this->confirm('确认使用以上配置开始安装？', true)) {
+            $this->info('已取消安装。');
+
+            return self::SUCCESS;
+        }
+
+        try {
+            $result = $installer->install($payload, function (string $message): void {
+                $this->line('[install] '.$message);
+            });
+        } catch (InstallException $exception) {
+            $this->components->error('安装失败：'.$exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->info('安装完成。');
+        $this->line('管理员账号：'.$result['admin_username']);
+        $this->line('管理员邮箱：'.$result['admin_email']);
+        $this->line('请妥善保存以上凭据，并尽快访问管理端验证登录。');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * 收集安装参数：显式选项优先，缺失项进入交互问答。
+     *
+     * @return array<string, mixed>
+     */
+    private function collectPayload(InstallService $installer): array
+    {
+        $payload = [
+            'app_name' => '图拉云',
+            'app_url' => (string) $this->option('app-url'),
+            'frontend_url' => (string) $this->option('frontend-url'),
+            'client_console_url' => (string) $this->option('console-url'),
+            'admin_url' => (string) $this->option('admin-url'),
+            'db_host' => (string) $this->option('db-host'),
+            'db_port' => (string) $this->option('db-port'),
+            'db_database' => (string) $this->option('db-database'),
+            'db_username' => (string) $this->option('db-username'),
+            'db_password' => (string) $this->option('db-password'),
+            'redis_host' => (string) $this->option('redis-host'),
+            'redis_port' => (string) $this->option('redis-port'),
+            'redis_password' => (string) $this->option('redis-password'),
+            'admin_username' => (string) $this->option('admin-username'),
+            'admin_email' => (string) $this->option('admin-email'),
+            'admin_password' => (string) $this->option('admin-password'),
+        ];
+
+        $askUrl = function (string $key, string $label) use (&$payload): void {
+            if ((string) $payload[$key] !== '') {
+                return;
+            }
+            $payload[$key] = $this->ask($label.'（如 https://api.example.com）') ?? '';
+        };
+
+        $askUrl('app_url', '后端 API 公开地址');
+        $askUrl('frontend_url', '官网门户地址');
+        $askUrl('client_console_url', '用户控制台地址');
+        $askUrl('admin_url', '管理端地址');
+
+        if ((string) $payload['db_database'] === '') {
+            $payload['db_database'] = $this->ask('数据库名') ?? '';
+        }
+        if ((string) $payload['db_username'] === '') {
+            $payload['db_username'] = $this->ask('数据库用户名') ?? '';
+        }
+        if ($this->didntReceiveOption('db-password')) {
+            $payload['db_password'] = (string) $this->secret('数据库密码（可为空）');
+        }
+
+        $test = $installer->testDatabase($payload);
+        $this->line('数据库检测：'.$test['message']);
+        if (! $test['ok']) {
+            throw new InstallException($test['message']);
+        }
+
+        $redisTest = $installer->testRedis($payload);
+        $this->line('Redis 检测：'.$redisTest['message']);
+        if (! $redisTest['ok']) {
+            throw new InstallException($redisTest['message']);
+        }
+
+        if ((string) $payload['admin_username'] === '') {
+            $payload['admin_username'] = $this->ask('管理员用户名（字母开头，3-32 位）') ?? '';
+        }
+        if ((string) $payload['admin_email'] === '') {
+            $payload['admin_email'] = $this->ask('管理员邮箱') ?? '';
+        }
+        if ($this->didntReceiveOption('admin-password')) {
+            $payload['admin_password'] = (string) $this->secret('管理员密码（至少 '.InstallService::ADMIN_PASSWORD_MIN_LENGTH.' 位）');
+        }
+
+        return $installer->validatePayload($payload);
+    }
+
+    /**
+     * 判断选项是否由命令行显式传入（区分“传了空值”与“未传”）。
+     */
+    private function didntReceiveOption(string $name): bool
+    {
+        return ! array_key_exists($name, $this->options()) || $this->option($name) === null;
+    }
+}

--- a/backend/app/Http/Controllers/InstallController.php
+++ b/backend/app/Http/Controllers/InstallController.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Services\Install\InstallException;
+use App\Services\Install\InstallService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Throwable;
+
+/**
+ * Web 安装向导：GET /install。
+ *
+ * 已安装（安装锁或管理员已存在）后所有入口直接 404，防止向导被重放。
+ * 安装期间不依赖 session/cookie，接口统一豁免 CSRF（见 bootstrap/app.php）。
+ */
+class InstallController extends Controller
+{
+    public function __construct(
+        private readonly InstallService $installer,
+    ) {}
+
+    public function index()
+    {
+        abort_if($this->installer->isInstalled(), 404);
+
+        return view('install.index');
+    }
+
+    public function requirements(): JsonResponse
+    {
+        abort_if($this->installer->isInstalled(), 404);
+
+        return response()->json([
+            'code' => 0,
+            'data' => [
+                'items' => $this->installer->requirements(),
+                'passed' => $this->installer->requirementsPassed(),
+            ],
+        ]);
+    }
+
+    public function test(Request $request): JsonResponse
+    {
+        abort_if($this->installer->isInstalled(), 404);
+
+        $database = $this->installer->testDatabase([
+            'host' => (string) $request->input('db_host', ''),
+            'port' => (int) $request->input('db_port', 3306),
+            'database' => (string) $request->input('db_database', ''),
+            'username' => (string) $request->input('db_username', ''),
+            'password' => (string) $request->input('db_password', ''),
+        ]);
+
+        $redis = $this->installer->testRedis([
+            'host' => (string) $request->input('redis_host', ''),
+            'port' => (int) $request->input('redis_port', 6379),
+            'password' => (string) $request->input('redis_password', ''),
+        ]);
+
+        return response()->json([
+            'code' => 0,
+            'data' => [
+                'database' => $database,
+                'redis' => $redis,
+            ],
+        ]);
+    }
+
+    public function run(Request $request): JsonResponse
+    {
+        abort_if($this->installer->isInstalled(), 404);
+
+        try {
+            $payload = $this->installer->validatePayload($request->all());
+        } catch (InstallException $exception) {
+            return $this->installError($exception->getMessage());
+        }
+
+        // 安装包含 schema 导入与迁移，放宽执行时限（FPM 层超时需运维侧放宽）。
+        if (function_exists('set_time_limit')) {
+            @set_time_limit(0);
+        }
+
+        $logs = [];
+        try {
+            $result = $this->installer->install($payload, static function (string $message) use (&$logs): void {
+                $logs[] = $message;
+            });
+        } catch (InstallException $exception) {
+            return $this->installError($exception->getMessage(), $logs);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return $this->installError('安装出现意外错误：'.$exception->getMessage(), $logs);
+        }
+
+        return response()->json([
+            'code' => 0,
+            'data' => [
+                'logs' => $logs,
+                'admin_username' => $result['admin_username'],
+                'admin_email' => $result['admin_email'],
+                'admin_url' => $payload['admin_url'],
+            ],
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $logs
+     */
+    private function installError(string $message, array $logs = []): JsonResponse
+    {
+        return response()->json([
+            'code' => 50000,
+            'message' => $message,
+            'data' => ['logs' => $logs],
+        ], 422);
+    }
+}

--- a/backend/app/Services/Install/InstallException.php
+++ b/backend/app/Services/Install/InstallException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Install;
+
+use App\Exceptions\BusinessException;
+
+/**
+ * 安装流程中的可预期错误，消息面向安装者展示。
+ */
+class InstallException extends BusinessException
+{
+}

--- a/backend/app/Services/Install/InstallService.php
+++ b/backend/app/Services/Install/InstallService.php
@@ -224,7 +224,8 @@ class InstallService
         } catch (Throwable $exception) {
             throw new InstallException('目标库连接失败：'.$exception->getMessage());
         }
-        $statement = $dbPdo->query('SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '.$dbPdo->quote($database));
+        $statement = $dbPdo->prepare('SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ?');
+        $statement->execute([$database]);
         $tableCount = (int) $statement->fetchColumn();
         if ($tableCount === 0) {
             $logger('导入数据库结构（schema baseline）');

--- a/backend/app/Services/Install/InstallService.php
+++ b/backend/app/Services/Install/InstallService.php
@@ -1,0 +1,579 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Install;
+
+use App\Models\AdminUser;
+use App\Models\Role;
+use App\Services\Admin\Rbac\BuiltinAdminRoleService;
+use Database\Seeders\SettingsSeeder;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PDO;
+use Redis;
+use RedisException;
+use RuntimeException;
+use Throwable;
+
+/**
+ * 安装服务：Web 向导与 app:install 命令共用的唯一安装实现。
+ *
+ * 流程对齐 scripts/install_db.py：建库 → 导入 schema baseline → 增量迁移
+ * → 同步内置角色 → 创建管理员 → 种入默认配置 → 写安装锁。
+ * 全程进程内执行，不依赖 mysql 客户端与 Python。
+ */
+class InstallService
+{
+    /** 安装锁文件（存在即视为已安装） */
+    public const LOCK_FILE = 'install.lock';
+
+    /** schema baseline 真源 */
+    private const SCHEMA_FILE = 'database/schema/mysql-schema.sql';
+
+    /** .env 生成模板 */
+    private const ENV_TEMPLATE = '.env.example';
+
+    /** 管理员密码最小长度（对齐 install_db.py 生产环境要求） */
+    public const ADMIN_PASSWORD_MIN_LENGTH = 12;
+
+    /** 生成 .env 时需要替换的键（保持 .env.example 其余行原样） */
+    private const REPLACEABLE_KEYS = [
+        'APP_NAME', 'APP_ENV', 'APP_DEBUG', 'APP_URL',
+        'FRONTEND_URL', 'CLIENT_CONSOLE_URL', 'ADMIN_URL',
+        'DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USERNAME', 'DB_PASSWORD',
+        'REDIS_HOST', 'REDIS_PORT', 'REDIS_PASSWORD',
+        'TICKET_UPSTREAM_CALLBACK_SECRET',
+    ];
+
+    /**
+     * 是否已安装：安装锁存在或已有管理员账号。
+     */
+    public function isInstalled(): bool
+    {
+        if (is_file($this->lockPath())) {
+            return true;
+        }
+
+        // 锁文件丢失（如手动清理 storage）时以管理员表兜底，避免已装站点暴露向导。
+        try {
+            return Schema::hasTable((new AdminUser())->getTable())
+                && AdminUser::query()->exists();
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * 环境检测项。
+     *
+     * @return list<array{name: string, required: bool, passed: bool, message: string}>
+     */
+    public function requirements(): array
+    {
+        $items = [
+            ['name' => 'PHP 版本 >= 8.3', 'required' => true, 'passed' => PHP_VERSION_ID >= 80300, 'message' => '当前 '.PHP_VERSION],
+            ['name' => 'PHP 扩展 pdo_mysql', 'required' => true, 'passed' => extension_loaded('pdo_mysql'), 'message' => ''],
+            ['name' => 'PHP 扩展 redis', 'required' => true, 'passed' => extension_loaded('redis'), 'message' => ''],
+            ['name' => 'PHP 扩展 openssl', 'required' => true, 'passed' => extension_loaded('openssl'), 'message' => ''],
+            ['name' => 'PHP 扩展 mbstring', 'required' => true, 'passed' => extension_loaded('mbstring'), 'message' => ''],
+            ['name' => 'PHP 扩展 fileinfo', 'required' => true, 'passed' => extension_loaded('fileinfo'), 'message' => ''],
+            ['name' => 'PHP 扩展 json', 'required' => true, 'passed' => extension_loaded('json'), 'message' => ''],
+            ['name' => 'Composer 依赖已安装（vendor/）', 'required' => true, 'passed' => is_file(base_path('vendor/autoload.php')), 'message' => ''],
+            ['name' => 'schema baseline 存在', 'required' => true, 'passed' => is_file($this->schemaPath()), 'message' => ''],
+            ['name' => '.env 模板存在', 'required' => true, 'passed' => is_file(base_path(self::ENV_TEMPLATE)), 'message' => ''],
+            ['name' => 'storage/ 目录可写', 'required' => true, 'passed' => is_writable(storage_path()), 'message' => ''],
+            ['name' => 'bootstrap/cache/ 目录可写', 'required' => true, 'passed' => is_writable(base_path('bootstrap/cache')), 'message' => ''],
+            ['name' => '.env 可写（不存在或可写入）', 'required' => true, 'passed' => $this->envFileWritable(), 'message' => ''],
+        ];
+
+        foreach ($items as &$item) {
+            $item['message'] = trim($item['message']);
+        }
+
+        return $items;
+    }
+
+    public function requirementsPassed(): bool
+    {
+        foreach ($this->requirements() as $item) {
+            if ($item['required'] && ! $item['passed']) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 测试数据库连接（不写任何配置）。
+     *
+     * @param  array{host: string, port: int, database: string, username: string, password: string}  $config
+     * @return array{ok: bool, message: string, database_exists: bool, database_empty: bool}
+     */
+    public function testDatabase(array $config): array
+    {
+        try {
+            $pdo = $this->makePdo($config['host'], (int) $config['port'], '', $config['username'], $config['password']);
+        } catch (Throwable $exception) {
+            return ['ok' => false, 'message' => '数据库连接失败：'.$exception->getMessage(), 'database_exists' => false, 'database_empty' => false];
+        }
+
+        $database = trim((string) $config['database']);
+        if ($database === '') {
+            return ['ok' => false, 'message' => '数据库名不能为空', 'database_exists' => false, 'database_empty' => false];
+        }
+
+        $exists = $this->databaseExists($pdo, $database);
+        $tableCount = 0;
+        if ($exists) {
+            $statement = $pdo->prepare('SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ?');
+            $statement->execute([$database]);
+            $tableCount = (int) $statement->fetchColumn();
+        }
+
+        return [
+            'ok' => true,
+            'message' => $exists
+                ? sprintf('连接成功，库已存在（%d 张表）', $tableCount)
+                : '连接成功，库不存在（将自动创建）',
+            'database_exists' => $exists,
+            'database_empty' => $tableCount === 0,
+        ];
+    }
+
+    /**
+     * 测试 Redis 连接（不写任何配置）。
+     *
+     * @param  array{host: string, port: int, password: string}  $config
+     * @return array{ok: bool, message: string}
+     */
+    public function testRedis(array $config): array
+    {
+        if (! extension_loaded('redis')) {
+            return ['ok' => false, 'message' => 'PHP redis 扩展未安装'];
+        }
+
+        try {
+            $redis = new Redis();
+            $connected = $redis->connect($config['host'], (int) $config['port'], 3.0);
+            if (! $connected) {
+                return ['ok' => false, 'message' => 'Redis 连接失败'];
+            }
+            $password = trim((string) $config['password']);
+            if ($password !== '' && ! $redis->auth($password)) {
+                return ['ok' => false, 'message' => 'Redis 密码认证失败'];
+            }
+            $pong = (string) $redis->ping();
+        } catch (RedisException|Throwable $exception) {
+            return ['ok' => false, 'message' => 'Redis 连接失败：'.$exception->getMessage()];
+        }
+
+        return ['ok' => true, 'message' => 'Redis 连接正常（'.$pong.'）'];
+    }
+
+    /**
+     * 执行安装主流程。
+     *
+     * @param  array<string, mixed>  $payload  已通过 validatePayload 校验的配置
+     * @param  callable(string): void  $logger  步骤日志回调
+     * @return array{admin_username: string, admin_email: string}
+     *
+     * @throws InstallException 安装失败（消息可直接展示给用户）
+     */
+    public function install(array $payload, callable $logger): array
+    {
+        if ($this->isInstalled()) {
+            throw new InstallException('系统已安装，如需重装请先删除 '.$this->lockPath());
+        }
+        if (! $this->requirementsPassed()) {
+            throw new InstallException('环境检测未通过，请先处理未满足的必选项');
+        }
+
+        // 写 .env 并让当前进程立即使用新配置（后续 migrate / 种子都依赖）。
+        $logger('生成 .env 配置文件');
+        $this->writeEnvironmentFile($payload);
+        $this->refreshRuntimeConfig($payload);
+        $appKey = $this->ensureAppKey();
+        $this->refreshRuntimeConfig($payload, $appKey);
+
+        // 数据库：确保库存在。
+        $logger('连接数据库并确认目标库');
+        $database = (string) $payload['db_database'];
+        try {
+            $adminPdo = $this->makePdo($payload['db_host'], (int) $payload['db_port'], '', $payload['db_username'], $payload['db_password']);
+        } catch (Throwable $exception) {
+            throw new InstallException('数据库连接失败：'.$exception->getMessage());
+        }
+        if (! $this->databaseExists($adminPdo, $database)) {
+            $logger('创建数据库 '.$database);
+            $adminPdo->exec(
+                sprintf(
+                    'CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
+                    str_replace('`', '``', $database)
+                )
+            );
+        }
+
+        // 空库导入 schema baseline；非空库跳过（由增量迁移对齐）。
+        try {
+            $dbPdo = $this->makePdo($payload['db_host'], (int) $payload['db_port'], $database, $payload['db_username'], $payload['db_password']);
+        } catch (Throwable $exception) {
+            throw new InstallException('目标库连接失败：'.$exception->getMessage());
+        }
+        $statement = $dbPdo->query('SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '.$dbPdo->quote($database));
+        $tableCount = (int) $statement->fetchColumn();
+        if ($tableCount === 0) {
+            $logger('导入数据库结构（schema baseline）');
+            $sql = file_get_contents($this->schemaPath());
+            if ($sql === false || trim($sql) === '') {
+                throw new InstallException('schema baseline 文件为空：'.$this->schemaPath());
+            }
+            $dbPdo->exec($sql);
+        } else {
+            $logger(sprintf('目标库已有 %d 张表，跳过 baseline 导入', $tableCount));
+        }
+
+        // 增量迁移（进程内 Artisan，配置已刷新）。
+        $logger('执行数据库增量迁移');
+        try {
+            Artisan::call('migrate', ['--force' => true]);
+            $output = trim(Artisan::output());
+            if ($output !== '') {
+                $logger($output);
+            }
+        } catch (Throwable $exception) {
+            throw new InstallException('数据库迁移失败：'.$exception->getMessage());
+        }
+
+        // 默认配置与通知模板。
+        $logger('写入系统默认配置与通知模板');
+        try {
+            SettingsSeeder::seed();
+        } catch (Throwable $exception) {
+            throw new InstallException('默认配置写入失败：'.$exception->getMessage());
+        }
+
+        // 管理员账号。
+        $logger('创建管理员账号');
+        $this->createAdmin(
+            (string) $payload['admin_username'],
+            (string) $payload['admin_password'],
+            (string) $payload['admin_email']
+        );
+
+        $logger('清理缓存并写入安装锁');
+        $this->clearCaches();
+        $this->writeLock();
+
+        Log::info('[install] 系统安装完成', ['database' => $database]);
+
+        return [
+            'admin_username' => (string) $payload['admin_username'],
+            'admin_email' => (string) $payload['admin_email'],
+        ];
+    }
+
+    /**
+     * 校验安装参数，失败抛 InstallException。
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed> 规范化后的 payload
+     */
+    public function validatePayload(array $payload): array
+    {
+        $get = static fn (string $key, mixed $default = '') => is_string($payload[$key] ?? null) ? trim($payload[$key]) : $default;
+
+        $normalized = [
+            'app_name' => $get('app_name') ?: '图拉云',
+            'app_url' => rtrim($get('app_url'), '/'),
+            'frontend_url' => rtrim($get('frontend_url'), '/'),
+            'client_console_url' => rtrim($get('client_console_url'), '/'),
+            'admin_url' => rtrim($get('admin_url'), '/'),
+            'db_host' => $get('db_host') ?: '127.0.0.1',
+            'db_port' => (int) ($get('db_port') ?: 3306),
+            'db_database' => $get('db_database'),
+            'db_username' => $get('db_username'),
+            'db_password' => (string) ($payload['db_password'] ?? ''),
+            'redis_host' => $get('redis_host') ?: '127.0.0.1',
+            'redis_port' => (int) ($get('redis_port') ?: 6379),
+            'redis_password' => (string) ($payload['redis_password'] ?? ''),
+            'admin_username' => $get('admin_username'),
+            'admin_email' => $get('admin_email'),
+            'admin_password' => (string) ($payload['admin_password'] ?? ''),
+        ];
+
+        foreach (['app_url', 'frontend_url', 'client_console_url', 'admin_url'] as $urlKey) {
+            $value = (string) $normalized[$urlKey];
+            if ($value === '' || ! filter_var($value, FILTER_VALIDATE_URL)) {
+                throw new InstallException('地址配置无效：'.$urlKey.' 需为完整 URL（如 https://api.example.com）');
+            }
+        }
+
+        foreach (['db_database' => '数据库名', 'db_username' => '数据库用户名'] as $key => $label) {
+            if ((string) $normalized[$key] === '') {
+                throw new InstallException($label.'不能为空');
+            }
+        }
+
+        $username = (string) $normalized['admin_username'];
+        if (! preg_match('/\A[a-zA-Z][a-zA-Z0-9_]{2,31}\z/', $username)) {
+            throw new InstallException('管理员用户名需以字母开头，3-32 位字母数字下划线');
+        }
+
+        $email = (string) $normalized['admin_email'];
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InstallException('管理员邮箱格式无效');
+        }
+
+        $password = (string) $normalized['admin_password'];
+        if (strlen($password) < self::ADMIN_PASSWORD_MIN_LENGTH) {
+            throw new InstallException('管理员密码长度不能少于 '.self::ADMIN_PASSWORD_MIN_LENGTH.' 位');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * 基于 .env.example 生成 .env，仅替换白名单键，其余注释与默认值原样保留。
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeEnvironmentFile(array $payload): void
+    {
+        $templatePath = base_path(self::ENV_TEMPLATE);
+        $template = file_get_contents($templatePath);
+        if ($template === false) {
+            throw new InstallException('无法读取 .env 模板：'.$templatePath);
+        }
+
+        $values = [
+            'APP_NAME' => (string) $payload['app_name'],
+            'APP_ENV' => 'production',
+            'APP_DEBUG' => 'false',
+            'APP_URL' => (string) $payload['app_url'],
+            'FRONTEND_URL' => (string) $payload['frontend_url'],
+            'CLIENT_CONSOLE_URL' => (string) $payload['client_console_url'],
+            'ADMIN_URL' => (string) $payload['admin_url'],
+            'DB_HOST' => (string) $payload['db_host'],
+            'DB_PORT' => (string) $payload['db_port'],
+            'DB_DATABASE' => (string) $payload['db_database'],
+            'DB_USERNAME' => (string) $payload['db_username'],
+            'DB_PASSWORD' => (string) $payload['db_password'],
+            'REDIS_HOST' => (string) $payload['redis_host'],
+            'REDIS_PORT' => (string) $payload['redis_port'],
+            'REDIS_PASSWORD' => (string) $payload['redis_password'],
+            // 随机生成回调签名密钥，避免空密钥下上游回调验签失效。
+            'TICKET_UPSTREAM_CALLBACK_SECRET' => Str::random(48),
+        ];
+
+        $replaced = [];
+        $lines = preg_split('/\r\n|\r|\n/', $template) ?: [];
+        foreach ($lines as &$line) {
+            $trimmed = ltrim($line);
+            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+                continue;
+            }
+            $equalsPosition = strpos($trimmed, '=');
+            if ($equalsPosition === false) {
+                continue;
+            }
+            $key = substr($trimmed, 0, $equalsPosition);
+            if (! in_array($key, self::REPLACEABLE_KEYS, true) || isset($replaced[$key])) {
+                continue;
+            }
+            $indent = substr($line, 0, strlen($line) - strlen($trimmed));
+            $line = $indent.$key.'='.$this->formatEnvValue((string) $values[$key]);
+            $replaced[$key] = true;
+        }
+        unset($line);
+
+        // 模板中不存在的白名单键（理论上不会发生）追加到文件末尾。
+        foreach ($values as $key => $value) {
+            if (! isset($replaced[$key])) {
+                $lines[] = $key.'='.$this->formatEnvValue((string) $value);
+            }
+        }
+
+        if (file_put_contents(base_path('.env'), implode(PHP_EOL, $lines).PHP_EOL) === false) {
+            throw new InstallException('写入 .env 失败，请检查 backend 目录权限');
+        }
+    }
+
+    private function formatEnvValue(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+        // 含空格、#、引号或 $ 的值必须加双引号并转义，与 dotenv 解析规则一致。
+        if (preg_match('/[\s#"\'$]/', $value) === 1) {
+            return '"'.str_replace(['\\', '"'], ['\\\\', '\\"'], $value).'"';
+        }
+
+        return $value;
+    }
+
+    /**
+     * 生成 APP_KEY 并写回 .env；返回生成值。
+     */
+    private function ensureAppKey(): string
+    {
+        $envPath = base_path('.env');
+        $content = (string) file_get_contents($envPath);
+
+        $currentKey = '';
+        if (preg_match('/^APP_KEY=(.*)$/m', $content, $matches) === 1) {
+            $currentKey = trim(trim($matches[1]), '"\'');
+        }
+
+        if (str_starts_with($currentKey, 'base64:')) {
+            return $currentKey;
+        }
+
+        $key = 'base64:'.base64_encode(random_bytes(32));
+        $updated = preg_match('/^APP_KEY=.*$/m', $content) === 1
+            ? preg_replace('/^APP_KEY=.*$/m', 'APP_KEY='.$key, $content)
+            : $content.PHP_EOL.'APP_KEY='.$key.PHP_EOL;
+
+        if (file_put_contents($envPath, (string) $updated) === false) {
+            throw new InstallException('写入 APP_KEY 失败');
+        }
+
+        return $key;
+    }
+
+    /**
+     * 让当前进程立即应用新 .env 的关键连接配置（Artisan::call 不会重读 .env）。
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function refreshRuntimeConfig(array $payload, ?string $appKey = null): void
+    {
+        config()->set('database.connections.mysql.host', (string) $payload['db_host']);
+        config()->set('database.connections.mysql.port', (int) $payload['db_port']);
+        config()->set('database.connections.mysql.database', (string) $payload['db_database']);
+        config()->set('database.connections.mysql.username', (string) $payload['db_username']);
+        config()->set('database.connections.mysql.password', (string) $payload['db_password']);
+
+        $redisPassword = (string) $payload['redis_password'] !== '' ? (string) $payload['redis_password'] : null;
+        // 项目使用 default / cache / volatile 三个 Redis 连接，全部指向同一实例。
+        foreach (['default', 'cache', 'volatile'] as $connection) {
+            config()->set('database.redis.'.$connection.'.host', (string) $payload['redis_host']);
+            config()->set('database.redis.'.$connection.'.port', (int) $payload['redis_port']);
+            config()->set('database.redis.'.$connection.'.password', $redisPassword);
+        }
+
+        if ($appKey !== null && $appKey !== '') {
+            config()->set('app.key', $appKey);
+        }
+
+        DB::purge('mysql');
+    }
+
+    /**
+     * 同步内置角色并创建超级管理员（对齐 install_db.py 的 bootstrap 逻辑）。
+     */
+    private function createAdmin(string $username, string $password, string $email): void
+    {
+        try {
+            app(BuiltinAdminRoleService::class)->sync();
+
+            $superAdminRole = Role::query()->where('name', 'super_admin')->first();
+            if (! $superAdminRole instanceof Role) {
+                throw new RuntimeException('super_admin 角色不存在');
+            }
+
+            $admin = AdminUser::query()->firstOrNew(['username' => $username]);
+            if ($admin->exists) {
+                throw new InstallException('管理员用户名已存在：'.$username);
+            }
+
+            $admin->forceFill([
+                'role_id' => (int) $superAdminRole->id,
+                'nickname' => '超级管理员',
+                'email' => $email,
+                'password' => $password,
+                'status' => 1,
+            ])->save();
+
+            if (Schema::hasTable('admin_user_roles')) {
+                DB::table('admin_user_roles')->updateOrInsert(
+                    [
+                        'admin_user_id' => (int) $admin->id,
+                        'role_id' => (int) $superAdminRole->id,
+                    ],
+                    []
+                );
+            }
+        } catch (InstallException $installException) {
+            throw $installException;
+        } catch (Throwable $exception) {
+            throw new InstallException('管理员创建失败：'.$exception->getMessage());
+        }
+    }
+
+    private function clearCaches(): void
+    {
+        foreach (['config:clear', 'cache:clear', 'route:clear', 'view:clear'] as $command) {
+            try {
+                Artisan::call($command);
+            } catch (Throwable) {
+                // 清缓存失败不影响安装结果。
+            }
+        }
+    }
+
+    private function writeLock(): void
+    {
+        $payload = json_encode([
+            'installed_at' => now()->toIso8601String(),
+            'version' => (string) config('app.version', ''),
+        ], JSON_UNESCAPED_UNICODE);
+
+        if (file_put_contents($this->lockPath(), (string) $payload.PHP_EOL) === false) {
+            throw new InstallException('写入安装锁失败：'.$this->lockPath());
+        }
+    }
+
+    private function lockPath(): string
+    {
+        return storage_path('app/'.self::LOCK_FILE);
+    }
+
+    private function schemaPath(): string
+    {
+        return base_path(self::SCHEMA_FILE);
+    }
+
+    private function envFileWritable(): bool
+    {
+        $envPath = base_path('.env');
+
+        return ! is_file($envPath) || is_writable($envPath);
+    }
+
+    private function databaseExists(PDO $pdo, string $database): bool
+    {
+        $statement = $pdo->prepare('SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = ?');
+
+        return $statement->execute([$database]) && (int) $statement->fetchColumn() > 0;
+    }
+
+    private function makePdo(string $host, int $port, string $database, string $username, string $password): PDO
+    {
+        $dsn = sprintf(
+            'mysql:host=%s;port=%d%s;charset=utf8mb4',
+            $host,
+            $port,
+            $database !== '' ? ';dbname='.$database : ''
+        );
+
+        return new PDO($dsn, $username, $password, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_TIMEOUT => 5,
+        ]);
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -94,6 +94,9 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->validateCsrfTokens(except: [
             'api/*',
             'upload_image',
+            // 安装向导运行于全新站点，session/cookie 域名与 HTTPS 可能尚未就绪，
+            // 豁免 CSRF；防重放依赖安装锁（storage/app/install.lock）与限流。
+            'install/*',
         ]);
 
         $middleware->alias([

--- a/backend/resources/views/install/index.blade.php
+++ b/backend/resources/views/install/index.blade.php
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex,nofollow">
+    <title>图拉云 TuraIDC 安装向导</title>
+    <style>
+        :root { --brand: #0052d9; --ok: #2ba471; --bad: #d54941; --line: #e7e7e7; --text: #333; --muted: #8a8a8a; }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: "PingFang SC", "Microsoft YaHei", system-ui, sans-serif; background: #f3f4f6; color: var(--text); min-height: 100vh; display: flex; justify-content: center; padding: 40px 16px; }
+        .card { background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.06); width: 100%; max-width: 780px; padding: 32px 40px; }
+        h1 { font-size: 20px; margin-bottom: 4px; }
+        .sub { color: var(--muted); font-size: 13px; margin-bottom: 24px; }
+        .steps { display: flex; gap: 8px; margin-bottom: 28px; }
+        .steps span { flex: 1; text-align: center; font-size: 13px; color: var(--muted); padding: 8px 0; border-bottom: 2px solid var(--line); }
+        .steps span.active { color: var(--brand); border-color: var(--brand); font-weight: 600; }
+        .steps span.done { color: var(--ok); border-color: var(--ok); }
+        .panel { display: none; }
+        .panel.show { display: block; }
+        .req-list { border: 1px solid var(--line); border-radius: 6px; overflow: hidden; margin-bottom: 16px; }
+        .req-list li { display: flex; align-items: center; gap: 10px; padding: 10px 14px; font-size: 13px; border-bottom: 1px solid var(--line); list-style: none; }
+        .req-list li:last-child { border-bottom: none; }
+        .tag { font-size: 12px; padding: 2px 10px; border-radius: 10px; }
+        .tag.ok { color: var(--ok); background: #e8f5ef; }
+        .tag.bad { color: var(--bad); background: #fbeceb; }
+        .msg { color: var(--muted); margin-left: auto; font-size: 12px; }
+        h2 { font-size: 15px; margin: 18px 0 10px; }
+        .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 16px; }
+        label { display: block; font-size: 13px; margin-bottom: 4px; color: #555; }
+        input { width: 100%; padding: 9px 12px; border: 1px solid var(--line); border-radius: 6px; font-size: 13px; outline: none; }
+        input:focus { border-color: var(--brand); }
+        .full { grid-column: 1 / -1; }
+        .hint { font-size: 12px; color: var(--muted); margin-top: 4px; }
+        .btns { display: flex; gap: 12px; margin-top: 24px; }
+        button { padding: 10px 28px; border-radius: 6px; font-size: 14px; cursor: pointer; border: none; }
+        .primary { background: var(--brand); color: #fff; }
+        .primary:disabled { background: #a8c0ea; cursor: not-allowed; }
+        .ghost { background: #fff; color: var(--brand); border: 1px solid var(--brand); }
+        .log { background: #1e1e1e; color: #d4d4d4; font-family: Consolas, monospace; font-size: 12px; border-radius: 6px; padding: 14px; max-height: 320px; overflow-y: auto; white-space: pre-wrap; margin-bottom: 16px; }
+        .log .ok { color: #6bc46d; }
+        .log .err { color: #f0705f; }
+        .alert { padding: 12px 14px; border-radius: 6px; font-size: 13px; margin-bottom: 16px; display: none; }
+        .alert.err { background: #fbeceb; color: var(--bad); display: block; }
+        .alert.ok { background: #e8f5ef; color: var(--ok); display: block; }
+        .done-box { border: 1px solid #cfe6db; background: #f2faf6; border-radius: 6px; padding: 16px; font-size: 13px; line-height: 1.9; margin-bottom: 16px; }
+        .done-box strong { color: var(--ok); }
+        .cred { font-family: Consolas, monospace; background: #fff; border: 1px solid var(--line); border-radius: 4px; padding: 1px 8px; }
+        ol.next { padding-left: 20px; font-size: 13px; color: #555; line-height: 2; }
+        .spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid #fff6; border-top-color: #fff; border-radius: 50%; animation: spin .7s linear infinite; vertical-align: -2px; margin-right: 6px; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
+</head>
+<body>
+<div class="card">
+    <h1>图拉云 TuraIDC 安装向导</h1>
+    <div class="sub">安装程序将生成 .env、初始化数据库并创建管理员账号；已安装系统无法重复进入本向导。</div>
+
+    <div class="steps">
+        <span id="step-1" class="active">1. 环境检测</span>
+        <span id="step-2">2. 配置信息</span>
+        <span id="step-3">3. 执行安装</span>
+        <span id="step-4">4. 安装完成</span>
+    </div>
+
+    <div id="alert" class="alert"></div>
+
+    <div id="panel-1" class="panel show">
+        <div class="req-list"><ul id="req-list"></ul></div>
+        <div class="btns">
+            <button class="primary" id="btn-req-refresh">重新检测</button>
+            <button class="primary" id="btn-req-next" disabled>下一步</button>
+        </div>
+    </div>
+
+    <div id="panel-2" class="panel">
+        <h2>数据库（MySQL 8）</h2>
+        <div class="grid">
+            <div><label>主机</label><input id="db_host" value="127.0.0.1"></div>
+            <div><label>端口</label><input id="db_port" value="3306"></div>
+            <div><label>数据库名</label><input id="db_database" placeholder="idc"></div>
+            <div><label>用户名</label><input id="db_username" placeholder="idc"></div>
+            <div class="full"><label>密码</label><input id="db_password" type="password" placeholder="可为空"><div class="hint">目标库不存在时将自动创建；非空库会跳过结构导入并执行增量迁移。</div></div>
+        </div>
+        <h2>Redis</h2>
+        <div class="grid">
+            <div><label>主机</label><input id="redis_host" value="127.0.0.1"></div>
+            <div><label>端口</label><input id="redis_port" value="6379"></div>
+            <div class="full"><label>密码</label><input id="redis_password" type="password" placeholder="可为空"></div>
+        </div>
+        <h2>站点地址（四个 origin 必须互不相同、同协议）</h2>
+        <div class="grid">
+            <div><label>后端 API 地址</label><input id="app_url" placeholder="https://api.example.com"></div>
+            <div><label>官网门户地址</label><input id="frontend_url" placeholder="https://www.example.com"></div>
+            <div><label>用户控制台地址</label><input id="client_console_url" placeholder="https://console.example.com"></div>
+            <div><label>管理端地址</label><input id="admin_url" placeholder="https://admin.example.com"></div>
+        </div>
+        <h2>管理员账号</h2>
+        <div class="grid">
+            <div><label>用户名</label><input id="admin_username" placeholder="字母开头，3-32 位"></div>
+            <div><label>邮箱</label><input id="admin_email" placeholder="admin@example.com"></div>
+            <div class="full"><label>密码</label><input id="admin_password" type="password" placeholder="至少 12 位"><div class="hint">安装完成后请立即登录管理端并妥善保管。</div></div>
+        </div>
+        <div class="btns">
+            <button class="ghost" id="btn-back-1">上一步</button>
+            <button class="ghost" id="btn-test">测试连接</button>
+            <button class="primary" id="btn-install">开始安装</button>
+        </div>
+    </div>
+
+    <div id="panel-3" class="panel">
+        <div class="log" id="install-log">正在准备安装…</div>
+        <div class="hint">安装包含数据库结构与默认数据写入，视服务器性能可能需要数十秒到数分钟，请勿关闭页面。</div>
+    </div>
+
+    <div id="panel-4" class="panel">
+        <div class="done-box" id="done-box"></div>
+        <h2>后续步骤</h2>
+        <ol class="next">
+            <li>登录管理端，确认管理员账号可用，并尽快修改默认通知、支付等配置。</li>
+            <li>按部署文档构建并发布三端前端（frontend-admin-v3 / frontend-user-v3-www / frontend-user-v4-console）。</li>
+            <li>配置队列 Worker 与调度任务（schedule:run、queue:work），详见部署文档。</li>
+            <li>确认 storage/app/install.lock 存在且不可被 Web 访问，防止向导被再次触发。</li>
+        </ol>
+    </div>
+</div>
+
+<script>
+(function () {
+    'use strict';
+
+    var $ = function (id) { return document.getElementById(id); };
+    var alertBox = $('alert');
+    var logs = [];
+
+    function showAlert(type, message) {
+        alertBox.className = 'alert ' + type;
+        alertBox.textContent = message;
+    }
+    function clearAlert() { alertBox.className = 'alert'; alertBox.textContent = ''; }
+
+    function goStep(n) {
+        for (var i = 1; i <= 4; i++) {
+            $('panel-' + i).className = 'panel' + (i === n ? ' show' : '');
+            var step = $('step-' + i);
+            step.className = i < n ? 'done' : (i === n ? 'active' : '');
+        }
+        if (n !== 2) clearAlert();
+    }
+
+    function appendLog(message, type) {
+        logs.push({ message: message, type: type || '' });
+        var box = $('install-log');
+        var line = document.createElement('div');
+        if (type) line.className = type;
+        line.textContent = '[install] ' + message;
+        box.appendChild(line);
+        box.scrollTop = box.scrollHeight;
+    }
+
+    function api(url, body) {
+        return fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body || {})
+        }).then(function (response) {
+            return response.json().then(function (data) { return { status: response.status, data: data }; });
+        });
+    }
+
+    function payload() {
+        return {
+            db_host: $('db_host').value.trim(),
+            db_port: parseInt($('db_port').value, 10) || 3306,
+            db_database: $('db_database').value.trim(),
+            db_username: $('db_username').value.trim(),
+            db_password: $('db_password').value,
+            redis_host: $('redis_host').value.trim(),
+            redis_port: parseInt($('redis_port').value, 10) || 6379,
+            redis_password: $('redis_password').value,
+            app_name: '图拉云',
+            app_url: $('app_url').value.trim(),
+            frontend_url: $('frontend_url').value.trim(),
+            client_console_url: $('client_console_url').value.trim(),
+            admin_url: $('admin_url').value.trim(),
+            admin_username: $('admin_username').value.trim(),
+            admin_email: $('admin_email').value.trim(),
+            admin_password: $('admin_password').value
+        };
+    }
+
+    function loadRequirements() {
+        $('btn-req-next').disabled = true;
+        $('req-list').innerHTML = '';
+        api('/install/requirements').then(function (result) {
+            if (result.status === 404) { window.location.reload(); return; }
+            var data = result.data && result.data.data;
+            if (!data) { showAlert('err', '环境检测接口异常'); return; }
+            var allPassed = data.passed;
+            data.items.forEach(function (item) {
+                var li = document.createElement('li');
+                var tag = document.createElement('span');
+                tag.className = 'tag ' + (item.passed ? 'ok' : 'bad');
+                tag.textContent = item.passed ? '通过' : '未通过';
+                var name = document.createElement('span');
+                name.textContent = item.name;
+                li.appendChild(tag); li.appendChild(name);
+                if (item.message) {
+                    var msg = document.createElement('span');
+                    msg.className = 'msg'; msg.textContent = item.message;
+                    li.appendChild(msg);
+                }
+                $('req-list').appendChild(li);
+            });
+            $('btn-req-next').disabled = !allPassed;
+            if (!allPassed) showAlert('err', '存在未通过的必选项，请先修复服务器环境后重新检测。');
+        }).catch(function () { showAlert('err', '网络异常，无法完成环境检测'); });
+    }
+
+    $('btn-req-refresh').addEventListener('click', function () { clearAlert(); loadRequirements(); });
+    $('btn-req-next').addEventListener('click', function () { goStep(2); });
+    $('btn-back-1').addEventListener('click', function () { goStep(1); });
+
+    $('btn-test').addEventListener('click', function () {
+        clearAlert();
+        this.disabled = true;
+        this.textContent = '检测中…';
+        var self = this;
+        api('/install/test', payload()).then(function (result) {
+            var data = result.data && result.data.data;
+            if (!data) { showAlert('err', '连接测试接口异常'); return; }
+            var parts = [];
+            parts.push('数据库：' + data.database.message);
+            parts.push('Redis：' + data.redis.message);
+            showAlert(data.database.ok && data.redis.ok ? 'ok' : 'err', parts.join('；'));
+        }).catch(function () { showAlert('err', '网络异常，无法完成连接测试'); }).finally(function () {
+            self.disabled = false; self.textContent = '测试连接';
+        });
+    });
+
+    $('btn-install').addEventListener('click', function () {
+        clearAlert();
+        logs = [];
+        $('install-log').innerHTML = '';
+        goStep(3);
+        appendLog('提交安装请求…');
+        var button = this;
+        button.disabled = true;
+        api('/install/run', payload()).then(function (result) {
+            var data = result.data;
+            if (logs.length === 0 && data && data.data && data.data.logs) {
+                data.data.logs.forEach(function (message) { appendLog(message); });
+            }
+            if (result.status !== 200 || !data || data.code !== 0) {
+                appendLog((data && data.message) || '安装失败', 'err');
+                appendLog('请修正配置后重试；已生成的 .env 将被下次尝试覆盖。', 'err');
+                goStep(2);
+                showAlert('err', (data && data.message) || '安装失败');
+                button.disabled = false;
+                return;
+            }
+            appendLog('安装完成', 'ok');
+            $('done-box').innerHTML =
+                '<strong>安装成功！</strong><br>' +
+                '管理员用户名：<span class="cred">' + data.data.admin_username + '</span><br>' +
+                '管理员邮箱：<span class="cred">' + data.data.admin_email + '</span><br>' +
+                '管理端地址：<a href="' + data.data.admin_url + '" target="_blank">' + data.data.admin_url + '</a>';
+            goStep(4);
+        }).catch(function () {
+            appendLog('网络中断，安装结果未知；请勿直接重试，先检查数据库与管理员是否已创建。', 'err');
+            goStep(2);
+            button.disabled = false;
+        });
+    });
+
+    loadRequirements();
+})();
+</script>
+</body>
+</html>

--- a/backend/resources/views/install/index.blade.php
+++ b/backend/resources/views/install/index.blade.php
@@ -260,11 +260,30 @@
                 return;
             }
             appendLog('安装完成', 'ok');
-            $('done-box').innerHTML =
-                '<strong>安装成功！</strong><br>' +
-                '管理员用户名：<span class="cred">' + data.data.admin_username + '</span><br>' +
-                '管理员邮箱：<span class="cred">' + data.data.admin_email + '</span><br>' +
-                '管理端地址：<a href="' + data.data.admin_url + '" target="_blank">' + data.data.admin_url + '</a>';
+            var box = $('done-box');
+            box.textContent = '';
+            var title = document.createElement('strong');
+            title.textContent = '安装成功！';
+            box.appendChild(title);
+            [['管理员用户名：', data.data.admin_username], ['管理员邮箱：', data.data.admin_email]]
+                .forEach(function (pair) {
+                    box.appendChild(document.createElement('br'));
+                    box.appendChild(document.createTextNode(pair[0]));
+                    var value = document.createElement('span');
+                    value.className = 'cred';
+                    value.textContent = pair[1];
+                    box.appendChild(value);
+                });
+            box.appendChild(document.createElement('br'));
+            box.appendChild(document.createTextNode('管理端地址：'));
+            var link = document.createElement('a');
+            link.target = '_blank';
+            link.rel = 'noopener';
+            link.textContent = data.data.admin_url;
+            if (/^https?:\/\//i.test(data.data.admin_url)) {
+                link.href = data.data.admin_url;
+            }
+            box.appendChild(link);
             goStep(4);
         }).catch(function () {
             appendLog('网络中断，安装结果未知；请勿直接重试，先检查数据库与管理员是否已创建。', 'err');

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Client\V2\TicketUpstreamUploadController;
+use App\Http\Controllers\InstallController;
 use App\Http\Controllers\SecureAssetController;
 use App\Http\Controllers\Site\SeoController;
 use App\Support\PublicUrl;
@@ -9,6 +10,15 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return ['message' => '图拉云 API'];
 });
+
+// ---- 安装向导（已安装后所有入口 404，见 InstallController） ----
+Route::get('/install', [InstallController::class, 'index']);
+Route::post('/install/requirements', [InstallController::class, 'requirements'])
+    ->middleware('throttle:10,1');
+Route::post('/install/test', [InstallController::class, 'test'])
+    ->middleware('throttle:10,1');
+Route::post('/install/run', [InstallController::class, 'run'])
+    ->middleware('throttle:4,1');
 
 // ---- 官网 SEO 动态渲染（由前端 Nginx 转发公开路径到此） ----
 Route::get('/seo/www/{path?}', [SeoController::class, 'render'])


### PR DESCRIPTION
## 概述

为 TuraIDC 新增面向站长的安装程序，覆盖 Web 向导与 CLI 两种形态，共用同一套安装服务，替代手工「复制 .env → python install_db.py → tinker 建管理员」流程。

## 改动内容

**新增**
- `backend/app/Services/Install/InstallService.php`：核心安装服务（环境检测、DB/Redis 连接测试、基于 `.env.example` 生成 `.env`、APP_KEY 生成、建库、schema baseline 导入、增量迁移、`SettingsSeeder` 种子、创建超级管理员、写安装锁）
- `backend/app/Services/Install/InstallException.php`：安装错误类型（消息可直接展示给安装者）
- `backend/app/Console/Commands/InstallCommand.php`：`php artisan app:install`，环境检测表格 + 交互问答/非交互选项双模式
- `backend/app/Http/Controllers/InstallController.php`：向导接口（requirements / test / run），已安装后一律 404
- `backend/resources/views/install/index.blade.php`：四步向导页（纯内联资源，无外网依赖）

**修改**
- `backend/routes/web.php`：`/install` 4 条路由，`run` 接口限流 4 次/分钟
- `backend/bootstrap/app.php`：`install/*` 豁免 CSRF（新装站点 session 域名与 HTTPS 未就绪，已加注释说明）

## 关键设计

- 安装流程行为对齐 `scripts/install_db.py`（建库 → baseline → migrate → 角色同步 → 管理员 → 种子 → 锁），但全程进程内执行（PDO + `Artisan::call`），**不依赖 mysql CLI 与 Python**
- 防重放双保险：`storage/app/install.lock` 安装锁 + 管理员表存在性兜底（锁文件丢失时仍不暴露向导）
- 管理员密码强制 ≥12 位（沿用 install_db.py 生产规则）；`.env` 固定写入 `APP_ENV=production`、`APP_DEBUG=false`，随机生成 `TICKET_UPSTREAM_CALLBACK_SECRET`
- 非空库自动跳过 baseline 只跑增量迁移，可修复中断的安装
- `refreshRuntimeConfig` 在写 `.env` 后即时刷新当前进程 DB/Redis 连接配置，保证进程内 migrate 与种子使用新配置

## 验证

- [x] `php -l` 语法检查 6 个 PHP 文件全部通过
- [ ] `php artisan test` 未运行（本机无 composer 依赖与 MySQL/Redis）
- [ ] 端到端安装验证待在有 PHP 8.3 + MySQL 8 + Redis 的环境执行 `php artisan app:install` 或访问 `/install` 确认

## 风险提示

- Web 向导的 `run` 接口包含 schema 导入与迁移，FPM 场景下若 `request_terminate_timeout` 过短可能中断；超时场景建议改用 CLI 安装（页面已有提示）
