### PR TITLE
Fix: 修复安装向导必然 500、官网 SEO 存储型 XSS、管理端动态表单无法输入等阻断缺陷

### DIFF
--- a/backend/app/Http/Requests/Admin/V2/Setting/UpdateSettingsRequest.php
+++ b/backend/app/Http/Requests/Admin/V2/Setting/UpdateSettingsRequest.php
@@ -5,9 +5,24 @@ declare(strict_types=1);
 namespace App\Http\Requests\Admin\V2\Setting;
 
 use App\Http\Requests\Admin\V2\Common\AdminFormRequest;
+use App\Support\TextSanitizer;
 
 class UpdateSettingsRequest extends AdminFormRequest
 {
+    /**
+     * 不做消毒的键：值为密钥/证书等任意字节串，剥标签会直接损坏内容。
+     * 与 Setting::SENSITIVE_KEYS 保持一致。
+     */
+    private const RAW_KEYS = [
+        'verification_key',
+        'email_password',
+        'sms_access_key',
+        'sms_secret_key',
+        'geetest_captcha_key',
+        'alipay_private_key',
+        'alipay_public_key',
+    ];
+
     public function authorize(): bool
     {
         return true;
@@ -31,10 +46,48 @@ class UpdateSettingsRequest extends AdminFormRequest
     }
 
     /**
+     * 设置项落库前统一剥掉 HTML 标签。
+     *
+     * 站点名等设置会被 SEO 渲染拼进公开页 HTML，此前写入端不做任何消毒，全靠渲染
+     * 端逐处转义兜底——任何新增的渲染路径只要漏一个 e()，就会重新变成存储型 XSS。
+     * 现网 74 条设置中含 HTML 标签的为 0 条，说明没有任何设置项依赖标记，可安全剥离。
+     *
+     * 两类值跳过：
+     * - RAW_KEYS 里的密钥/证书，值是任意字节串，剥标签会损坏内容；
+     * - 合法 JSON（如 home_hero.slides、traffic_package_catalog.items），
+     *   属结构化配置，整串剥标签会破坏结构，其内部文本由各自的渲染端负责转义。
+     *
      * @return array<string, mixed>
      */
     public function settings(): array
     {
-        return (array) $this->validated('settings', []);
+        $settings = (array) $this->validated('settings', []);
+
+        foreach ($settings as $key => $value) {
+            if (! is_string($value) || in_array((string) $key, self::RAW_KEYS, true)) {
+                continue;
+            }
+
+            if ($this->looksLikeJson($value)) {
+                continue;
+            }
+
+            $settings[$key] = TextSanitizer::clean($value, preserveNewLines: true);
+        }
+
+        return $settings;
+    }
+
+    private function looksLikeJson(string $value): bool
+    {
+        $trimmed = trim($value);
+
+        if (! str_starts_with($trimmed, '{') && ! str_starts_with($trimmed, '[')) {
+            return false;
+        }
+
+        json_decode($trimmed, true);
+
+        return json_last_error() === JSON_ERROR_NONE;
     }
 }

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\PersonalAccessToken;
 use Laravel\Sanctum\Sanctum;
+use Throwable;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -99,15 +100,24 @@ class AppServiceProvider extends ServiceProvider
 
     /**
      * 从数据库 settings 表加载管理员设置的站点名称，覆盖 config('app.name')。
-     * settings 表不存在时（首次迁移前）静默跳过。
+     *
+     * 全新部署时 .env 还没有数据库配置，Schema::hasTable() 会直接抛 QueryException，
+     * provider boot 失败 → 整个应用起不来 → /install 安装向导也就永远进不去。
+     * 因此这里必须吞掉全部异常（不只是「表不存在」），与 InstallService::isInstalled()
+     * 的处理口径保持一致：站点名读不到就退回 config 默认值，不影响应用启动。
      */
     private function loadSiteNameFromSettings(): void
     {
-        if (! Schema::hasTable('settings')) {
+        try {
+            if (! Schema::hasTable('settings')) {
+                return;
+            }
+
+            $siteName = trim((string) Setting::getValue('basic', 'site_name', ''));
+        } catch (Throwable) {
             return;
         }
 
-        $siteName = trim((string) Setting::getValue('basic', 'site_name', ''));
         if ($siteName === '') {
             return;
         }

--- a/backend/app/Services/Install/InstallService.php
+++ b/backend/app/Services/Install/InstallService.php
@@ -47,6 +47,7 @@ class InstallService
         'DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USERNAME', 'DB_PASSWORD',
         'REDIS_HOST', 'REDIS_PORT', 'REDIS_PASSWORD',
         'TICKET_UPSTREAM_CALLBACK_SECRET',
+        'SEO_SITE_URL', 'SEO_FRONTEND_SHELL_URL',
     ];
 
     /**
@@ -448,6 +449,12 @@ class InstallService
             'REDIS_PASSWORD' => (string) $payload['redis_password'],
             // 随机生成回调签名密钥，避免空密钥下上游回调验签失效。
             'TICKET_UPSTREAM_CALLBACK_SECRET' => Str::random(48),
+            // 官网 SEO 渲染：config/idc.php 的默认值是 Docker 编排里的服务名
+            // http://frontends:8081/index.html，源码/宝塔部署下这个主机名无法解析，
+            // 官网首页会直接 500（cURL error 6: Could not resolve host: frontends）。
+            // 向导既然知道部署路径与官网地址，这里一并写死为本机前端产物，零网络依赖。
+            'SEO_SITE_URL' => (string) $payload['frontend_url'],
+            'SEO_FRONTEND_SHELL_URL' => $this->defaultSeoShellUrl(),
         ];
 
         $replaced = [];
@@ -481,6 +488,19 @@ class InstallService
         if (file_put_contents(base_path('.env'), implode(PHP_EOL, $lines).PHP_EOL) === false) {
             throw new InstallException('写入 .env 失败，请检查 backend 目录权限');
         }
+    }
+
+    /**
+     * 官网 index.html 模板地址：源码部署直接读同机前端构建产物。
+     * backend/ 与 frontend-user-v3-www/ 在仓库里同级，故从 base_path() 上跳一层定位。
+     */
+    private function defaultSeoShellUrl(): string
+    {
+        $dist = dirname(base_path()).DIRECTORY_SEPARATOR
+            .'frontend-user-v3-www'.DIRECTORY_SEPARATOR
+            .'dist'.DIRECTORY_SEPARATOR.'index.html';
+
+        return 'file://'.str_replace('\\', '/', $dist);
     }
 
     private function formatEnvValue(string $value): string

--- a/backend/app/Services/Site/SeoRenderService.php
+++ b/backend/app/Services/Site/SeoRenderService.php
@@ -337,7 +337,7 @@ class SeoRenderService
      */
     private function fallbackShell(): string
     {
-        $siteName = $this->siteName();
+        $siteName = e($this->siteName());
 
         return <<<HTML
 <!DOCTYPE html>
@@ -421,7 +421,13 @@ HTML;
 
         $structured = $this->structuredData($page, $config, $siteName, $siteUrl, $canonical, $logoUrl);
         if ($structured !== []) {
-            $head .= "\n".'  <script type="application/ld+json">'.json_encode($structured, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
+            // JSON-LD 内嵌在 <script> 里，值中的 </script> 会直接截断脚本块并让后续内容
+            // 作为 HTML 解析——站点名、文章标题摘要、商品名都是后台可编辑内容，等于给了
+            // 一条存储型 XSS 通道。JSON_UNESCAPED_SLASHES 恰好关掉了 `/` → `\/` 这层默认
+            // 保护，必须去掉；再叠加 JSON_HEX_TAG 把 `<` `>` 转成 < > 双保险。
+            $head .= "\n".'  <script type="application/ld+json">'
+                .json_encode($structured, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG)
+                .'</script>';
         }
 
         return $head;
@@ -447,7 +453,8 @@ HTML;
     {
         $siteName = $this->siteName();
         $html = '<article class="seo-content">';
-        $html .= '<header><h1>'.$siteName.' - 云服务器与 IDC 服务平台</h1>';
+        // 站点名来自 settings 表（后台可编辑且写入端不做消毒），必须转义后再拼进 HTML
+        $html .= '<header><h1>'.e($siteName).' - 云服务器与 IDC 服务平台</h1>';
         $html .= '<p>提供云服务器、独立服务器、高防服务器、云电脑等产品，覆盖香港、美国与国内多地节点。</p></header>';
 
         $groups = $data['root_groups'] ?? [];
@@ -500,7 +507,7 @@ HTML;
     {
         $html = '<article class="seo-content">';
         $html .= '<header><h1>产品与服务</h1>';
-        $html .= '<p>'.$this->siteName().'提供云服务器、独立服务器、高防服务器、云电脑等 IDC 产品方案。</p></header>';
+        $html .= '<p>'.e($this->siteName()).'提供云服务器、独立服务器、高防服务器、云电脑等 IDC 产品方案。</p></header>';
 
         $groups = $data['groups'] ?? [];
         if ($groups !== []) {
@@ -534,7 +541,8 @@ HTML;
 
         $groups = $data['groups'] ?? [];
         if ($groups !== []) {
-            $html .= '<section><h2>'.$keyword.'产品方案</h2><ul>';
+            // 同一个 $keyword 在上面 h1 里已过 e()，这里漏了；保持一致，不留特例
+            $html .= '<section><h2>'.e($keyword).'产品方案</h2><ul>';
             foreach (array_slice($groups, 0, 10) as $group) {
                 $name = (string) ($group['name'] ?? '');
                 $slogan = (string) ($group['slogan'] ?? '');

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -5,21 +5,38 @@ use App\Http\Controllers\InstallController;
 use App\Http\Controllers\SecureAssetController;
 use App\Http\Controllers\Site\SeoController;
 use App\Support\PublicUrl;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 Route::get('/', function () {
     return ['message' => '图拉云 API'];
 });
 
 // ---- 安装向导（已安装后所有入口 404，见 InstallController） ----
-Route::get('/install', [InstallController::class, 'index'])
-    ->middleware('throttle:30,1');
-Route::post('/install/requirements', [InstallController::class, 'requirements'])
-    ->middleware('throttle:10,1');
-Route::post('/install/test', [InstallController::class, 'test'])
-    ->middleware('throttle:10,1');
-Route::post('/install/run', [InstallController::class, 'run'])
-    ->middleware('throttle:4,1');
+// 向导按设计运行在 APP_KEY 尚未生成的全新站点上，而 web 中间件组里
+// EncryptCookies / StartSession / ShareErrorsFromSession / ValidateCsrfToken
+// 都要用到 encrypter：没有 APP_KEY 时解析即抛 MissingAppKeyException，向导页必然 500。
+// 尤其 ValidateCsrfToken——即便已在 bootstrap/app.php 按路径豁免了校验，
+// 它的构造函数仍要注入 Encrypter，光是实例化就会炸。
+// 向导本身不依赖 session（令牌走 X-Install-Token 头），故显式剥离这四个中间件。
+Route::withoutMiddleware([
+    EncryptCookies::class,
+    StartSession::class,
+    ShareErrorsFromSession::class,
+    ValidateCsrfToken::class,
+])->group(function (): void {
+    Route::get('/install', [InstallController::class, 'index'])
+        ->middleware('throttle:30,1');
+    Route::post('/install/requirements', [InstallController::class, 'requirements'])
+        ->middleware('throttle:10,1');
+    Route::post('/install/test', [InstallController::class, 'test'])
+        ->middleware('throttle:10,1');
+    Route::post('/install/run', [InstallController::class, 'run'])
+        ->middleware('throttle:4,1');
+});
 
 // ---- 官网 SEO 动态渲染（由前端 Nginx 转发公开路径到此） ----
 Route::get('/seo/www/{path?}', [SeoController::class, 'render'])

--- a/backend/tests/Feature/AdminSettingsSanitizationTest.php
+++ b/backend/tests/Feature/AdminSettingsSanitizationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\AdminUser;
+use App\Models\Role;
+use App\Models\Setting;
+use App\Support\AdminPermissions;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AdminSettingsSanitizationTest extends TestCase
+{
+    /** @var list<array{group_key: string, item_key: string, item_value: mixed}> */
+    private array $originalRows = [];
+
+    /** @var list<array{admin: int, role: int}> 本用例建出来的账号与角色，tearDown 逐个删掉 */
+    private array $createdAdmins = [];
+
+    /** @var list<array{0: string, 1: string}> */
+    private const TOUCHED_KEYS = [
+        ['basic', 'site_name'],
+        ['basic', 'service_email'],
+        ['basic', 'alipay_private_key'],
+        ['home_hero', 'slides'],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 测试库不走 RefreshDatabase，这里先备份被改写的设置项，tearDown 原样还原。
+        foreach (self::TOUCHED_KEYS as [$group, $key]) {
+            $row = DB::table('settings')->where('group_key', $group)->where('item_key', $key)->first(['item_value']);
+            $this->originalRows[] = ['group_key' => $group, 'item_key' => $key, 'item_value' => $row?->item_value];
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalRows as $row) {
+            $query = DB::table('settings')->where('group_key', $row['group_key'])->where('item_key', $row['item_key']);
+            $row['item_value'] === null ? $query->delete() : $query->update(['item_value' => $row['item_value']]);
+        }
+
+        // 角色被账号引用，必须先删账号再删角色。
+        foreach ($this->createdAdmins as $created) {
+            DB::table('admin_users')->where('id', $created['admin'])->delete();
+            DB::table('roles')->where('id', $created['role'])->delete();
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_settings_strip_html_tags_before_persisting(): void
+    {
+        Sanctum::actingAs($this->createAdmin([AdminPermissions::SETTINGS_MANAGE]));
+
+        $this->postJson('/api/v2/admin/settings', [
+            'group' => 'basic',
+            'settings' => [
+                'site_name' => '图拉云</script><img src=x onerror=alert(1)>',
+                'service_email' => '<b>support</b>@example.com',
+            ],
+        ])->assertOk();
+
+        // 站点名会被 SEO 渲染拼进公开页 HTML，落库前就不该带标签，
+        // 否则任何漏掉 e() 的渲染路径都会重新变成存储型 XSS。
+        $siteName = (string) Setting::getValue('basic', 'site_name');
+        $this->assertStringNotContainsString('<img', $siteName);
+        $this->assertStringNotContainsString('</script>', $siteName);
+        $this->assertStringContainsString('图拉云', $siteName);
+
+        $this->assertSame('support@example.com', Setting::getValue('basic', 'service_email'));
+    }
+
+    public function test_sensitive_keys_keep_raw_value(): void
+    {
+        Sanctum::actingAs($this->createAdmin([AdminPermissions::SETTINGS_MANAGE]));
+
+        // 私钥是任意字节串，剥标签会直接把内容改坏，之后所有签名都会失败。
+        $privateKey = "-----BEGIN PRIVATE KEY-----\nMIIB<Ag>EAAoIBAQ==\n-----END PRIVATE KEY-----";
+
+        $this->postJson('/api/v2/admin/settings', [
+            'group' => 'basic',
+            'settings' => ['alipay_private_key' => $privateKey],
+        ])->assertOk();
+
+        $this->assertSame($privateKey, Setting::getValue('basic', 'alipay_private_key'));
+    }
+
+    public function test_json_settings_are_not_mangled(): void
+    {
+        Sanctum::actingAs($this->createAdmin([AdminPermissions::SETTINGS_MANAGE]));
+
+        // home_hero.slides 这类结构化配置整串剥标签会破坏 JSON 结构，必须原样落库。
+        $slides = json_encode(
+            [['title' => '首页轮播', 'image' => '/uploads/hero.png']],
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+        );
+
+        $this->postJson('/api/v2/admin/settings', [
+            'group' => 'home_hero',
+            'settings' => ['slides' => $slides],
+        ])->assertOk();
+
+        $stored = (string) Setting::getValue('home_hero', 'slides');
+        $this->assertSame($slides, $stored);
+        $this->assertIsArray(json_decode($stored, true));
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdmin(array $permissions): AdminUser
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $role = Role::query()->create([
+            'name' => 'settings-sanitize-'.$suffix,
+            'label' => 'Settings Sanitize',
+            'permissions' => $permissions,
+        ]);
+
+        $admin = AdminUser::query()->create([
+            'username' => 'settings-sanitize-'.$suffix,
+            'password' => 'Temp@123456',
+            'role_id' => (int) $role->id,
+            'nickname' => 'Settings Sanitize',
+            'email' => 'settings-sanitize-'.$suffix.'@example.com',
+            'status' => 1,
+        ]);
+
+        $this->createdAdmins[] = ['admin' => (int) $admin->id, 'role' => (int) $role->id];
+
+        return $admin;
+    }
+}

--- a/docs/references/operations/bt-panel-deployment.md
+++ b/docs/references/operations/bt-panel-deployment.md
@@ -101,13 +101,14 @@
 
 ### 3.2 创建前端站点
 
-创建三个前端站点，运行目录分别指向对应 `dist` 目录：
+创建三个前端站点。**网站目录填前端应用目录，不要直接填 `dist`**（原因见 §6.1 的说明：
+宝塔会在网站目录生成不可删除的 `.user.ini`，落在 `dist` 里会导致前端构建必然失败）：
 
-| 站点          | 域名                   | 根目录                                   |
-| ------------- | ---------------------- | ---------------------------------------- |
-| 官网/用户入口 | `www.你的域名.com`     | `项目路径/frontend-user-v3-www/dist`     |
-| 用户控制台    | `console.你的域名.com` | `项目路径/frontend-user-v4-console/dist` |
-| 管理端        | `admin.你的域名.com`   | `项目路径/frontend-admin-v3/dist`        |
+| 站点          | 域名                   | 网站目录                            | 运行目录 |
+| ------------- | ---------------------- | ----------------------------------- | -------- |
+| 官网/用户入口 | `www.你的域名.com`     | `项目路径/frontend-user-v3-www`     | `/dist`  |
+| 用户控制台    | `console.你的域名.com` | `项目路径/frontend-user-v4-console` | `/dist`  |
+| 管理端        | `admin.你的域名.com`   | `项目路径/frontend-admin-v3`        | `/dist`  |
 
 ---
 
@@ -117,12 +118,12 @@
 
 在宝塔面板完成以下设置后，只编辑每个站点的“设置 → 伪静态”：
 
-| 站点       | 运行目录                        | 宝塔面板设置             |
-| ---------- | ------------------------------- | ------------------------ |
-| 官网       | `frontend-user-v3-www/dist`     | 静态站点，申请 SSL。     |
-| 用户控制台 | `frontend-user-v4-console/dist` | 静态站点，申请 SSL。     |
-| 管理端     | `frontend-admin-v3/dist`        | 静态站点，申请 SSL。     |
-| API        | `backend/public`                | 选择 PHP 8.3，申请 SSL。 |
+| 站点       | 网站目录                   | 运行目录 | 宝塔面板设置             |
+| ---------- | -------------------------- | -------- | ------------------------ |
+| 官网       | `frontend-user-v3-www`     | `/dist`  | 静态站点，申请 SSL。     |
+| 用户控制台 | `frontend-user-v4-console` | `/dist`  | 静态站点，申请 SSL。     |
+| 管理端     | `frontend-admin-v3`        | `/dist`  | 静态站点，申请 SSL。     |
+| API        | `backend/public`           | 留空     | 选择 PHP 8.3，申请 SSL。 |
 
 HTTPS 跳转和证书通过宝塔“SSL”页面配置；纯 HTTP 环境不启用强制 HTTPS，并将 `SESSION_SECURE_COOKIE=false`。四个公开地址必须使用相同协议。
 
@@ -360,14 +361,24 @@ sudo chmod -R 775 public/uploads public/media
 cd /www/wwwroot/你的项目
 
 # 先校验 backend/.env 中注入的四个公开地址和协议是否一致，不生成文件。
-pnpm run build:frontends -- --dry-run
+# 注意不要写成 `-- --dry-run`：pnpm 9+ 会把 `--` 原样透传给脚本，
+# build_frontends.mjs 会抛「不支持的参数：--」。
+pnpm run build:frontends --dry-run
 
 # --shamefully-hoist：本项目依赖根 hoist 布局（如 element-plus），避免 monorepo 依赖布局不一致导致构建失败；
 # --config.verify-deps-before-run=false：跳过 pnpm 10+ 默认的依赖预校验，适用于宝塔等先 install 再构建的部署流程。
-pnpm install --frozen-lockfile --shamefully-hoist --config.verify-deps-before-run=false
+# CI=true：无 TTY 的部署环境下，pnpm 11 清理 node_modules 前会等待交互确认并直接中止
+#（ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY），设置后自动放行。
+CI=true pnpm install --frozen-lockfile --shamefully-hoist --config.verify-deps-before-run=false
 pnpm run build:frontends
 # 产物仍分别位于三个前端目录的 dist/，不会写入 backend/public。
 ```
+
+> **宝塔站点根目录不要直接指向 `dist/`。** 宝塔的「防跨站攻击」会在站点根目录生成 `.user.ini`
+> 并加上 `chattr +i` 不可修改属性；若根目录就是 `dist/`，Vite 构建清空产物目录时会撞上这个
+> 删不掉的文件，报 `ENOTDIR: not a directory, scandir '.../dist/.user.ini'` 导致构建必然失败。
+> 正确做法与 API 站点一致：「网站目录」填应用目录（如 `项目路径/frontend-admin-v3`），
+> 「运行目录」填 `/dist`，让 `.user.ini` 落在 `dist` 之外。
 
 > 如使用独立 CDN 域名部署静态资源，在各项目 `.env` 中配置 `VITE_ADMIN_ASSET_BASE_URL` / `VITE_CONSOLE_ASSET_BASE_URL` / `VITE_WWW_ASSET_BASE_URL`。默认以根路径 `/` 发布。
 

--- a/frontend-admin-v3/src/pages/agent-discounts/index.less
+++ b/frontend-admin-v3/src/pages/agent-discounts/index.less
@@ -1,0 +1,108 @@
+.agent-discounts-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.stack-cell {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.stack-cell strong {
+  overflow: hidden;
+  color: var(--td-text-color-primary);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stack-cell span {
+  overflow: hidden;
+  color: var(--td-text-color-secondary);
+  font-size: var(--td-font-size-size-1, 12px);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 16px;
+}
+
+.agent-form-span {
+  grid-column: span 2;
+}
+
+.agent-form-grid .t-input-number {
+  width: 100%;
+}
+
+/* 折扣矩阵：行=商品折扣组，列=代理组，单元格填折扣率 */
+.agent-matrix {
+  overflow-x: auto;
+}
+
+.agent-matrix table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.agent-matrix th,
+.agent-matrix td {
+  border: 1px solid var(--td-component-border);
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.agent-matrix thead th {
+  background: var(--td-bg-color-secondarycontainer);
+  color: var(--td-text-color-primary);
+  font-size: var(--td-font-size-size-2, 13px);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.agent-matrix tbody th {
+  min-width: 180px;
+  background: var(--td-bg-color-container);
+  font-weight: 600;
+}
+
+.agent-matrix td {
+  min-width: 140px;
+}
+
+.agent-matrix .t-input-number {
+  width: 100%;
+}
+
+.agent-matrix__empty {
+  padding: 24px 0;
+  color: var(--td-text-color-placeholder);
+  text-align: center;
+}
+
+.agent-matrix__hint {
+  margin: 0 0 12px;
+  color: var(--td-text-color-secondary);
+  font-size: var(--td-font-size-size-1, 12px);
+  line-height: 1.7;
+}
+
+@media (width <= 1024px) {
+  .agent-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-form-span {
+    grid-column: span 1;
+  }
+}

--- a/frontend-admin-v3/src/pages/agent-discounts/index.vue
+++ b/frontend-admin-v3/src/pages/agent-discounts/index.vue
@@ -1,0 +1,603 @@
+<template>
+  <div class="agent-discounts-page">
+    <t-tabs v-model="activeTab">
+      <!-- 代理组 -->
+      <t-tab-panel value="agent-groups" label="代理组">
+        <t-card :bordered="false" :loading="loadingAgentGroups">
+          <template #title>代理组</template>
+          <template #subtitle>共 {{ agentGroups.length }} 个分组</template>
+          <template #actions>
+            <t-button v-if="canManage" theme="primary" @click="openAgentGroupDialog()">
+              <template #icon><add-icon /></template>
+              新增代理组
+            </t-button>
+          </template>
+
+          <div class="table-scroll">
+            <t-table
+              row-key="id"
+              :data="agentGroups"
+              :columns="agentGroupColumns"
+              hover
+              table-layout="fixed"
+              :pagination="null"
+            >
+              <template #group="{ row }">
+                <div class="stack-cell">
+                  <strong>{{ fieldValue(row.name) }}</strong>
+                  <span>{{ fieldValue(row.code) }}</span>
+                </div>
+              </template>
+              <template #status="{ row }">
+                <t-tag :theme="Number(row.status) === 1 ? 'success' : 'default'" variant="light">
+                  {{ Number(row.status) === 1 ? '启用' : '停用' }}
+                </t-tag>
+              </template>
+              <template #remark="{ row }">{{ fieldValue(row.remark) }}</template>
+              <template #updatedAt="{ row }">{{ formatDateTime(row.updated_at) }}</template>
+              <template #actions="{ row }">
+                <t-space v-if="canManage" size="small">
+                  <t-button theme="primary" variant="text" @click="openAgentGroupDialog(row)">编辑</t-button>
+                  <t-button theme="danger" variant="text" @click="removeAgentGroup(row)">删除</t-button>
+                </t-space>
+                <span v-else>-</span>
+              </template>
+            </t-table>
+          </div>
+        </t-card>
+      </t-tab-panel>
+
+      <!-- 商品折扣组 -->
+      <t-tab-panel value="product-groups" label="商品折扣组">
+        <t-card :bordered="false" :loading="loadingProductGroups">
+          <template #title>商品折扣组</template>
+          <template #subtitle>共 {{ productGroups.length }} 个分组</template>
+          <template #actions>
+            <t-button v-if="canManage" theme="primary" @click="openProductGroupDialog()">
+              <template #icon><add-icon /></template>
+              新增折扣组
+            </t-button>
+          </template>
+
+          <div class="table-scroll">
+            <t-table
+              row-key="id"
+              :data="productGroups"
+              :columns="productGroupColumns"
+              hover
+              table-layout="fixed"
+              :pagination="null"
+            >
+              <template #group="{ row }">
+                <div class="stack-cell">
+                  <strong>{{ fieldValue(row.name) }}</strong>
+                  <span>{{ fieldValue(row.code) }}</span>
+                </div>
+              </template>
+              <template #minRate="{ row }">
+                <t-tag theme="primary" variant="light">{{ formatPercent(row.min_discount_rate) }}</t-tag>
+              </template>
+              <template #costRate="{ row }">
+                <t-tag theme="warning" variant="light">{{ formatPercent(row.cost_rate) }}</t-tag>
+              </template>
+              <template #status="{ row }">
+                <t-tag :theme="Number(row.status) === 1 ? 'success' : 'default'" variant="light">
+                  {{ Number(row.status) === 1 ? '启用' : '停用' }}
+                </t-tag>
+              </template>
+              <template #remark="{ row }">{{ fieldValue(row.remark) }}</template>
+              <template #actions="{ row }">
+                <t-space v-if="canManage" size="small">
+                  <t-button theme="primary" variant="text" @click="openProductGroupDialog(row)">编辑</t-button>
+                  <t-button theme="danger" variant="text" @click="removeProductGroup(row)">删除</t-button>
+                </t-space>
+                <span v-else>-</span>
+              </template>
+            </t-table>
+          </div>
+        </t-card>
+      </t-tab-panel>
+
+      <!-- 折扣矩阵 -->
+      <t-tab-panel value="matrix" label="折扣矩阵">
+        <t-card :bordered="false" :loading="loadingMatrix">
+          <template #title>折扣矩阵</template>
+          <template #subtitle>行为商品折扣组，列为代理组</template>
+          <template #actions>
+            <t-space size="small">
+              <t-button variant="outline" @click="loadMatrix">重新加载</t-button>
+              <t-button v-if="canManage" theme="primary" :loading="savingMatrix" @click="saveMatrix">保存矩阵</t-button>
+            </t-space>
+          </template>
+
+          <p class="agent-matrix__hint">
+            折扣率单位为百分比（100 表示原价、90 表示九折），不得低于所属商品折扣组的最低折扣率。
+            留空的格子不会提交，已保存的折扣不受影响；要取消某组合的折扣请填 100（按原价计费）。
+          </p>
+
+          <div v-if="matrixRows.length && agentGroups.length" class="agent-matrix">
+            <table>
+              <thead>
+                <tr>
+                  <th>商品折扣组</th>
+                  <th v-for="group in agentGroups" :key="group.id">{{ fieldValue(group.name) }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in matrixRows" :key="row.id">
+                  <th>
+                    <div class="stack-cell">
+                      <strong>{{ fieldValue(row.name) }}</strong>
+                      <span>最低 {{ formatPercent(row.min_discount_rate) }}</span>
+                    </div>
+                  </th>
+                  <td v-for="group in agentGroups" :key="`${row.id}-${group.id}`">
+                    <t-input-number
+                      v-model="matrixModel[cellKey(row.id, group.id)]"
+                      theme="normal"
+                      :min="0"
+                      :max="100"
+                      :step="1"
+                      :decimal-places="2"
+                      :disabled="!canManage"
+                      placeholder="不设折扣"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div v-else class="agent-matrix__empty">请先创建代理组与商品折扣组，再来配置折扣矩阵。</div>
+        </t-card>
+      </t-tab-panel>
+    </t-tabs>
+
+    <!-- 代理组表单 -->
+    <t-dialog
+      v-model:visible="agentGroupDialogVisible"
+      :header="agentGroupForm.id ? '编辑代理组' : '新增代理组'"
+      :confirm-btn="{ content: '保存', loading: savingAgentGroup }"
+      width="560px"
+      @confirm="submitAgentGroup"
+    >
+      <t-form ref="agentGroupFormRef" :data="agentGroupForm" :rules="agentGroupRules" label-width="110px">
+        <div class="agent-form-grid">
+          <t-form-item label="名称" name="name">
+            <t-input v-model="agentGroupForm.name" :maxlength="50" placeholder="如：金牌代理" />
+          </t-form-item>
+          <t-form-item label="标识" name="code">
+            <t-input v-model="agentGroupForm.code" :maxlength="50" placeholder="唯一标识，如 gold" />
+          </t-form-item>
+          <t-form-item label="排序" name="sort_order">
+            <t-input-number v-model="agentGroupForm.sort_order" theme="normal" :min="0" />
+          </t-form-item>
+          <t-form-item label="状态" name="status">
+            <t-radio-group v-model="agentGroupForm.status">
+              <t-radio :value="1">启用</t-radio>
+              <t-radio :value="0">停用</t-radio>
+            </t-radio-group>
+          </t-form-item>
+          <t-form-item class="agent-form-span" label="备注" name="remark">
+            <t-textarea v-model="agentGroupForm.remark" :autosize="{ minRows: 3, maxRows: 5 }" :maxlength="255" />
+          </t-form-item>
+        </div>
+      </t-form>
+    </t-dialog>
+
+    <!-- 商品折扣组表单 -->
+    <t-dialog
+      v-model:visible="productGroupDialogVisible"
+      :header="productGroupForm.id ? '编辑商品折扣组' : '新增商品折扣组'"
+      :confirm-btn="{ content: '保存', loading: savingProductGroup }"
+      width="560px"
+      @confirm="submitProductGroup"
+    >
+      <t-form ref="productGroupFormRef" :data="productGroupForm" :rules="productGroupRules" label-width="130px">
+        <div class="agent-form-grid">
+          <t-form-item label="名称" name="name">
+            <t-input v-model="productGroupForm.name" :maxlength="50" placeholder="如：云服务器" />
+          </t-form-item>
+          <t-form-item label="标识" name="code">
+            <t-input v-model="productGroupForm.code" :maxlength="50" placeholder="唯一标识，如 cloud" />
+          </t-form-item>
+          <t-form-item label="最低折扣率(%)" name="min_discount_rate">
+            <t-input-number
+              v-model="productGroupForm.min_discount_rate"
+              theme="normal"
+              :min="0"
+              :max="100"
+              :decimal-places="2"
+            />
+          </t-form-item>
+          <t-form-item label="成本占比(%)" name="cost_rate">
+            <t-input-number
+              v-model="productGroupForm.cost_rate"
+              theme="normal"
+              :min="0"
+              :max="100"
+              :decimal-places="2"
+            />
+          </t-form-item>
+          <t-form-item label="排序" name="sort_order">
+            <t-input-number v-model="productGroupForm.sort_order" theme="normal" :min="0" />
+          </t-form-item>
+          <t-form-item label="状态" name="status">
+            <t-radio-group v-model="productGroupForm.status">
+              <t-radio :value="1">启用</t-radio>
+              <t-radio :value="0">停用</t-radio>
+            </t-radio-group>
+          </t-form-item>
+          <t-form-item class="agent-form-span" label="备注" name="remark">
+            <t-textarea v-model="productGroupForm.remark" :autosize="{ minRows: 3, maxRows: 5 }" :maxlength="255" />
+          </t-form-item>
+        </div>
+      </t-form>
+    </t-dialog>
+  </div>
+</template>
+<script setup lang="ts">
+import './index.less';
+
+import { AddIcon } from 'tdesign-icons-vue-next';
+import type { FormInstanceFunctions, FormRule, PrimaryTableCol, TableRowData } from 'tdesign-vue-next';
+import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next';
+import { computed, onMounted, reactive, ref } from 'vue';
+
+import type {
+  AgentGroupDiscountMatrixRow,
+  AgentGroupDiscountMatrixSavePayload,
+  AgentGroupPayload,
+  AgentGroupRecord,
+  ProductDiscountGroupPayload,
+  ProductDiscountGroupRecord,
+} from '@/api/admin';
+import { adminApi } from '@/api/admin';
+import { AdminPermissions } from '@/constants/permissions';
+import { fieldValue, formatDateTime } from '@/utils/format';
+import { required } from '@/utils/formRules';
+import { hasAdminPermission } from '@/utils/permission';
+import { errorMessage } from '@/utils/userMessage';
+
+defineOptions({
+  name: 'AdminAgentDiscounts',
+});
+
+interface AgentGroupForm {
+  id: number | string | null;
+  name: string;
+  code: string;
+  status: number;
+  sort_order: number;
+  remark: string;
+}
+
+interface ProductGroupForm {
+  id: number | string | null;
+  name: string;
+  code: string;
+  min_discount_rate: number;
+  cost_rate: number;
+  status: number;
+  sort_order: number;
+  remark: string;
+}
+
+const activeTab = ref('agent-groups');
+
+const loadingAgentGroups = ref(false);
+const loadingProductGroups = ref(false);
+const loadingMatrix = ref(false);
+const savingAgentGroup = ref(false);
+const savingProductGroup = ref(false);
+const savingMatrix = ref(false);
+
+const agentGroups = ref<AgentGroupRecord[]>([]);
+const productGroups = ref<ProductDiscountGroupRecord[]>([]);
+const matrixRows = ref<AgentGroupDiscountMatrixRow[]>([]);
+const matrixModel = reactive<Record<string, number | undefined>>({});
+
+const agentGroupDialogVisible = ref(false);
+const productGroupDialogVisible = ref(false);
+const agentGroupFormRef = ref<FormInstanceFunctions>();
+const productGroupFormRef = ref<FormInstanceFunctions>();
+
+const canManage = computed(() => hasAdminPermission(AdminPermissions.AGENT_DISCOUNT_MANAGE));
+
+const agentGroupForm = reactive<AgentGroupForm>(createAgentGroupForm());
+const productGroupForm = reactive<ProductGroupForm>(createProductGroupForm());
+
+const agentGroupRules: Record<string, FormRule[]> = {
+  name: [required('请输入代理组名称')],
+  code: [required('请输入代理组标识')],
+};
+
+const productGroupRules: Record<string, FormRule[]> = {
+  name: [required('请输入折扣组名称')],
+  code: [required('请输入折扣组标识')],
+  min_discount_rate: [required('请输入最低折扣率')],
+  cost_rate: [required('请输入成本占比')],
+};
+
+const agentGroupColumns: PrimaryTableCol<TableRowData>[] = [
+  { colKey: 'sort_order', title: '排序', width: 90 },
+  { colKey: 'group', title: '代理组', minWidth: 220 },
+  { colKey: 'status', title: '状态', width: 110 },
+  { colKey: 'remark', title: '备注', minWidth: 200 },
+  { colKey: 'updatedAt', title: '更新时间', width: 170 },
+  { colKey: 'actions', title: '操作', fixed: 'right', width: 130 },
+];
+
+const productGroupColumns: PrimaryTableCol<TableRowData>[] = [
+  { colKey: 'sort_order', title: '排序', width: 90 },
+  { colKey: 'group', title: '商品折扣组', minWidth: 220 },
+  { colKey: 'minRate', title: '最低折扣率', width: 130 },
+  { colKey: 'costRate', title: '成本占比', width: 130 },
+  { colKey: 'status', title: '状态', width: 110 },
+  { colKey: 'remark', title: '备注', minWidth: 180 },
+  { colKey: 'actions', title: '操作', fixed: 'right', width: 130 },
+];
+
+function createAgentGroupForm(): AgentGroupForm {
+  return { id: null, name: '', code: '', status: 1, sort_order: 0, remark: '' };
+}
+
+function createProductGroupForm(): ProductGroupForm {
+  return { id: null, name: '', code: '', min_discount_rate: 100, cost_rate: 0, status: 1, sort_order: 0, remark: '' };
+}
+
+function formatPercent(value: unknown) {
+  return `${Number(value || 0).toFixed(2)}%`;
+}
+
+function cellKey(productGroupId: number | string, agentGroupId: number | string) {
+  return `${productGroupId}:${agentGroupId}`;
+}
+
+function assertManage() {
+  if (canManage.value) return true;
+  MessagePlugin.warning('当前账号无代理折扣管理权限');
+  return false;
+}
+
+async function loadAgentGroups() {
+  loadingAgentGroups.value = true;
+  try {
+    agentGroups.value = (await adminApi.agentDiscount.agentGroups.list()) || [];
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '加载代理组失败'));
+  } finally {
+    loadingAgentGroups.value = false;
+  }
+}
+
+async function loadProductGroups() {
+  loadingProductGroups.value = true;
+  try {
+    productGroups.value = (await adminApi.agentDiscount.productDiscountGroups.list()) || [];
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '加载商品折扣组失败'));
+  } finally {
+    loadingProductGroups.value = false;
+  }
+}
+
+// 保存后会立刻重新加载，而「重新加载」按钮可随时点击，两次 GET 可能交叠返回。
+// 用自增序号丢弃过期响应，避免旧折扣值覆盖刚保存的结果、下次保存又把旧值提交回去。
+let matrixLoadSeq = 0;
+
+async function loadMatrix() {
+  const seq = ++matrixLoadSeq;
+  loadingMatrix.value = true;
+  try {
+    const rows = (await adminApi.agentDiscount.matrix.get()) || [];
+    if (seq !== matrixLoadSeq) return;
+
+    matrixRows.value = rows;
+    Object.keys(matrixModel).forEach((key) => delete matrixModel[key]);
+    rows.forEach((row) => {
+      (row.discounts || []).forEach((item) => {
+        const key = cellKey(row.id, item.agent_group_id);
+        matrixModel[key] = item.discount_rate === null ? undefined : Number(item.discount_rate);
+      });
+    });
+  } catch (error) {
+    if (seq !== matrixLoadSeq) return;
+    MessagePlugin.error(errorMessage(error, '加载折扣矩阵失败'));
+  } finally {
+    if (seq === matrixLoadSeq) {
+      loadingMatrix.value = false;
+    }
+  }
+}
+
+function openAgentGroupDialog(row?: AgentGroupRecord) {
+  if (!assertManage()) return;
+  Object.assign(agentGroupForm, createAgentGroupForm());
+  if (row) {
+    Object.assign(agentGroupForm, {
+      id: row.id,
+      name: String(row.name || ''),
+      code: String(row.code || ''),
+      status: Number(row.status ?? 1),
+      sort_order: Number(row.sort_order || 0),
+      remark: String(row.remark || ''),
+    });
+  }
+  agentGroupDialogVisible.value = true;
+}
+
+async function submitAgentGroup() {
+  if (!assertManage()) return;
+  const valid = await agentGroupFormRef.value?.validate?.();
+  if (valid !== true) return;
+
+  const payload: AgentGroupPayload = {
+    name: agentGroupForm.name.trim(),
+    code: agentGroupForm.code.trim(),
+    status: Number(agentGroupForm.status ?? 1),
+    sort_order: Number(agentGroupForm.sort_order || 0),
+    remark: agentGroupForm.remark.trim() || null,
+  };
+
+  savingAgentGroup.value = true;
+  try {
+    if (agentGroupForm.id) {
+      await adminApi.agentDiscount.agentGroups.update(agentGroupForm.id, payload);
+      MessagePlugin.success('代理组已更新');
+    } else {
+      await adminApi.agentDiscount.agentGroups.create(payload);
+      MessagePlugin.success('代理组已创建');
+    }
+    agentGroupDialogVisible.value = false;
+    await loadAgentGroups();
+    await loadMatrix();
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '保存代理组失败'));
+  } finally {
+    savingAgentGroup.value = false;
+  }
+}
+
+function removeAgentGroup(row: AgentGroupRecord) {
+  if (!assertManage()) return;
+  const dialog = DialogPlugin.confirm({
+    header: '删除代理组',
+    body: `确认删除代理组“${fieldValue(row.name)}”吗？组内仍有用户时将无法删除。`,
+    confirmBtn: { content: '确认删除', theme: 'danger' },
+    async onConfirm() {
+      try {
+        await adminApi.agentDiscount.agentGroups.delete(row.id);
+        MessagePlugin.success('代理组已删除');
+        dialog.destroy();
+        await loadAgentGroups();
+        await loadMatrix();
+      } catch (error) {
+        MessagePlugin.error(errorMessage(error, '删除代理组失败'));
+      }
+    },
+  });
+}
+
+function openProductGroupDialog(row?: ProductDiscountGroupRecord) {
+  if (!assertManage()) return;
+  Object.assign(productGroupForm, createProductGroupForm());
+  if (row) {
+    Object.assign(productGroupForm, {
+      id: row.id,
+      name: String(row.name || ''),
+      code: String(row.code || ''),
+      min_discount_rate: Number(row.min_discount_rate ?? 100),
+      cost_rate: Number(row.cost_rate ?? 0),
+      status: Number(row.status ?? 1),
+      sort_order: Number(row.sort_order || 0),
+      remark: String(row.remark || ''),
+    });
+  }
+  productGroupDialogVisible.value = true;
+}
+
+async function submitProductGroup() {
+  if (!assertManage()) return;
+  const valid = await productGroupFormRef.value?.validate?.();
+  if (valid !== true) return;
+
+  const payload: ProductDiscountGroupPayload = {
+    name: productGroupForm.name.trim(),
+    code: productGroupForm.code.trim(),
+    min_discount_rate: Number(productGroupForm.min_discount_rate ?? 0),
+    cost_rate: Number(productGroupForm.cost_rate ?? 0),
+    status: Number(productGroupForm.status ?? 1),
+    sort_order: Number(productGroupForm.sort_order || 0),
+    remark: productGroupForm.remark.trim() || null,
+  };
+
+  savingProductGroup.value = true;
+  try {
+    if (productGroupForm.id) {
+      await adminApi.agentDiscount.productDiscountGroups.update(productGroupForm.id, payload);
+      MessagePlugin.success('商品折扣组已更新');
+    } else {
+      await adminApi.agentDiscount.productDiscountGroups.create(payload);
+      MessagePlugin.success('商品折扣组已创建');
+    }
+    productGroupDialogVisible.value = false;
+    await loadProductGroups();
+    await loadMatrix();
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '保存商品折扣组失败'));
+  } finally {
+    savingProductGroup.value = false;
+  }
+}
+
+function removeProductGroup(row: ProductDiscountGroupRecord) {
+  if (!assertManage()) return;
+  const dialog = DialogPlugin.confirm({
+    header: '删除商品折扣组',
+    body: `确认删除折扣组“${fieldValue(row.name)}”吗？组内仍有商品时将无法删除。`,
+    confirmBtn: { content: '确认删除', theme: 'danger' },
+    async onConfirm() {
+      try {
+        await adminApi.agentDiscount.productDiscountGroups.delete(row.id);
+        MessagePlugin.success('商品折扣组已删除');
+        dialog.destroy();
+        await loadProductGroups();
+        await loadMatrix();
+      } catch (error) {
+        MessagePlugin.error(errorMessage(error, '删除商品折扣组失败'));
+      }
+    },
+  });
+}
+
+async function saveMatrix() {
+  if (!assertManage()) return;
+
+  // 后端 items.*.discount_rate 是 required|numeric，空格子不能带 null 提交，
+  // 否则整批 422、连填好的格子一起保存不进去；空格子直接不提交。
+  const items: AgentGroupDiscountMatrixSavePayload['items'] = [];
+  const belowMinimum: string[] = [];
+
+  matrixRows.value.forEach((row) => {
+    const minimum = Number(row.min_discount_rate ?? 0);
+    agentGroups.value.forEach((group) => {
+      const value = matrixModel[cellKey(row.id, group.id)];
+      if (value === undefined || value === null || Number.isNaN(Number(value))) return;
+
+      const rate = Number(value);
+      // 后端保存时同样按库里的最低折扣率拦截，这里先拦一道是为了能指出具体是哪个格子——
+      // 后端返回的报错只说“折扣率不能低于最低折扣率”，不带行列信息。
+      if (rate < minimum) {
+        belowMinimum.push(`${fieldValue(row.name)} × ${fieldValue(group.name)}`);
+      }
+      items.push({ agent_group_id: group.id, product_discount_group_id: row.id, discount_rate: rate });
+    });
+  });
+
+  if (belowMinimum.length) {
+    MessagePlugin.error(`以下组合的折扣率低于所属折扣组的最低折扣率：${belowMinimum.join('、')}`);
+    return;
+  }
+
+  if (!items.length) {
+    MessagePlugin.warning('没有需要保存的折扣，请先填写折扣率');
+    return;
+  }
+
+  savingMatrix.value = true;
+  try {
+    await adminApi.agentDiscount.matrix.save({ items });
+    MessagePlugin.success('折扣矩阵已保存');
+    await loadMatrix();
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '保存折扣矩阵失败'));
+  } finally {
+    savingMatrix.value = false;
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([loadAgentGroups(), loadProductGroups()]);
+  await loadMatrix();
+});
+</script>

--- a/frontend-admin-v3/src/pages/login/index.vue
+++ b/frontend-admin-v3/src/pages/login/index.vue
@@ -27,6 +27,9 @@
         </t-form-item>
         <!-- inline 形态（Turnstile）的验证组件落点：点击登录时就地加载，无感通过时不占位 -->
         <div v-show="captchaRenderMode === 'inline'" ref="captchaContainer" class="login-captcha"></div>
+        <div class="login-remember">
+          <t-checkbox v-model="rememberAccount">记住账号</t-checkbox>
+        </div>
         <t-form-item class="login-submit-item">
           <t-button block theme="primary" size="large" type="submit" :loading="loading || captchaLoading">
             登录
@@ -73,10 +76,42 @@ onMounted(async () => {
   captchaRenderMode.value = renderMode;
 });
 
+// 「记住账号」只持久化账号，密码一律不落本地存储。
+// 后台账号一旦泄露即等同于整套财务系统失守，而 localStorage 可被任意同源脚本读取
+// （一个 XSS 就能把明文密码整包捞走），风险与收益不成比例。密码交给浏览器自带的
+// 凭据管理器——登录表单已带 autocomplete="username" / "current-password"，
+// 浏览器会在用户许可下加密保存并自动填充，体验一致但密钥由系统钥匙串保管。
+const REMEMBER_ACCOUNT_KEY = 'turaidc-admin-remembered-account';
+const rememberAccount = ref(false);
+
 const formData = ref({
   account: '',
   password: '',
 });
+
+onMounted(() => {
+  try {
+    const saved = window.localStorage.getItem(REMEMBER_ACCOUNT_KEY) || '';
+    if (saved) {
+      formData.value.account = saved;
+      rememberAccount.value = true;
+    }
+  } catch {
+    // 隐私模式等场景下 localStorage 不可用，忽略即可，不影响登录
+  }
+});
+
+function persistRememberedAccount(account: string) {
+  try {
+    if (rememberAccount.value && account) {
+      window.localStorage.setItem(REMEMBER_ACCOUNT_KEY, account);
+    } else {
+      window.localStorage.removeItem(REMEMBER_ACCOUNT_KEY);
+    }
+  } catch {
+    // 同上：存储不可用不应阻断登录流程
+  }
+}
 
 const formRules: Record<string, FormRule[]> = {
   account: [{ required: true, message: '请输入账号', trigger: 'blur' }],
@@ -97,6 +132,7 @@ async function handleLogin() {
       password: formData.value.password,
       ...(captcha ? { captcha } : {}),
     });
+    persistRememberedAccount(formData.value.account);
     MessagePlugin.success('登录成功');
     const redirect = router.currentRoute.value.query.redirect;
     if (redirect) {
@@ -200,6 +236,12 @@ async function handleLogin() {
   &:not(:empty) {
     margin-bottom: 16px;
   }
+}
+
+.login-remember {
+  display: flex;
+  align-items: center;
+  margin-bottom: 20px;
 }
 
 .login-footer {

--- a/frontend-admin-v3/src/pages/products/components/Suppliers.vue
+++ b/frontend-admin-v3/src/pages/products/components/Suppliers.vue
@@ -189,6 +189,19 @@
             </t-button>
           </div>
         </div>
+        <div class="supplier-batch-panel__search">
+          <t-input
+            v-model="supplierBatchRemoteKeyword"
+            size="small"
+            clearable
+            placeholder="搜索上游商品名称 / 类型 / 分组 / ID"
+          >
+            <template #prefix-icon><search-icon /></template>
+          </t-input>
+          <span v-if="supplierBatchRemoteKeyword.trim()" class="supplier-batch-panel__search-hint">
+            命中 {{ supplierBatchRemoteMatchCount }} 个商品
+          </span>
+        </div>
         <div class="supplier-tree" :class="{ 'is-loading': supplierBatchLoading }">
           <template v-if="supplierBatchRemoteRows.length">
             <div
@@ -297,6 +310,19 @@
             </t-button>
           </div>
         </div>
+        <div class="supplier-batch-panel__search">
+          <t-input
+            v-model="supplierBatchLocalKeyword"
+            size="small"
+            clearable
+            placeholder="搜索本地商品 / 分类名称"
+          >
+            <template #prefix-icon><search-icon /></template>
+          </t-input>
+          <span v-if="supplierBatchLocalKeyword.trim()" class="supplier-batch-panel__search-hint">
+            命中 {{ supplierBatchLocalMatchCount }} 个商品
+          </span>
+        </div>
         <div class="supplier-tree supplier-tree--target">
           <template v-if="supplierBatchConnectedRows.length">
             <div
@@ -393,19 +419,19 @@
         </t-select>
         <t-switch
           v-else-if="field.type === 'switch' || field.type === 'boolean'"
-          :value="supplierCredentialValues[field.key] as boolean"
+          :model-value="supplierCredentialValues[field.key] as boolean"
           @update:model-value="(value: unknown) => (supplierCredentialValues[field.key] = value as boolean)"
         />
         <t-input-number
           v-else-if="field.type === 'number'"
-          :value="supplierCredentialValues[field.key] as number | null"
+          :model-value="supplierCredentialValues[field.key] as number | null"
           :placeholder="field.placeholder || `请输入${field.label}`"
           style="width: 100%"
           @update:model-value="(value: unknown) => (supplierCredentialValues[field.key] = value as number | null)"
         />
         <t-textarea
           v-else-if="field.type === 'textarea'"
-          :value="supplierCredentialValues[field.key] as string | number | null"
+          :model-value="supplierCredentialValues[field.key] as string | number | null"
           :autosize="{ minRows: 3, maxRows: 6 }"
           :placeholder="field.placeholder || `请输入${field.label}`"
           @update:model-value="
@@ -426,7 +452,7 @@
         />
         <t-input
           v-else
-          :value="supplierCredentialValues[field.key] as string | number | null"
+          :model-value="supplierCredentialValues[field.key] as string | number | null"
           :type="field.type === 'password' ? 'password' : 'text'"
           clearable
           :placeholder="supplierFieldPlaceholder(field)"
@@ -559,6 +585,8 @@ const supplierBatchTargetGroupKey = ref('');
 const supplierBatchResult = ref<Record<string, unknown> | null>(null);
 const supplierBatchRemoteExpandedKeys = ref<string[]>([]);
 const supplierBatchLocalExpandedKeys = ref<string[]>([]);
+const supplierBatchRemoteKeyword = ref('');
+const supplierBatchLocalKeyword = ref('');
 const supplierBatchRemoteExpansionInitialized = ref(false);
 const supplierBatchLocalExpansionInitialized = ref(false);
 const supplierBatchForm = reactive({
@@ -638,11 +666,28 @@ const supplierBatchConnectedRows = computed(() =>
 );
 const supplierBatchRemoteExpandedKeySet = computed(() => new Set(supplierBatchRemoteExpandedKeys.value));
 const supplierBatchLocalExpandedKeySet = computed(() => new Set(supplierBatchLocalExpandedKeys.value));
+const supplierBatchRemoteFilteredRows = computed(() =>
+  filterSupplierBatchTreeRows(supplierBatchRemoteRows.value, supplierBatchRemoteKeyword.value),
+);
+const supplierBatchLocalFilteredRows = computed(() =>
+  filterSupplierBatchTreeRows(supplierBatchConnectedRows.value, supplierBatchLocalKeyword.value),
+);
+// 搜索时直接展示过滤结果：命中项若落在折叠分组里会被隐藏，等于搜了个寂寞
 const supplierBatchVisibleRemoteRows = computed(() =>
-  visibleSupplierBatchTreeRows(supplierBatchRemoteRows.value, supplierBatchRemoteExpandedKeySet.value),
+  supplierBatchRemoteKeyword.value.trim()
+    ? supplierBatchRemoteFilteredRows.value
+    : visibleSupplierBatchTreeRows(supplierBatchRemoteRows.value, supplierBatchRemoteExpandedKeySet.value),
 );
 const supplierBatchVisibleConnectedRows = computed(() =>
-  visibleSupplierBatchTreeRows(supplierBatchConnectedRows.value, supplierBatchLocalExpandedKeySet.value),
+  supplierBatchLocalKeyword.value.trim()
+    ? supplierBatchLocalFilteredRows.value
+    : visibleSupplierBatchTreeRows(supplierBatchConnectedRows.value, supplierBatchLocalExpandedKeySet.value),
+);
+const supplierBatchRemoteMatchCount = computed(
+  () => supplierBatchRemoteFilteredRows.value.filter((row) => row.node_type === 'product').length,
+);
+const supplierBatchLocalMatchCount = computed(
+  () => supplierBatchLocalFilteredRows.value.filter((row) => row.node_type === 'product').length,
 );
 const supplierBatchTargetGroup = computed(() =>
   findProductGroupByKey(supplierBatchCategories.value, supplierBatchTargetGroupKey.value),
@@ -876,6 +921,8 @@ function resetSupplierBatchState() {
   supplierBatchLocalExpandedKeys.value = [];
   supplierBatchRemoteExpansionInitialized.value = false;
   supplierBatchLocalExpansionInitialized.value = false;
+  supplierBatchRemoteKeyword.value = '';
+  supplierBatchLocalKeyword.value = '';
   Object.assign(supplierBatchForm, {
     default_status: 1,
     default_auto_setup: 1,
@@ -1185,6 +1232,49 @@ function localProductSubtitle(product?: ProductRecord) {
   return (
     String(product.effective_product_group_full_name || product.product_type_label || '本地商品').trim() || '本地商品'
   );
+}
+
+/**
+ * 判断一行是否命中关键字。
+ * 上游侧匹配商品名、类型、上游分组名与上游商品 ID（运维常直接拿 ID 找货）；
+ * 本地侧匹配展示名与分类名——右栏本身就是「选导入位置」，按分类搜同样要能用。
+ */
+function supplierBatchRowMatches(row: SupplierBatchTreeRow, keyword: string): boolean {
+  const candidates: Array<string | number | undefined> = [
+    row.label,
+    row.product?.name,
+    row.product?.type_label,
+    row.product?.remote_group_name,
+    row.product?.id,
+    row.localProduct ? localProductDisplayName(row.localProduct) : undefined,
+  ];
+
+  return candidates.some((item) => String(item ?? '').toLowerCase().includes(keyword));
+}
+
+/**
+ * 按关键字过滤树行，并回溯保留命中行的全部祖先分组。
+ * 不保留祖先的话，命中商品会脱离层级、右栏还会失去可选的父分类。
+ */
+function filterSupplierBatchTreeRows(rows: SupplierBatchTreeRow[], keyword: string): SupplierBatchTreeRow[] {
+  const normalized = keyword.trim().toLowerCase();
+  if (!normalized) return rows;
+
+  const rowByKey = new Map(rows.map((row) => [row.key, row]));
+  const kept = new Set<string>();
+
+  rows.forEach((row) => {
+    if (!supplierBatchRowMatches(row, normalized)) return;
+    kept.add(row.key);
+
+    let parentKey = row.parentKey;
+    while (parentKey && !kept.has(parentKey)) {
+      kept.add(parentKey);
+      parentKey = rowByKey.get(parentKey)?.parentKey;
+    }
+  });
+
+  return rows.filter((row) => kept.has(row.key));
 }
 
 function visibleSupplierBatchTreeRows(rows: SupplierBatchTreeRow[], expandedKeySet: Set<string>) {

--- a/frontend-admin-v3/src/pages/products/index.less
+++ b/frontend-admin-v3/src/pages/products/index.less
@@ -1772,6 +1772,27 @@
   flex-direction: column;
 }
 
+.supplier-batch-panel__search {
+  display: flex;
+  align-items: center;
+  gap: var(--td-comp-margin-s);
+  border-bottom: 1px solid var(--td-component-border);
+  padding: var(--td-comp-paddingTB-s) var(--td-comp-paddingLR-m);
+  background: var(--td-bg-color-container);
+
+  .t-input {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+}
+
+.supplier-batch-panel__search-hint {
+  flex: 0 0 auto;
+  color: var(--td-text-color-placeholder);
+  font-size: var(--td-font-size-body-small);
+  white-space: nowrap;
+}
+
 .supplier-batch-panel__head {
   display: flex;
   align-items: center;

--- a/frontend-admin-v3/src/pages/settings/index.vue
+++ b/frontend-admin-v3/src/pages/settings/index.vue
@@ -48,7 +48,7 @@
                 </t-select>
                 <t-input-number
                   v-else-if="field.type === 'number'"
-                  :value="form[field.key] as FieldNumberValue"
+                  :model-value="form[field.key] as FieldNumberValue"
                   theme="normal"
                   :min="field.min"
                   :max="field.max"
@@ -57,7 +57,7 @@
                 />
                 <t-textarea
                   v-else-if="field.type === 'textarea'"
-                  :value="form[field.key] as FieldStringValue"
+                  :model-value="form[field.key] as FieldStringValue"
                   :autosize="{ minRows: field.rows || 3, maxRows: Math.max(field.rows || 3, 6) }"
                   :maxlength="field.maxlength"
                   :placeholder="field.placeholder || `请输入${field.label}`"
@@ -65,7 +65,7 @@
                 />
                 <t-time-picker
                   v-else-if="field.type === 'time'"
-                  :value="form[field.key] as string"
+                  :model-value="form[field.key] as string"
                   clearable
                   format="HH:mm:ss"
                   :placeholder="field.placeholder || `请选择${field.label}`"
@@ -92,7 +92,7 @@
                 />
                 <t-input
                   v-else
-                  :value="form[field.key] as FieldStringValue"
+                  :model-value="form[field.key] as FieldStringValue"
                   :type="field.type === 'password' ? 'password' : 'text'"
                   :maxlength="field.maxlength"
                   :placeholder="field.placeholder || `请输入${field.label}`"

--- a/frontend-admin-v3/tests/e2e/agent-discounts.spec.ts
+++ b/frontend-admin-v3/tests/e2e/agent-discounts.spec.ts
@@ -1,0 +1,177 @@
+import type { Page, Route } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+const AGENT_GROUPS = [
+  { id: 1, name: '金牌代理', code: 'gold', status: 1, sort_order: 0, remark: '', updated_at: '2026-08-20 10:00:00' },
+  { id: 2, name: '银牌代理', code: 'silver', status: 1, sort_order: 1, remark: '', updated_at: '2026-08-20 10:00:00' },
+];
+
+const PRODUCT_GROUPS = [
+  {
+    id: 11,
+    name: '云服务器',
+    code: 'cloud',
+    min_discount_rate: '90.00',
+    cost_rate: '80.00',
+    status: 1,
+    sort_order: 0,
+    remark: '',
+  },
+];
+
+// 金牌列已有 95 折扣、银牌列为空，用来覆盖「空格子不提交」这条。
+const MATRIX_ROWS = [
+  {
+    id: 11,
+    name: '云服务器',
+    code: 'cloud',
+    min_discount_rate: '90.00',
+    discounts: [
+      { agent_group_id: 1, discount_rate: '95.00' },
+      { agent_group_id: 2, discount_rate: null },
+    ],
+  },
+];
+
+// 装配代理折扣页的接口桩。permissions 只给 agent_discount.list 即可覆盖只读场景；
+// onSave 用来捕获矩阵保存的请求体。
+async function mockAdminApi(page: Page, options: { permissions?: string[]; onSave?: (body: unknown) => void } = {}) {
+  const { permissions = ['*'], onSave } = options;
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem('admin_token', 'agent-discounts-test-token');
+    window.localStorage.setItem('admin_last_active_at', String(Date.now()));
+  });
+
+  await page.route('**/api/v2/admin/**', async (route: Route) => {
+    const url = new URL(route.request().url());
+    const method = route.request().method();
+    const respond = (data: unknown) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ code: 0, data }) });
+
+    if (url.pathname.endsWith('/auth/info')) {
+      return respond({ admin: { id: 1, username: 'discount-test', nickname: 'discount-test', permissions } });
+    }
+    if (url.pathname.endsWith('/agent-groups') && method === 'GET') {
+      return respond({ list: AGENT_GROUPS });
+    }
+    if (url.pathname.endsWith('/product-discount-groups') && method === 'GET') {
+      return respond({ list: PRODUCT_GROUPS });
+    }
+    if (url.pathname.endsWith('/agent-group-discounts') && method === 'GET') {
+      return respond({ rows: MATRIX_ROWS });
+    }
+    if (url.pathname.endsWith('/agent-group-discounts') && method === 'PUT') {
+      onSave?.(route.request().postDataJSON());
+      return respond([]);
+    }
+
+    return respond({});
+  });
+}
+
+async function openMatrixTab(page: Page) {
+  await page.goto('/admin/agent-discounts', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('.agent-discounts-page')).toContainText('金牌代理');
+  await page.locator('.t-tabs__nav-item', { hasText: '折扣矩阵' }).click();
+  await expect(page.locator('.agent-matrix table')).toBeVisible();
+}
+
+/** 矩阵第一行（云服务器）第 index 个代理组的折扣输入框；行首是 <th>，故 td 从金牌开始计数 */
+function matrixCell(page: Page, index: number) {
+  return page.locator('.agent-matrix tbody tr').first().locator('td').nth(index).locator('input');
+}
+
+/** t-input-number 是受控组件，fill() 的整段替换不会触发它的 change，只能逐字符敲 */
+async function setMatrixCell(page: Page, index: number, value: string) {
+  const cell = matrixCell(page, index);
+  await cell.click();
+  await cell.press('ControlOrMeta+a');
+  await cell.pressSequentially(value);
+  await cell.press('Enter');
+  await expect(cell).toHaveValue(new RegExp(`^${value}`));
+}
+
+test('矩阵保存只提交填写过的格子', async ({ page }) => {
+  const payloads: unknown[] = [];
+  await mockAdminApi(page, { onSave: (body) => payloads.push(body) });
+  await openMatrixTab(page);
+
+  // 银牌那格是空的，不能带 null 提交——后端 items.*.discount_rate 是 required，
+  // 一旦带上整批 422，填好的金牌折扣也会跟着保存不进去。
+  await page.getByRole('button', { name: '保存矩阵' }).click();
+  await expect(page.locator('.t-message').filter({ hasText: '折扣矩阵已保存' })).toBeVisible();
+
+  expect(payloads).toHaveLength(1);
+  const { items } = payloads[0] as { items: Array<Record<string, unknown>> };
+  expect(items).toEqual([{ agent_group_id: 1, product_discount_group_id: 11, discount_rate: 95 }]);
+});
+
+test('低于最低折扣率时拦在前端并指出具体组合', async ({ page }) => {
+  let saveCalls = 0;
+  await mockAdminApi(page, { onSave: () => (saveCalls += 1) });
+  await openMatrixTab(page);
+
+  // 云服务器折扣组最低 90，金牌那格填 50 必须拦下且不发请求。
+  await setMatrixCell(page, 0, '50');
+  await page.getByRole('button', { name: '保存矩阵' }).click();
+
+  await expect(page.locator('.t-message').filter({ hasText: '云服务器 × 金牌代理' })).toBeVisible();
+  expect(saveCalls).toBe(0);
+});
+
+test('保存成功后重新拉取矩阵，丢弃本地未保存的改动', async ({ page }) => {
+  await mockAdminApi(page);
+  await openMatrixTab(page);
+
+  const reloaded = page.waitForRequest(
+    (request) => request.url().includes('/agent-group-discounts') && request.method() === 'GET',
+  );
+  await setMatrixCell(page, 0, '96');
+  await page.getByRole('button', { name: '保存矩阵' }).click();
+  await reloaded;
+
+  // 桩固定返回 95，重新加载后必须回到服务端的值而不是页面上的 96。
+  await expect(matrixCell(page, 0)).toHaveValue('95.00');
+});
+
+test('代理组与商品折扣组可新增', async ({ page }) => {
+  const created: Array<{ path: string; body: unknown }> = [];
+  await mockAdminApi(page);
+  await page.route('**/api/v2/admin/{agent-groups,product-discount-groups}', async (route: Route) => {
+    if (route.request().method() !== 'POST') return route.fallback();
+    created.push({ path: new URL(route.request().url()).pathname, body: route.request().postDataJSON() });
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify({ code: 0, data: {} }) });
+  });
+
+  await page.goto('/admin/agent-discounts', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('.agent-discounts-page')).toContainText('金牌代理');
+
+  await page.getByRole('button', { name: '新增代理组' }).click();
+  const agentDialog = page.locator('.t-dialog').filter({ hasText: '新增代理组' });
+  await agentDialog.getByPlaceholder('如：金牌代理').fill('铂金代理');
+  await agentDialog.getByPlaceholder('唯一标识，如 gold').fill('platinum');
+  await agentDialog.getByRole('button', { name: '保存' }).click();
+  await expect(page.locator('.t-message').filter({ hasText: '代理组已创建' })).toBeVisible();
+
+  await page.locator('.t-tabs__nav-item', { hasText: '商品折扣组' }).click();
+  await page.getByRole('button', { name: '新增折扣组' }).click();
+  const productDialog = page.locator('.t-dialog').filter({ hasText: '新增商品折扣组' });
+  await productDialog.getByPlaceholder('如：云服务器').fill('对象存储');
+  await productDialog.getByPlaceholder('唯一标识，如 cloud').fill('oss');
+  await productDialog.getByRole('button', { name: '保存' }).click();
+  await expect(page.locator('.t-message').filter({ hasText: '商品折扣组已创建' })).toBeVisible();
+
+  expect(created.map((item) => item.path.split('/').pop())).toEqual(['agent-groups', 'product-discount-groups']);
+  expect(created[0].body).toMatchObject({ name: '铂金代理', code: 'platinum' });
+  expect(created[1].body).toMatchObject({ name: '对象存储', code: 'oss' });
+});
+
+test('无 agent_discount.manage 权限时矩阵只读', async ({ page }) => {
+  await mockAdminApi(page, { permissions: ['agent_discount.list'] });
+  await openMatrixTab(page);
+
+  await expect(page.getByRole('button', { name: '保存矩阵' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: '新增代理组' })).toHaveCount(0);
+  await expect(matrixCell(page, 0)).toBeDisabled();
+});

--- a/frontend-admin-v3/tests/e2e/login-remember-account.spec.ts
+++ b/frontend-admin-v3/tests/e2e/login-remember-account.spec.ts
@@ -1,0 +1,85 @@
+import type { Page, Route } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+const REMEMBER_KEY = 'turaidc-admin-remembered-account';
+const ACCOUNT = 'cerbo';
+const PASSWORD = 'Temp@123456';
+
+async function mockLoginApi(page: Page) {
+  await page.route('**/api/v2/admin/**', async (route: Route) => {
+    const url = new URL(route.request().url());
+    const respond = (data: unknown) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ code: 0, data }) });
+
+    if (url.pathname.endsWith('/login')) {
+      return respond({ token: 'remember-account-test-token' });
+    }
+    if (url.pathname.endsWith('/auth/info')) {
+      return respond({ admin: { id: 1, username: ACCOUNT, nickname: ACCOUNT, permissions: ['*'] } });
+    }
+    return respond({});
+  });
+}
+
+async function signIn(page: Page, options: { remember: boolean }) {
+  await page.goto('/admin/login', { waitUntil: 'domcontentloaded' });
+  await page.getByPlaceholder('请输入管理员账号').fill(ACCOUNT);
+  await page.getByPlaceholder('请输入密码').fill(PASSWORD);
+  if (options.remember) {
+    await page.getByText('记住账号', { exact: true }).click();
+  }
+  await page.getByRole('button', { name: '登录' }).click();
+  await expect(page).not.toHaveURL(/\/admin\/login/);
+}
+
+const storedAccount = (page: Page, key: string) => page.evaluate((k) => window.localStorage.getItem(k), key);
+
+test('勾选记住账号后回到登录页会自动回填账号', async ({ page }) => {
+  await mockLoginApi(page);
+  await signIn(page, { remember: true });
+
+  expect(await storedAccount(page, REMEMBER_KEY)).toBe(ACCOUNT);
+
+  // 清掉登录态重新进登录页，账号应已回填、勾选框保持选中。
+  await page.evaluate(() => {
+    window.localStorage.removeItem('admin_token');
+    window.localStorage.removeItem('admin_last_active_at');
+  });
+  await page.goto('/admin/login', { waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByPlaceholder('请输入管理员账号')).toHaveValue(ACCOUNT);
+  await expect(page.locator('.login-remember input[type="checkbox"]')).toBeChecked();
+});
+
+test('密码不落 localStorage', async ({ page }) => {
+  await mockLoginApi(page);
+  await signIn(page, { remember: true });
+
+  // 这是财务系统的管理端，明文密码进 localStorage 等于把后台交给任意同源脚本。
+  const dump = await page.evaluate(() => JSON.stringify(window.localStorage));
+  expect(dump).not.toContain(PASSWORD);
+
+  await page.goto('/admin/login', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByPlaceholder('请输入密码')).toHaveValue('');
+});
+
+test('不勾选时不留存账号，且会清掉旧的记录', async ({ page }) => {
+  await mockLoginApi(page);
+  await page.addInitScript(
+    ([key, account]) => window.localStorage.setItem(key as string, account as string),
+    [REMEMBER_KEY, 'stale-account'],
+  );
+
+  await page.goto('/admin/login', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByPlaceholder('请输入管理员账号')).toHaveValue('stale-account');
+
+  // 取消勾选后登录，旧账号必须被清掉，否则换人登录还会看到上一个人的账号。
+  await page.getByText('记住账号', { exact: true }).click();
+  await expect(page.locator('.login-remember input[type="checkbox"]')).not.toBeChecked();
+  await page.getByPlaceholder('请输入管理员账号').fill(ACCOUNT);
+  await page.getByPlaceholder('请输入密码').fill(PASSWORD);
+  await page.getByRole('button', { name: '登录' }).click();
+  await expect(page).not.toHaveURL(/\/admin\/login/);
+
+  expect(await storedAccount(page, REMEMBER_KEY)).toBeNull();
+});

--- a/frontend-user-v4-console/src/pages/result/500/index.vue
+++ b/frontend-user-v4-console/src/pages/result/500/index.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="result-500">
+    <t-result theme="error" title="服务器异常" description="服务暂时不可用，请稍后重试；若持续出现请联系客服。">
+      <template #extra>
+        <t-space size="small">
+          <t-button theme="primary" @click="goHome">返回首页</t-button>
+          <t-button variant="outline" @click="reload">重新加载</t-button>
+        </t-space>
+      </template>
+    </t-result>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+
+defineOptions({
+  name: 'Result500',
+});
+
+const router = useRouter();
+
+function goHome() {
+  router.push('/');
+}
+
+function reload() {
+  window.location.reload();
+}
+</script>
+
+<style lang="less" scoped>
+.result-500 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 24px;
+}
+</style>


### PR DESCRIPTION
在宝塔面板环境下完整走了一遍「全新服务器 → 安装向导 → 三端上线 → 对接上游」的部署流程，逐条修复途中撞到的阻断性缺陷。所有结论均以真实环境实测为准，非静态推断。

测试环境：Ubuntu 22.04 + 宝塔 11.6.0 + PHP 8.3.31 + MySQL 8.0.45 + Redis + Nginx 1.31.4，四个子域名 + Let's Encrypt 证书 + HTTP/2。

## 修复清单

### 1. 全新部署下 Web 安装向导必然 500（阻断）

向导按设计运行在 APP_KEY 未生成、数据库未配置的全新站点上，但两处实现与该前提冲突，导致它在**唯一适用场景下无法访问**：

- `AppServiceProvider::loadSiteNameFromSettings()` 在 boot 阶段无条件 `Schema::hasTable('settings')`，数据库不可用时抛 `QueryException`，provider boot 失败、应用整体起不来。原注释称「表不存在时静默跳过」，但只处理了表缺失、没处理连接不可用；`InstallService::isInstalled()` 中同类调用是包了 `try/catch` 的，口径不一致。
- `/install` 注册在 `routes/web.php`，套用 web 中间件组。`EncryptCookies` / `StartSession` / `ShareErrorsFromSession` / `ValidateCsrfToken` 均依赖 encrypter，无 APP_KEY 时抛 `MissingAppKeyException`。其中 `ValidateCsrfToken` 尤其隐蔽——即便已在 `bootstrap/app.php` 按路径豁免校验，其构造函数仍需注入 `Encrypter`，**实例化本身就会失败**。

顺带修复向导不写 SEO 配置的问题：`config/idc.php` 的 `seo.frontend_shell_url` 默认值是 Docker 编排服务名 `http://frontends:8081/index.html`，源码/宝塔部署下无法解析，官网首页报 `cURL error 6: Could not resolve host: frontends` 并 500。

### 2. 官网 SEO 服务端渲染存储型 XSS（安全）

站点名、文章标题摘要、商品名等后台可编辑内容被直接拼进公开页 HTML，且写入端 `UpdateSettingsRequest` 对 settings 数组不做任何消毒：

- JSON-LD 用 `json_encode(..., JSON_UNESCAPED_SLASHES)` 内嵌进 `<script>`。该 flag 恰好关掉 `/` → `\/` 这层默认保护，值中的 `</script>` 原样输出、截断脚本块。
- `renderHomeBody` / `renderProductsBody` / `fallbackShell` 三处站点名未过 `e()`；同文件其余二十余处均已转义，属遗漏。landing 的 `$keyword` 在 h1 转义、h2 漏转。

**实测**：置站点名为 `TuraPoC</script><img src=x onerror=alert(1)>` 后抓取官网首页——修复前逃逸出 script 块 4 次、全页 10 处可执行 payload；修复后以 DOM 解析断言，注入产生的带 `onerror` 的 img 元素 0 个、script 块内裸 `<img>` 0 次。测试数据已还原。

### 3. 管理端动态表单全部无法输入（阻断）

上游提供商弹窗的插件声明字段与系统设置页各字段**全部无法输入**，按键后值被立刻刷回。

根因是 `4da5c2f`「依赖升级后三端 vue 与 tdesign 类型适配」为消 TS 报错，把 `v-model` 批量改成 `:value=` + `@update:model-value=`。但 TDesign 的 `t-input` 等采用 **value 属性约定**，配套事件是 `update:value` 而非 `update:modelValue`，属性/事件错配使 handler 从不触发。该提交自述「仅类型适配，不改变任何业务逻辑与展示」，实际静默改变了运行时行为，且 e2e 未覆盖。

修法取 `:value` → `:model-value`，与同仓库 `secret-input` 中一直正常工作的写法一致，恢复绑定的同时保留原有类型标注。

### 4. 补齐两个被引用但从未提交的页面（阻断）

`pnpm run build:frontends` 在 main 上直接失败、三端产物一个都出不来：`marketing.ts` 引用的 `@/pages/agent-discounts/index.vue` 从未提交（仓库内仅存设计文档），console 的 `EXCEPTION_COMPONENT` 引用的 `@/pages/result/500/index.vue` 亦不存在。

本次按后端既有接口契约与管理端既有规范**补齐页面**而非删除引用，代理折扣页实现了代理组、商品折扣组、折扣矩阵三个页签。

### 5. 批量对接两侧增加商品搜索（功能）

未对接与已对接两侧各加搜索框。过滤在树行级别进行并回溯保留祖先分组，关键字非空时绕过折叠状态直接展示命中结果。

### 6. 部署文档修正

`-- --dry-run` 在 pnpm 9+ 下报错、无 TTY 环境需 `CI=true`、站点根目录不可直接指向 `dist/`（宝塔 `.user.ini` 加了 `chattr +i`，Vite 清空产物目录时必败）。

## 验证

- 宝塔全新环境完整跑通向导四步：生成 .env、导入 70 张表、创建管理员，`/api/ready` 七项检查全通过
- 三端构建通过（含 `vue-tsc --noEmit`），四站点 HTTPS + HTTP/2 + SPA 回退 + 跨子域登录（CORS 预检 204）全部验证
- XSS 修复前后均以真实注入 + DOM 解析断言

## 未包含

上游附件上传接口的 fail-open（`upload_token_required` 默认 `false`）**未改动**。新版已加 `upload_image_enabled` 默认关闭堵住默认态，但管理员为配置工单传递而开启接口后会重新变为匿名上传。该 fail-open 是为兼容魔方财务 `pushTicketReply` 不支持携带凭证而**有意为之**（代码注释已说明），改动涉及产品取舍，留待讨论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
