### PR TITLE
chore: 重导 schema 基线；fix: 三端状态与校验口径对齐、商品目录缓存失效收敛

### DIFF
--- a/backend/app/Http/Controllers/Admin/V2/AuthController.php
+++ b/backend/app/Http/Controllers/Admin/V2/AuthController.php
@@ -60,7 +60,7 @@ class AuthController extends Controller
 
         if (! ($verification['ok'] ?? false)) {
             return $this->error(
-                42210,
+                CaptchaPolicyService::VERIFY_FAILED_ERROR_CODE,
                 $verification['message'] ?? '行为验证未通过，请重试',
                 ['captcha_required' => true]
             );

--- a/backend/app/Http/Controllers/Client/V2/AuthController.php
+++ b/backend/app/Http/Controllers/Client/V2/AuthController.php
@@ -749,7 +749,7 @@ class AuthController extends Controller
 
         if (! ($result['ok'] ?? false)) {
             return $this->error(
-                42210,
+                CaptchaPolicyService::VERIFY_FAILED_ERROR_CODE,
                 $result['message'] ?? '行为验证未通过，请重试',
                 ['captcha_required' => true]
             );

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -247,13 +247,26 @@ class User extends Authenticatable
         return (int) $this->is_verified === 1 || (int) $this->verification_status === 2;
     }
 
+    /**
+     * 实名状态中文名。
+     *
+     * 状态 5 曾写作「已解绑」，与前端两处的「已驳回」不一致，看上去像两个业务事件，
+     * 实际只有一个：VerificationService::unbind() 是它唯一的写入点，仅管理员可调
+     * （routes/v2-admin.php 的 verifications/{id}/unbindings），前置条件是当前已认证
+     * （verification_status === 2），落库时一并写入驳回原因（缺省「管理员驳回」）。
+     *
+     * 「解绑」是这件事对数据的效果，「驳回」是管理员在界面上做的动作。取后者：
+     * 本常量只被 5 个 Admin/V2 Resource 输出，读它的是管理员，而管理端整条流程
+     * （canReject / openReject /「请输入驳回原因」）和 shared/statusConfig.js 都叫「驳回」。
+     * unbind 保留为 API 与权限标识符，不随文案改动。
+     */
     public const VERIFICATION_STATUS_LABELS = [
         0 => '未认证',
         1 => '待认证',
         2 => '已认证',
         3 => '认证失败',
         4 => '待认证',
-        5 => '已解绑',
+        5 => '已驳回',
     ];
 
     public static function verificationStatusLabel(int $status): string

--- a/backend/app/Services/Auth/CaptchaPolicyService.php
+++ b/backend/app/Services/Auth/CaptchaPolicyService.php
@@ -33,6 +33,18 @@ use App\Services\Integrations\Plugins\PluginDomain;
  */
 final class CaptchaPolicyService
 {
+    /**
+     * 行为验证未通过的业务错误码。
+     *
+     * 曾与 ReferralService 的退款拦截码 42210 冲突：两处语义完全不同，却落在同一个码上。
+     * 当时没炸，只因为前端判断的是响应里的 captcha_required 布尔字段而不是码值；
+     * 一旦有人改成按码判断，退款被拦截时就会弹出验证码框。
+     *
+     * 让码的是验证码这一侧：42210-42212 是 ReferralService 连续且具名的退款拦截码段，
+     * 其中 42211/42212 的错误码还写进了给管理员看的文案（「错误码 42211。」），不宜变动。
+     */
+    public const VERIFY_FAILED_ERROR_CODE = 42220;
+
     public const SCENE_CLIENT_LOGIN = 'client_login';
 
     public const SCENE_CLIENT_REGISTER = 'client_register';

--- a/backend/app/Services/Content/HomeHeroService.php
+++ b/backend/app/Services/Content/HomeHeroService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Content;
 
 use App\Models\Setting;
-use App\Support\ContentPublishedCacheVersion;
+use App\Services\Site\SiteHomeService;
 use Illuminate\Support\Facades\Cache;
 
 /**
@@ -84,9 +84,10 @@ class HomeHeroService
         ]);
 
         Cache::forget(self::CACHE_KEY);
-        $contentVersion = ContentPublishedCacheVersion::current();
-        Cache::forget(sprintf('site:home:%s:%d:%d:v%d', 'all', 50, 4, $contentVersion));
-        Cache::forget(sprintf('site:home:%d:%d:%d:v%d', 4, 50, 4, $contentVersion));
+        // 首页聚合缓存的键由 SiteHomeService 统一构造：这里改 hero，内容版本号不会变，
+        // 必须按当前版本把实际在用的两个变体显式清掉。'site:home:4:50:4' 是遗留的无版本键。
+        Cache::forget(SiteHomeService::overviewCacheKey(0, 50, 4));
+        Cache::forget(SiteHomeService::overviewCacheKey(4, 50, 4));
         Cache::forget('site:home:4:50:4');
 
         return [

--- a/backend/app/Services/ProductCatalog/Concerns/HandlesProductCatalogHelpers.php
+++ b/backend/app/Services/ProductCatalog/Concerns/HandlesProductCatalogHelpers.php
@@ -7,16 +7,10 @@ namespace App\Services\ProductCatalog\Concerns;
 use App\Constants\BillingCycle;
 use App\Exceptions\BusinessException;
 use App\Models\Product;
-use App\Services\ProductCatalog\ProductDisplayNameResolver;
-use App\Support\CacheKey;
-use Illuminate\Support\Facades\Cache;
+use App\Services\ProductCatalog\SiteCatalogCacheInvalidator;
 
 trait HandlesProductCatalogHelpers
 {
-    private const ADMIN_SUMMARY_CACHE_KEY = 'catalog:admin_summary:v1';
-
-    private const SITE_CATALOG_CACHE_KEY = 'catalog:site:v1';
-
     private const SITE_PRODUCT_TYPES_CACHE_KEY = 'catalog:site:types';
 
     private const SITE_ROOT_GROUPS_CACHE_KEY = 'catalog:site:root_groups';
@@ -43,35 +37,17 @@ trait HandlesProductCatalogHelpers
 
     private function forgetSiteCatalogCache(): void
     {
-        Cache::forget(self::ADMIN_SUMMARY_CACHE_KEY);
-        Cache::forget(self::SITE_CATALOG_CACHE_KEY);
-
-        // ProductDisplayNameResolver 现为容器 singleton，其显示名与规格文案缓存是进程内长命的。
-        // 商品目录发生变更时必须一并失效，否则长驻进程（队列 Worker、Octane）会继续返回旧值。
-        app(ProductDisplayNameResolver::class)->flushCaches();
-
-        // 清理所有 site:home 相关缓存
-        if (Cache::supportsTags()) {
-            Cache::tags(['site:home'])->flush();
-            Cache::tags(['site:products'])->flush();
-        }
-
-        $this->bumpSiteCatalogCacheVersion();
-    }
-
-    private function bumpSiteCatalogCacheVersion(): void
-    {
-        Cache::put(CacheKey::siteCatalogSplitVersion(), $this->siteCacheVersion() + 1, now()->addYear());
+        app(SiteCatalogCacheInvalidator::class)->flush();
     }
 
     private function siteCacheVersion(): int
     {
-        return max(1, (int) Cache::get(CacheKey::siteCatalogSplitVersion(), 1));
+        return app(SiteCatalogCacheInvalidator::class)->currentVersion();
     }
 
     private function siteCacheKey(string $cacheSuffix): string
     {
-        return $cacheSuffix.':v'.$this->siteCacheVersion();
+        return app(SiteCatalogCacheInvalidator::class)->versionedKey($cacheSuffix);
     }
 
     private function resolveDisplayStock(Product $product): int

--- a/backend/app/Services/ProductCatalog/CpuModelCatalogService.php
+++ b/backend/app/Services/ProductCatalog/CpuModelCatalogService.php
@@ -5,8 +5,6 @@ namespace App\Services\ProductCatalog;
 use App\Exceptions\BusinessException;
 use App\Models\Product;
 use App\Models\Setting;
-use App\Support\CacheKey;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -281,16 +279,9 @@ class CpuModelCatalogService
 
     private function forgetSiteCatalogCache(): void
     {
-        Cache::forget(CacheKey::siteCatalog());
-        Cache::put(CacheKey::siteCatalogSplitVersion(), $this->siteCacheVersion() + 1, now()->addYear());
-
-        // 同 HandlesProductCatalogHelpers：CPU 型号变更会改变规格文案，需失效解析器的进程内缓存
-        app(ProductDisplayNameResolver::class)->flushCaches();
-    }
-
-    private function siteCacheVersion(): int
-    {
-        return max(1, (int) Cache::get(CacheKey::siteCatalogSplitVersion(), 1));
+        // 这里原本自带一份实现，漏掉了管理端目录概览（catalog:admin_summary:v1）的失效，
+        // 改完 CPU 型号后管理端概览会继续读旧值。统一走唯一入口。
+        app(SiteCatalogCacheInvalidator::class)->flush();
     }
 
     private function normalizeId(mixed $id, string $prefix, int $primaryIndex, ?int $secondaryIndex): string

--- a/backend/app/Services/ProductCatalog/InstanceSpecCatalogService.php
+++ b/backend/app/Services/ProductCatalog/InstanceSpecCatalogService.php
@@ -7,7 +7,6 @@ namespace App\Services\ProductCatalog;
 use App\Exceptions\BusinessException;
 use App\Models\Product;
 use App\Models\Setting;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -16,8 +15,6 @@ class InstanceSpecCatalogService
     public const SETTING_GROUP = 'product';
 
     public const SETTING_KEY = 'instance_spec_catalog';
-
-    private const SITE_CATALOG_CACHE_KEY = 'catalog:site:instance_spec:v1';
 
     public function __construct(
         private readonly ?ProductDisplayNameResolver $productDisplayNameResolver = null,
@@ -325,10 +322,9 @@ class InstanceSpecCatalogService
 
     private function forgetSiteCatalogCache(): void
     {
-        Cache::forget(self::SITE_CATALOG_CACHE_KEY);
-
-        // 同 HandlesProductCatalogHelpers：实例规格变更会改变规格文案，需失效解析器的进程内缓存
-        app(ProductDisplayNameResolver::class)->flushCaches();
+        // 这里原本清的是自定义常量 'catalog:site:instance_spec:v1'——全仓没有任何写入方，
+        // 且不 bump 目录拆分版本号，等于改完实例规格后官网目录页要等 600-900 秒 TTL 才更新。
+        app(SiteCatalogCacheInvalidator::class)->flush();
     }
 
     private function normalizeId(mixed $id, int $index): string

--- a/backend/app/Services/ProductCatalog/ProductCategoryService.php
+++ b/backend/app/Services/ProductCatalog/ProductCategoryService.php
@@ -12,6 +12,7 @@ use App\Models\SecondProductGroup;
 use App\Models\Service;
 use App\Models\ThirdProductGroup;
 use App\Services\ProductCatalog\Concerns\HandlesProductCatalogHelpers;
+use App\Support\CacheKey;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -35,7 +36,7 @@ class ProductCategoryService
     public function adminSummary(): array
     {
         return Cache::remember(
-            self::ADMIN_SUMMARY_CACHE_KEY,
+            CacheKey::adminCatalogSummary(),
             now()->addSeconds(self::ADMIN_SUMMARY_CACHE_TTL_SECONDS),
             fn () => [
                 'first_product_groups_total' => FirstProductGroup::query()->count(),

--- a/backend/app/Services/ProductCatalog/ProductSiteService.php
+++ b/backend/app/Services/ProductCatalog/ProductSiteService.php
@@ -12,6 +12,7 @@ use App\Models\SecondProductGroup;
 use App\Models\ThirdProductGroup;
 use App\Services\Integrations\Plugins\PluginBindingResolver;
 use App\Services\ProductCatalog\Concerns\HandlesProductCatalogHelpers;
+use App\Support\CacheKey;
 use App\Support\ProductGroupHierarchyFields;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -329,7 +330,7 @@ class ProductSiteService
         }
 
         return Cache::remember(
-            self::SITE_CATALOG_CACHE_KEY,
+            CacheKey::siteCatalog(),
             now()->addSeconds(self::SITE_CATALOG_CACHE_TTL_SECONDS),
             fn () => $this->visibleSecondProductGroupQuery()
                 ->select('second_product_groups.*')

--- a/backend/app/Services/ProductCatalog/SiteCatalogCacheInvalidator.php
+++ b/backend/app/Services/ProductCatalog/SiteCatalogCacheInvalidator.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ProductCatalog;
+
+use App\Support\CacheKey;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * 商品目录缓存的唯一失效入口。
+ *
+ * 此前同名的 forgetSiteCatalogCache() 有三份实现，各自漏掉不同的步骤：
+ *
+ * | 步骤              | HandlesProductCatalogHelpers | CpuModelCatalogService | InstanceSpecCatalogService |
+ * |-------------------|------------------------------|------------------------|----------------------------|
+ * | 清 admin_summary  | 有                           | 无                     | 无                         |
+ * | 清 catalog:site   | 有                           | 有                     | 清了个没人写的键           |
+ * | 刷解析器进程缓存  | 有                           | 有                     | 有                         |
+ * | bump 拆分版本号   | 有                           | 有                     | **无**                     |
+ *
+ * 最后一格是唯一会让线上显示旧数据的：官网目录页全部经 ProductSiteService::rememberSitePayload()
+ * 读取，键里嵌着版本号（siteCacheKey()），**bump 版本号才是真正的失效手段**。
+ * InstanceSpecCatalogService 不 bump，改完实例规格后目录页要等 600-900 秒 TTL 自然过期。
+ * 它另外定义了一个 'catalog:site:instance_spec:v1' 常量并去清，而那个键全仓没有任何写入方，
+ * 清它是空操作——名字和 trait 的常量一样，值却不同，看起来像做了事。
+ *
+ * 关于被移除的 Cache::tags(['site:home','site:products'])->flush()：
+ * 全仓（含 plugins/）没有任何一处用 tags 写缓存，所以它 flush 的是空标签集。
+ * 它想清的 site:home:* 是 SiteHomeService 写的**普通键**，tag flush 碰不到——
+ * 那个意图现在由 SiteHomeService::overviewCacheKey() 把目录版本号编进键里真正实现。
+ *
+ * 用 app() 取本类而不是构造注入：CpuModelCatalogService / InstanceSpecCatalogService /
+ * ProductSiteService / SiteHomeService 都存在被直接 new 的调用点
+ * （ProductDisplayNameResolver:900 与若干测试），加构造参数会把它们全打断。
+ */
+final class SiteCatalogCacheInvalidator
+{
+    /**
+     * 当前目录拆分版本号。读路径用它拼键，失效时 +1。
+     */
+    public function currentVersion(): int
+    {
+        return max(1, (int) Cache::get(CacheKey::siteCatalogSplitVersion(), 1));
+    }
+
+    /**
+     * 给缓存后缀拼上当前版本号。
+     */
+    public function versionedKey(string $cacheSuffix): string
+    {
+        return $cacheSuffix.':v'.$this->currentVersion();
+    }
+
+    /**
+     * 失效全部商品目录缓存。任何改动商品、分组、CPU 型号、实例规格、规格亮点的写操作都应调用它。
+     */
+    public function flush(): void
+    {
+        Cache::forget(CacheKey::adminCatalogSummary());
+        Cache::forget(CacheKey::siteCatalog());
+
+        // ProductDisplayNameResolver 是容器 singleton，其显示名与规格文案缓存是进程内长命的。
+        // 不刷的话长驻进程（队列 Worker、Octane）会继续返回旧值。
+        app(ProductDisplayNameResolver::class)->flushCaches();
+
+        // 放在最后：上面几步读到的都是旧版本下的键，bump 之后新请求一律落到新键。
+        Cache::put(CacheKey::siteCatalogSplitVersion(), $this->currentVersion() + 1, now()->addYear());
+    }
+}

--- a/backend/app/Services/Site/SiteHomeService.php
+++ b/backend/app/Services/Site/SiteHomeService.php
@@ -7,6 +7,7 @@ namespace App\Services\Site;
 use App\Models\ContentArticle;
 use App\Services\Content\ContentArticleService;
 use App\Services\Content\HomeHeroService;
+use App\Services\ProductCatalog\SiteCatalogCacheInvalidator;
 use App\Support\ContentPublishedCacheVersion;
 use App\Support\SiteConfigPayload;
 use App\Support\UploadUrl;
@@ -24,20 +25,37 @@ class SiteHomeService
         private readonly HomeHeroService $homeHeroService,
     ) {}
 
-    public function overview(int $groupLimit = 0, int $noticeLimit = 50, int $helpLimit = 4): array
+    /**
+     * 首页聚合缓存键。写入方与失效方共用，避免两边各拼一次 sprintf 后走形。
+     *
+     * 键里有两个版本号：
+     * - v{contentVersion}：文章发布版本，内容变更时换键；
+     * - c{catalogVersion}：商品目录拆分版本，商品/分组/CPU 型号/实例规格变更时由
+     *   SiteCatalogCacheInvalidator::flush() 递增。
+     *
+     * 加 c 段是因为这份 payload 里含商品数据（productTypes / productGroups / groupCatalogMap），
+     * 而它此前只跟着内容版本走：改完商品，首页仍旧读旧值直到 600 秒 TTL 到期。
+     * 原先 HandlesProductCatalogHelpers 里那句 Cache::tags(['site:home'])->flush()
+     * 想解决的正是这件事，但全仓没有一处用 tags 写缓存，它 flush 的是空标签集。
+     */
+    public static function overviewCacheKey(int $groupLimit, int $noticeLimit, int $helpLimit): string
     {
-        $groupLimit = max(0, $groupLimit);
-        $contentVersion = ContentPublishedCacheVersion::current();
-        $cacheKey = sprintf(
-            'site:home:%s:%d:%d:v%d',
+        return sprintf(
+            'site:home:%s:%d:%d:v%d:c%d',
             $groupLimit > 0 ? (string) $groupLimit : 'all',
             $noticeLimit,
             $helpLimit,
-            $contentVersion
+            ContentPublishedCacheVersion::current(),
+            app(SiteCatalogCacheInvalidator::class)->currentVersion(),
         );
+    }
+
+    public function overview(int $groupLimit = 0, int $noticeLimit = 50, int $helpLimit = 4): array
+    {
+        $groupLimit = max(0, $groupLimit);
 
         return Cache::remember(
-            $cacheKey,
+            self::overviewCacheKey($groupLimit, $noticeLimit, $helpLimit),
             now()->addSeconds(self::HOME_CACHE_TTL_SECONDS),
             function () use ($groupLimit, $noticeLimit, $helpLimit): array {
                 $contentOverview = $this->contentArticleService->publishedOverview($noticeLimit, $helpLimit);

--- a/backend/app/Support/CacheKey.php
+++ b/backend/app/Support/CacheKey.php
@@ -62,6 +62,14 @@ final class CacheKey
     }
 
     /**
+     * 管理端目录概览缓存。
+     */
+    public static function adminCatalogSummary(): string
+    {
+        return 'catalog:admin_summary:v1';
+    }
+
+    /**
      * 站点目录拆分版本缓存。
      */
     public static function siteCatalogSplitVersion(): string

--- a/backend/database/schema/mysql-schema.sql
+++ b/backend/database/schema/mysql-schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE `account_transactions` (
   `account_type` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '账户类型：cash/credit/referral 等',
   `event_type` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '流水事件类型：recharge/consume/refund/adjust/reward_frozen/reward_released 等',
   `change_amount` decimal(12,2) NOT NULL DEFAULT '0.00' COMMENT '本次变动金额，收入为正、支出为负',
-  `currency` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
+  `currency` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
   `balance_after` decimal(12,2) NOT NULL DEFAULT '0.00' COMMENT '本次变动后的账户余额',
   `source_type` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '业务来源类型，如 invoice/payment/referral_withdrawal',
   `source_id` bigint unsigned DEFAULT NULL COMMENT '业务来源ID',
@@ -31,6 +31,7 @@ CREATE TABLE `account_transactions` (
   KEY `account_transactions_origin_idx` (`origin_type`,`origin_id`),
   KEY `account_transactions_trace_id_idx` (`trace_id`),
   KEY `account_transactions_created_at_idx` (`created_at`),
+  KEY `account_transactions_source_idx` (`source_type`,`source_id`),
   CONSTRAINT `fk_stage2_account_transactions_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE RESTRICT
 ) ENGINE=InnoDB AUTO_INCREMENT=1745 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='账户流水表，记录现金账户、授信账户、推荐奖励账户的每一次余额变化';
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -121,6 +122,84 @@ CREATE TABLE `agent_applications` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+DROP TABLE IF EXISTS `agent_group_discounts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `agent_group_discounts` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `agent_group_id` bigint unsigned NOT NULL,
+  `product_discount_group_id` bigint unsigned NOT NULL,
+  `discount_rate` decimal(5,2) NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `agent_group_discount_unique` (`agent_group_id`,`product_discount_group_id`),
+  KEY `agent_group_discounts_product_discount_group_id_foreign` (`product_discount_group_id`),
+  CONSTRAINT `agent_group_discounts_agent_group_id_foreign` FOREIGN KEY (`agent_group_id`) REFERENCES `agent_groups` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_group_discounts_product_discount_group_id_foreign` FOREIGN KEY (`product_discount_group_id`) REFERENCES `product_discount_groups` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `agent_groups`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `agent_groups` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `code` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` tinyint NOT NULL DEFAULT '1',
+  `sort_order` int NOT NULL DEFAULT '0',
+  `remark` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `agent_groups_code_unique` (`code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `api_key_usage_logs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `api_key_usage_logs` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `api_key_id` bigint unsigned NOT NULL,
+  `user_id` bigint unsigned NOT NULL,
+  `method` varchar(8) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `path` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `status_code` smallint unsigned NOT NULL DEFAULT '0',
+  `ip` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `duration_ms` int unsigned NOT NULL DEFAULT '0',
+  `created_at` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `api_key_usage_logs_api_key_id_index` (`api_key_id`),
+  KEY `api_key_usage_logs_created_at_index` (`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `api_keys`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `api_keys` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint unsigned NOT NULL,
+  `name` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `key_prefix` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secret_hash` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secret_last4` varchar(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `scopes` json DEFAULT NULL,
+  `expires_at` timestamp NULL DEFAULT NULL,
+  `ip_allowlist` json DEFAULT NULL,
+  `status` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'enabled',
+  `last_used_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `api_keys_key_prefix_unique` (`key_prefix`),
+  KEY `api_keys_user_id_index` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 DROP TABLE IF EXISTS `archive_audit_logs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
@@ -200,11 +279,7 @@ CREATE TABLE `content_articles` (
   KEY `idx_content_type_status_publish` (`content_type`,`status`,`publish_at`),
   KEY `idx_content_type_pin_sort` (`content_type`,`is_pinned`,`sort_order`,`id`),
   KEY `idx_content_type_recommend` (`content_type`,`is_recommended`,`publish_at`),
-  KEY `idx_content_category_type` (`category_name`,`content_type`),
-  KEY `content_articles_created_by_index` (`created_by`),
-  KEY `content_articles_updated_by_index` (`updated_by`),
   KEY `idx_content_article_type_category` (`content_type`,`category_id`),
-  KEY `idx_article_published` (`status`,`publish_at`,`is_pinned`),
   KEY `idx_article_category_published` (`category_id`,`status`,`publish_at`),
   CONSTRAINT `fk_stage2_content_articles_category_id` FOREIGN KEY (`category_id`) REFERENCES `content_categories` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -252,7 +327,7 @@ CREATE TABLE `coupon_campaigns` (
   `product_ids` json DEFAULT NULL,
   `first_order_only` tinyint(1) NOT NULL DEFAULT '0',
   `per_user_limit` int unsigned DEFAULT NULL,
-  `status` tinyint NOT NULL DEFAULT '1',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0=禁用 1=启用',
   `sort_order` int unsigned NOT NULL DEFAULT '0',
   `last_dispatched_at` timestamp NULL DEFAULT NULL,
   `last_coupon_id` bigint unsigned DEFAULT NULL,
@@ -290,7 +365,7 @@ CREATE TABLE `coupons` (
   `total_usage_limit` int unsigned DEFAULT NULL,
   `per_user_limit` int unsigned DEFAULT NULL,
   `used_count` int unsigned NOT NULL DEFAULT '0',
-  `status` tinyint NOT NULL DEFAULT '1',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0=禁用 1=启用',
   `sort_order` int unsigned NOT NULL DEFAULT '0',
   `starts_at` timestamp NULL DEFAULT NULL,
   `expires_at` timestamp NULL DEFAULT NULL,
@@ -299,6 +374,7 @@ CREATE TABLE `coupons` (
   `trace_id` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
+  `allow_agent` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `coupons_code_unique` (`code`),
   KEY `coupons_campaign_status_idx` (`coupon_campaign_id`,`status`),
@@ -328,13 +404,13 @@ DROP TABLE IF EXISTS `first_product_groups`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `first_product_groups` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '业务编码：vps/dedicated/domain/…',
-  `product_type` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '商品类型：cloud_server/game_cloud/…',
-  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '名称',
-  `slug` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'URL标识',
-  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分组说明',
-  `icon` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '图标',
-  `banner_image` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '横幅图',
+  `code` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '业务编码：vps/dedicated/domain/…',
+  `product_type` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '商品类型：cloud_server/game_cloud/…',
+  `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '名称',
+  `slug` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'URL标识',
+  `description` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分组说明',
+  `icon` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '图标',
+  `banner_image` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '横幅图',
   `sort_order` int NOT NULL DEFAULT '0' COMMENT '排序',
   `is_visible` tinyint unsigned NOT NULL DEFAULT '1' COMMENT '前台可见',
   `is_system` tinyint unsigned NOT NULL DEFAULT '0' COMMENT '系统内置',
@@ -473,6 +549,7 @@ CREATE TABLE `integration_plugins` (
   `plugin_key` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `version` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '1.0.0',
+  `manifest_hash` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `provider_class` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `entry_class` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `capabilities_json` json DEFAULT NULL,
@@ -532,7 +609,7 @@ CREATE TABLE `invoices` (
   `coupon_code` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '使用的优惠码快照',
   `type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'normal' COMMENT '账单类型：normal/new/renew/recharge/deduction/referral_credit/manual/upgrade',
   `amount` decimal(12,2) NOT NULL COMMENT '账单应收金额',
-  `currency` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
+  `currency` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
   `discount` decimal(12,2) NOT NULL DEFAULT '0.00' COMMENT '账单优惠抵扣金额',
   `billing_cycle` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '计费周期：monthly/quarterly/annually/onetime 等',
   `quantity` int unsigned NOT NULL DEFAULT '1' COMMENT '购买数量或计费数量',
@@ -540,7 +617,7 @@ CREATE TABLE `invoices` (
   `config_pricing_snapshot` json DEFAULT NULL COMMENT '配置项计价快照 JSON',
   `coupon_snapshot` json DEFAULT NULL COMMENT '优惠券使用快照 JSON',
   `paid_amount` decimal(12,2) NOT NULL DEFAULT '0.00' COMMENT '已支付入账金额',
-  `status` tinyint NOT NULL DEFAULT '0' COMMENT '账单状态：0待支付 1已支付 2已取消 3已逾期 5已退款',
+  `status` tinyint NOT NULL DEFAULT '0' COMMENT '账单状态：0未付 1已付 2已取消 3逾期 5已退款 6部分退款',
   `due_date` date DEFAULT NULL,
   `paid_at` timestamp NULL DEFAULT NULL COMMENT '账单支付完成时间',
   `deleted_at` timestamp NULL DEFAULT NULL,
@@ -555,7 +632,6 @@ CREATE TABLE `invoices` (
   `trace_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '链路追踪号',
   PRIMARY KEY (`id`),
   UNIQUE KEY `invoices_invoice_no_unique` (`invoice_no`),
-  KEY `invoices_user_id_index` (`user_id`),
   KEY `invoices_status_due_date_index` (`status`,`due_date`),
   KEY `invoices_user_status_id_idx` (`user_id`,`status`,`id`),
   KEY `invoices_status_paid_at_idx` (`status`,`paid_at`),
@@ -662,7 +738,6 @@ CREATE TABLE `message_logs` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `message_logs_channel_created_at_idx` (`channel`,`created_at`),
   KEY `message_logs_recipient_created_at_idx` (`recipient`,`created_at`),
   KEY `message_logs_driver_created_idx` (`driver_key`,`created_at`),
   KEY `message_logs_plugin_created_idx` (`plugin_id`,`created_at`),
@@ -682,7 +757,7 @@ CREATE TABLE `migrations` (
   `migration` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `batch` int NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=177 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=200 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `notice_reads`;
@@ -696,7 +771,6 @@ CREATE TABLE `notice_reads` (
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `notice_reads_user_id_article_id_unique` (`user_id`,`article_id`),
-  KEY `notice_reads_user_id_index` (`user_id`),
   KEY `notice_reads_article_id_index` (`article_id`),
   CONSTRAINT `fk_stage2_notice_reads_article_id` FOREIGN KEY (`article_id`) REFERENCES `content_articles` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_stage2_notice_reads_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
@@ -743,7 +817,6 @@ CREATE TABLE `operation_logs` (
   `ip_address` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `operation_logs_user_id_user_type_index` (`user_id`,`user_type`),
   KEY `operation_logs_module_created_at_index` (`module`,`created_at`),
   KEY `operation_logs_user_type_created_at_idx` (`user_id`,`user_type`,`created_at`),
   KEY `operation_logs_module_subject_created_idx` (`module`,`subject_id`,`created_at`,`id`),
@@ -768,7 +841,7 @@ CREATE TABLE `orders` (
   `user_coupon_id` bigint unsigned DEFAULT NULL,
   `coupon_code` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `amount` decimal(12,2) NOT NULL,
-  `currency` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
+  `currency` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
   `discount` decimal(12,2) NOT NULL DEFAULT '0.00',
   `paid_amount` decimal(12,2) NOT NULL DEFAULT '0.00',
   `billing_cycle` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -860,8 +933,8 @@ CREATE TABLE `payments` (
   `gateway_key` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `trade_no` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '第三方交易号',
   `amount` decimal(12,2) NOT NULL COMMENT '第三方支付金额',
-  `currency` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
-  `status` tinyint NOT NULL DEFAULT '0' COMMENT '支付状态：0待支付 1成功 2失败 3已退款',
+  `currency` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
+  `status` tinyint NOT NULL DEFAULT '0' COMMENT '支付状态：0待支付 1成功 2失败 3已退款 4已取消',
   `callback_raw` json DEFAULT NULL COMMENT '最近一次回调原始载荷 JSON',
   `paid_at` timestamp NULL DEFAULT NULL COMMENT '第三方确认支付时间',
   `deleted_at` timestamp NULL DEFAULT NULL,
@@ -907,6 +980,25 @@ CREATE TABLE `personal_access_tokens` (
   KEY `personal_access_tokens_tokenable_type_tokenable_id_index` (`tokenable_type`,`tokenable_id`),
   KEY `personal_access_tokens_expires_at_index` (`expires_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=174 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `product_discount_groups`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `product_discount_groups` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `code` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `min_discount_rate` decimal(5,2) NOT NULL DEFAULT '100.00',
+  `cost_rate` decimal(5,2) NOT NULL DEFAULT '0.00',
+  `status` tinyint NOT NULL DEFAULT '1',
+  `sort_order` int NOT NULL DEFAULT '0',
+  `remark` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `product_discount_groups_code_unique` (`code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `product_upstream_bindings`;
@@ -964,9 +1056,9 @@ CREATE TABLE `products` (
   `created_at` timestamp NULL DEFAULT NULL COMMENT '创建时间',
   `updated_at` timestamp NULL DEFAULT NULL COMMENT '更新时间',
   `deleted_at` timestamp NULL DEFAULT NULL COMMENT '软删除时间',
+  `product_discount_group_id` bigint unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `products_type_status_index` (`product_type`,`status`),
-  KEY `idx_product_status_groups` (`status`),
   KEY `products_group_status_sort_id_idx` (`product_group_id`,`status`,`sort_order`,`id`),
   CONSTRAINT `products_product_group_fk` FOREIGN KEY (`product_group_id`) REFERENCES `third_product_groups` (`id`) ON DELETE RESTRICT
 ) ENGINE=InnoDB AUTO_INCREMENT=379 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='商品表，记录可售卖产品的分类、定价、库存、上游绑定和开通策略';
@@ -977,7 +1069,7 @@ DROP TABLE IF EXISTS `recharge_records`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `recharge_records` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `record_no` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `record_no` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` bigint unsigned NOT NULL,
   `order_id` bigint unsigned DEFAULT NULL,
   `invoice_id` bigint unsigned DEFAULT NULL,
@@ -985,16 +1077,16 @@ CREATE TABLE `recharge_records` (
   `account_transaction_id` bigint unsigned DEFAULT NULL,
   `refund_id` bigint unsigned DEFAULT NULL,
   `origin_recharge_record_id` bigint unsigned DEFAULT NULL,
-  `scene` varchar(30) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `direction` varchar(8) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `scene` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '业务场景：recharge=支付充值 admin_recharge=管理员充值 refund=退款 等',
+  `direction` varchar(8) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '资金方向：in=入账 out=出账',
   `amount` decimal(12,2) NOT NULL,
-  `currency` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
-  `entry_type` varchar(30) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `operator_type` varchar(30) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `currency` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
+  `entry_type` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '入账类型：third_party_payment/manual_recharge/account_recharge/refund_offset',
+  `remark` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operator_type` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `operator_id` bigint unsigned DEFAULT NULL,
-  `operator_name` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `trace_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operator_name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `trace_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -1051,7 +1143,7 @@ CREATE TABLE `referral_rewards` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `referrer_user_id` bigint unsigned NOT NULL,
   `referred_user_id` bigint unsigned NOT NULL,
-  `order_id` bigint unsigned NOT NULL,
+  `order_id` bigint unsigned DEFAULT NULL,
   `invoice_id` bigint unsigned DEFAULT NULL,
   `product_id` bigint unsigned DEFAULT NULL,
   `order_amount` decimal(12,2) NOT NULL DEFAULT '0.00',
@@ -1092,7 +1184,7 @@ CREATE TABLE `referral_withdrawals` (
   `account_name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `account_no` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `status` tinyint NOT NULL DEFAULT '0' COMMENT '0=待处理 1=已通过 2=已拒绝',
-  `payment_no` varchar(120) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `payment_no` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `remark` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `operator` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `paid_at` timestamp NULL DEFAULT NULL,
@@ -1113,21 +1205,21 @@ DROP TABLE IF EXISTS `refunds`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `refunds` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `refund_no` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `refund_no` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` bigint unsigned NOT NULL,
   `invoice_id` bigint unsigned NOT NULL,
   `refund_invoice_id` bigint unsigned DEFAULT NULL,
   `payment_id` bigint unsigned DEFAULT NULL,
   `amount` decimal(12,2) NOT NULL,
-  `status` tinyint unsigned NOT NULL DEFAULT '1',
-  `refund_method` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'balance',
-  `currency` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
-  `reason` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `gateway_refund_no` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `operator_type` varchar(30) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` tinyint unsigned NOT NULL DEFAULT '1' COMMENT '退款状态：1=已完成',
+  `refund_method` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'balance',
+  `currency` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY',
+  `reason` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `gateway_refund_no` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operator_type` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `operator_id` bigint unsigned DEFAULT NULL,
-  `operator_name` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `trace_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operator_name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `trace_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `refunded_at` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
@@ -1175,10 +1267,9 @@ CREATE TABLE `schedule_run_logs` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `schedule_run_logs_task_name_index` (`task_name`),
-  KEY `schedule_run_logs_status_index` (`status`),
   KEY `schedule_run_logs_created_at_index` (`created_at`),
-  KEY `schedule_run_logs_task_name_created_at_index` (`task_name`,`created_at`)
+  KEY `schedule_run_logs_task_name_created_at_index` (`task_name`,`created_at`),
+  KEY `schedule_run_logs_status_created_at_index` (`status`,`created_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=151566 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1187,6 +1278,7 @@ DROP TABLE IF EXISTS `schedule_task_runs`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `schedule_task_runs` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `parent_run_id` bigint unsigned DEFAULT NULL,
   `schedule_tick_id` bigint unsigned DEFAULT NULL,
   `task_key` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `task_name` varchar(160) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1194,12 +1286,15 @@ CREATE TABLE `schedule_task_runs` (
   `source` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'heartbeat',
   `queue` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `status` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'queued',
+  `attempt` smallint unsigned NOT NULL DEFAULT '1',
   `duration_ms` int unsigned DEFAULT NULL,
   `summary` json DEFAULT NULL,
   `error_msg` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `queued_at` timestamp NULL DEFAULT NULL,
   `started_at` timestamp NULL DEFAULT NULL,
   `finished_at` timestamp NULL DEFAULT NULL,
+  `manual_retry_at` timestamp NULL DEFAULT NULL,
+  `manual_retry_by` bigint unsigned DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -1208,7 +1303,8 @@ CREATE TABLE `schedule_task_runs` (
   KEY `schedule_task_runs_status_created_at_index` (`status`,`created_at`),
   KEY `schedule_task_runs_source_created_at_index` (`source`,`created_at`),
   KEY `schedule_task_runs_active_lookup_index` (`task_key`,`status`,`queued_at`),
-  CONSTRAINT `schedule_task_runs_schedule_tick_id_foreign` FOREIGN KEY (`schedule_tick_id`) REFERENCES `schedule_ticks` (`id`) ON DELETE CASCADE
+  KEY `schedule_task_runs_parent_created_at_index` (`parent_run_id`,`created_at`),
+  CONSTRAINT `schedule_task_runs_schedule_tick_id_foreign` FOREIGN KEY (`schedule_tick_id`) REFERENCES `schedule_ticks` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB AUTO_INCREMENT=3359 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1226,7 +1322,8 @@ CREATE TABLE `schedule_ticks` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `schedule_ticks_slot_started_at_unique` (`slot_started_at`),
   UNIQUE KEY `schedule_ticks_global_number_unique` (`global_number`),
-  KEY `schedule_ticks_daily_index_index` (`daily_index`)
+  KEY `schedule_ticks_daily_index_index` (`daily_index`),
+  KEY `schedule_ticks_triggered_at_index` (`triggered_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=281 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1236,10 +1333,10 @@ DROP TABLE IF EXISTS `second_product_groups`;
 CREATE TABLE `second_product_groups` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `first_product_group_id` bigint unsigned NOT NULL COMMENT '→ first_product_groups.id',
-  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '名称',
-  `slug` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'URL标识',
-  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分组说明',
-  `banner_image` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '横幅图',
+  `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '名称',
+  `slug` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'URL标识',
+  `description` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分组说明',
+  `banner_image` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '横幅图',
   `sort_order` int NOT NULL DEFAULT '0' COMMENT '排序',
   `is_visible` tinyint unsigned NOT NULL DEFAULT '1' COMMENT '前台可见',
   `created_at` timestamp NULL DEFAULT NULL,
@@ -1461,6 +1558,7 @@ CREATE TABLE `supplier_plugin_bindings` (
   `provider_key` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `environment` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'production',
   `status` tinyint unsigned NOT NULL DEFAULT '1',
+  `ticket_delivery_enabled` tinyint(1) NOT NULL DEFAULT '0',
   `priority` int NOT NULL DEFAULT '0',
   `base_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `account_name` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1480,6 +1578,7 @@ CREATE TABLE `supplier_plugin_bindings` (
   KEY `supplier_plugin_provider_status_idx` (`provider_key`,`status`),
   KEY `supplier_plugin_plugin_status_idx` (`plugin_id`,`status`),
   KEY `supplier_plugin_backfill_batch_idx` (`backfill_batch_id`),
+  KEY `supplier_binding_ticket_delivery_idx` (`provider_key`,`ticket_delivery_enabled`),
   CONSTRAINT `supplier_plugin_bindings_plugin_id_foreign` FOREIGN KEY (`plugin_id`) REFERENCES `integration_plugins` (`id`) ON DELETE RESTRICT,
   CONSTRAINT `supplier_plugin_bindings_supplier_id_foreign` FOREIGN KEY (`supplier_id`) REFERENCES `suppliers` (`id`) ON DELETE RESTRICT
 ) ENGINE=InnoDB AUTO_INCREMENT=105 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1513,9 +1612,9 @@ DROP TABLE IF EXISTS `third_product_groups`;
 CREATE TABLE `third_product_groups` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `second_product_group_id` bigint unsigned NOT NULL COMMENT '→ second_product_groups.id',
-  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '名称',
-  `slug` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'URL标识',
-  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分组说明',
+  `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '名称',
+  `slug` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'URL标识',
+  `description` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分组说明',
   `sort_order` int NOT NULL DEFAULT '0' COMMENT '排序',
   `is_visible` tinyint unsigned NOT NULL DEFAULT '1' COMMENT '前台可见',
   `created_at` timestamp NULL DEFAULT NULL,
@@ -1527,6 +1626,48 @@ CREATE TABLE `third_product_groups` (
 ) ENGINE=InnoDB AUTO_INCREMENT=53 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+DROP TABLE IF EXISTS `ticket_delivery_rule_products`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `ticket_delivery_rule_products` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `rule_id` bigint unsigned NOT NULL,
+  `product_id` bigint unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ticket_delivery_rule_products_rule_id_product_id_unique` (`rule_id`,`product_id`),
+  KEY `ticket_delivery_rule_products_product_id_foreign` (`product_id`),
+  CONSTRAINT `ticket_delivery_rule_products_product_id_foreign` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `ticket_delivery_rule_products_rule_id_foreign` FOREIGN KEY (`rule_id`) REFERENCES `ticket_delivery_rules` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `ticket_delivery_rules`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `ticket_delivery_rules` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `department` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `supplier_id` bigint unsigned DEFAULT NULL,
+  `provider_key` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `product_scope_mode` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'selected',
+  `upstream_department_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `sync_admin_replies` tinyint(1) NOT NULL DEFAULT '0',
+  `auto_reply_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `auto_reply_content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `mask_keywords` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  `supplier_scope_key` bigint unsigned GENERATED ALWAYS AS (coalesce(`supplier_id`,0)) VIRTUAL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ticket_delivery_rule_scope_unique` (`supplier_scope_key`,`department`,`provider_key`,`product_scope_mode`),
+  KEY `ticket_delivery_rule_match_idx` (`supplier_id`,`department`,`provider_key`,`enabled`),
+  KEY `ticket_delivery_rule_settings_idx` (`supplier_id`,`department`,`provider_key`,`enabled`),
+  CONSTRAINT `ticket_delivery_rules_supplier_id_foreign` FOREIGN KEY (`supplier_id`) REFERENCES `suppliers` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 DROP TABLE IF EXISTS `ticket_replies`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
@@ -1536,6 +1677,9 @@ CREATE TABLE `ticket_replies` (
   `user_id` bigint unsigned NOT NULL,
   `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `is_staff` tinyint NOT NULL DEFAULT '0',
+  `sender_type` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `sender_name` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `is_pre_reply` tinyint unsigned NOT NULL DEFAULT '0',
   `attachments` json DEFAULT NULL,
   `quote_reply_id` bigint unsigned DEFAULT NULL,
   `recalled_at` timestamp NULL DEFAULT NULL,
@@ -1546,6 +1690,93 @@ CREATE TABLE `ticket_replies` (
   CONSTRAINT `fk_stage2_ticket_replies_quote_reply_id` FOREIGN KEY (`quote_reply_id`) REFERENCES `ticket_replies` (`id`) ON DELETE SET NULL,
   CONSTRAINT `fk_ticket_replies_ticket_id` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB AUTO_INCREMENT=172 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `ticket_reply_deliveries`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `ticket_reply_deliveries` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `ticket_reply_id` bigint unsigned NOT NULL,
+  `direction` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content_prefix` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `idempotency_key` varchar(160) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `remote_event_id` varchar(160) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `attempts` int unsigned NOT NULL DEFAULT '0',
+  `last_attempt_at` timestamp NULL DEFAULT NULL,
+  `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `delivered_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ticket_reply_deliveries_ticket_reply_id_unique` (`ticket_reply_id`),
+  UNIQUE KEY `ticket_reply_deliveries_idempotency_key_unique` (`idempotency_key`),
+  UNIQUE KEY `ticket_reply_deliveries_remote_event_id_direction_unique` (`remote_event_id`,`direction`),
+  CONSTRAINT `ticket_reply_deliveries_ticket_reply_id_foreign` FOREIGN KEY (`ticket_reply_id`) REFERENCES `ticket_replies` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `ticket_upstream_bindings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `ticket_upstream_bindings` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `ticket_id` bigint unsigned NOT NULL,
+  `provider_key` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `supplier_id` bigint unsigned DEFAULT NULL,
+  `upstream_department_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `upstream_service_id` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `upstream_ticket_id` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `attempts` int unsigned NOT NULL DEFAULT '0',
+  `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `last_attempt_at` timestamp NULL DEFAULT NULL,
+  `delivered_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ticket_upstream_bindings_ticket_id_unique` (`ticket_id`),
+  UNIQUE KEY `ticket_upstream_bindings_provider_key_upstream_ticket_id_unique` (`provider_key`,`upstream_ticket_id`),
+  KEY `ticket_upstream_lookup_idx` (`upstream_service_id`,`upstream_ticket_id`),
+  CONSTRAINT `ticket_upstream_bindings_ticket_id_foreign` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `ticket_upstream_delivery_logs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `ticket_upstream_delivery_logs` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `ticket_id` bigint unsigned NOT NULL,
+  `ticket_reply_id` bigint unsigned DEFAULT NULL,
+  `binding_id` bigint unsigned DEFAULT NULL,
+  `delivery_id` bigint unsigned DEFAULT NULL,
+  `direction` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'outbound',
+  `operation` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `reason_code` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `provider_key` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `supplier_id` bigint unsigned DEFAULT NULL,
+  `attempt` int unsigned DEFAULT NULL,
+  `http_status` smallint unsigned DEFAULT NULL,
+  `duration_ms` int unsigned DEFAULT NULL,
+  `message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `occurred_at` timestamp NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ticket_upstream_delivery_logs_delivery_id_foreign` (`delivery_id`),
+  KEY `ticket_upstream_log_ticket_time_idx` (`ticket_id`,`occurred_at`),
+  KEY `ticket_upstream_log_binding_time_idx` (`binding_id`,`occurred_at`),
+  KEY `ticket_upstream_log_reply_time_idx` (`ticket_reply_id`,`occurred_at`),
+  KEY `ticket_upstream_log_status_time_idx` (`status`,`occurred_at`),
+  CONSTRAINT `ticket_upstream_delivery_logs_binding_id_foreign` FOREIGN KEY (`binding_id`) REFERENCES `ticket_upstream_bindings` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `ticket_upstream_delivery_logs_delivery_id_foreign` FOREIGN KEY (`delivery_id`) REFERENCES `ticket_reply_deliveries` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `ticket_upstream_delivery_logs_ticket_id_foreign` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `ticket_upstream_delivery_logs_ticket_reply_id_foreign` FOREIGN KEY (`ticket_reply_id`) REFERENCES `ticket_replies` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `tickets`;
@@ -1564,7 +1795,6 @@ CREATE TABLE `tickets` (
   `updated_at` timestamp NULL DEFAULT NULL,
   `close_reason` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'admin, client, auto',
   PRIMARY KEY (`id`),
-  KEY `tickets_user_id_index` (`user_id`),
   KEY `tickets_user_status_updated_at_idx` (`user_id`,`status`,`updated_at`),
   KEY `tickets_status_updated_at_idx` (`status`,`updated_at`),
   KEY `tickets_user_updated_at_idx` (`user_id`,`updated_at`,`id`),
@@ -1604,7 +1834,7 @@ CREATE TABLE `user_coupons` (
   `coupon_id` bigint unsigned NOT NULL,
   `user_id` bigint unsigned NOT NULL,
   `receive_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'claim',
-  `status` tinyint NOT NULL DEFAULT '1',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '优惠券状态：1=持有 2=已使用 3=已回收',
   `claimed_at` timestamp NULL DEFAULT NULL,
   `used_at` timestamp NULL DEFAULT NULL,
   `revoked_at` timestamp NULL DEFAULT NULL,
@@ -1687,6 +1917,7 @@ CREATE TABLE `users` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   `deleted_at` timestamp NULL DEFAULT NULL,
+  `agent_group_id` bigint unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_phone_unique` (`phone`),
   UNIQUE KEY `users_email_unique` (`email`),
@@ -1696,7 +1927,6 @@ CREATE TABLE `users` (
   KEY `users_verification_status_id_idx` (`verification_status`,`id`),
   KEY `users_created_at_idx` (`created_at`),
   KEY `users_verification_certify_id_idx` (`verification_certify_id`),
-  KEY `users_login_email_alert_index` (`login_email_alert`),
   KEY `users_referrer_user_id_index` (`referrer_user_id`),
   KEY `users_member_level_id_index` (`member_level_id`),
   CONSTRAINT `fk_stage2_users_member_level_id` FOREIGN KEY (`member_level_id`) REFERENCES `member_levels` (`id`) ON DELETE SET NULL,
@@ -1903,6 +2133,29 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (173,'2026_07_20_00
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (174,'2026_07_21_000001_add_active_lookup_index_to_schedule_task_runs_table',91);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (175,'2026_07_21_000002_drop_legacy_product_group_mapping_columns',92);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (176,'2026_07_24_000001_add_soft_deletes_to_services_table',93);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (177,'2026_07_27_000001_add_console_template_to_products_table',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (178,'2026_08_01_000001_default_services_auto_renew_to_disabled',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (179,'2026_08_10_000001_add_retry_lineage_to_schedule_task_runs_table',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (180,'2026_08_12_000001_change_schedule_task_runs_tick_foreign_to_null_on_delete',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (181,'2026_08_13_000001_add_payment_voucher_to_referral_withdrawals_table',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (182,'2026_08_13_000002_add_manifest_hash_to_integration_plugins_table',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (183,'2026_08_13_000003_add_index_to_schedule_ticks_triggered_at',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (184,'2026_08_13_234137_cleanup_redundant_database_indexes',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (185,'2026_08_13_234138_add_source_composite_index_to_account_transactions',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (186,'2026_08_13_234138_backfill_status_enum_comments',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (187,'2026_08_14_000001_drop_product_groups_compatibility_table',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (188,'2026_08_20_120000_create_ticket_upstream_delivery_tables',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (189,'2026_08_20_130000_add_ticket_delivery_settings',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (190,'2026_08_20_140000_add_upstream_reply_metadata',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (191,'2026_08_20_150000_add_ticket_delivery_rule_uniqueness',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (192,'2026_08_20_160000_create_ticket_upstream_delivery_logs',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (193,'2026_08_21_000001_make_referral_rewards_order_id_nullable',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (194,'2026_08_22_000001_create_agent_discount_tables',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (195,'2026_08_23_120000_backfill_ticket_delivery_manage_permission',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (196,'2026_08_23_130000_backfill_ticket_pre_reply_manage_permission',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (197,'2026_08_23_140000_add_is_pre_reply_to_ticket_replies',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (198,'2026_08_24_000001_create_api_keys_table',94);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (199,'2026_08_24_000002_create_api_key_usage_logs_table',94);
 
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/backend/tests/Feature/SiteCatalogCacheInvalidationTest.php
+++ b/backend/tests/Feature/SiteCatalogCacheInvalidationTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Services\ProductCatalog\CpuModelCatalogService;
+use App\Services\ProductCatalog\InstanceSpecCatalogService;
+use App\Services\ProductCatalog\SiteCatalogCacheInvalidator;
+use App\Services\Site\SiteHomeService;
+use App\Support\CacheKey;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * 商品目录缓存失效的回归测试。
+ *
+ * 起因：forgetSiteCatalogCache() 曾有三份实现，各漏不同步骤且无任何测试覆盖。
+ * 其中 InstanceSpecCatalogService 不 bump 拆分版本号——而官网目录页全部经
+ * ProductSiteService::rememberSitePayload() 读取、键里嵌着版本号，
+ * 于是改完实例规格后官网要等 600-900 秒 TTL 才更新。
+ *
+ * 这几条断言锁的就是「每个目录写入口都必须真正让目录缓存失效」，
+ * 任何一处再退化成漏步骤的实现都会在这里失败。
+ */
+class SiteCatalogCacheInvalidationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+        app('db')->setDefaultConnection('sqlite');
+
+        Schema::connection('sqlite')->create('settings', function (Blueprint $table): void {
+            $table->id();
+            $table->string('group_key', 100);
+            $table->string('item_key', 100);
+            $table->text('item_value')->nullable();
+            $table->unique(['group_key', 'item_key'], 'settings_group_item_unique');
+        });
+
+        Cache::flush();
+    }
+
+    private function invalidator(): SiteCatalogCacheInvalidator
+    {
+        return app(SiteCatalogCacheInvalidator::class);
+    }
+
+    /** 往两个非版本化的目录键里塞值，返回失效前的版本号。 */
+    private function seedCatalogCaches(): int
+    {
+        Cache::put(CacheKey::adminCatalogSummary(), ['products_total' => 1], now()->addHour());
+        Cache::put(CacheKey::siteCatalog(), ['stale'], now()->addHour());
+
+        return $this->invalidator()->currentVersion();
+    }
+
+    private function assertCatalogCachesInvalidated(int $versionBefore): void
+    {
+        // 版本号放第一条：它是唯一会让线上显示旧数据的那步，
+        // 断言失败时希望直接看到它，而不是被前面的键断言挡住。
+        $this->assertSame(
+            $versionBefore + 1,
+            $this->invalidator()->currentVersion(),
+            '目录拆分版本号未递增——官网目录页会继续读旧键直到 600-900 秒 TTL 过期'
+        );
+        $this->assertNull(
+            Cache::get(CacheKey::adminCatalogSummary()),
+            '管理端目录概览缓存未失效'
+        );
+        $this->assertNull(
+            Cache::get(CacheKey::siteCatalog()),
+            '站点目录缓存未失效'
+        );
+    }
+
+    public function test_flush_forgets_catalog_keys_and_bumps_version(): void
+    {
+        $versionBefore = $this->seedCatalogCaches();
+
+        $this->invalidator()->flush();
+
+        $this->assertCatalogCachesInvalidated($versionBefore);
+    }
+
+    public function test_versioned_key_follows_current_version(): void
+    {
+        $before = $this->invalidator()->versionedKey('catalog:site:products');
+
+        $this->invalidator()->flush();
+
+        $after = $this->invalidator()->versionedKey('catalog:site:products');
+
+        $this->assertNotSame($before, $after, '版本号递增后拼出的键必须改变，否则旧缓存仍会命中');
+        $this->assertStringStartsWith('catalog:site:products:v', $after);
+    }
+
+    public function test_saving_instance_spec_catalog_invalidates_site_catalog(): void
+    {
+        $versionBefore = $this->seedCatalogCaches();
+
+        app(InstanceSpecCatalogService::class)->saveCatalog([
+            ['text' => '2C4G', 'status' => '仅文本'],
+        ]);
+
+        $this->assertCatalogCachesInvalidated($versionBefore);
+    }
+
+    public function test_saving_cpu_model_catalog_invalidates_site_catalog(): void
+    {
+        $versionBefore = $this->seedCatalogCaches();
+
+        app(CpuModelCatalogService::class)->saveCatalog([
+            ['name' => 'Intel Xeon', 'models' => []],
+        ]);
+
+        $this->assertCatalogCachesInvalidated($versionBefore);
+    }
+
+    public function test_home_overview_cache_key_changes_when_catalog_changes(): void
+    {
+        // 首页聚合 payload 里含商品数据，键上却只有文章发布版本号——
+        // 改商品时首页曾会继续返回旧值直到 600 秒 TTL 过期。
+        $before = SiteHomeService::overviewCacheKey(0, 50, 4);
+
+        $this->invalidator()->flush();
+
+        $this->assertNotSame(
+            $before,
+            SiteHomeService::overviewCacheKey(0, 50, 4),
+            '目录变更后首页聚合缓存键必须改变，否则首页仍展示旧商品'
+        );
+    }
+}

--- a/frontend-admin-v3/src/constants/permissions.ts
+++ b/frontend-admin-v3/src/constants/permissions.ts
@@ -38,6 +38,7 @@ export const AdminPermissions = {
   INTEGRATION_PLUGIN_SECRET_REVEAL: 'integration_plugin.secret_reveal',
   SCHEDULE_VIEW: 'schedule.view',
   SCHEDULE_TRIGGER: 'schedule.trigger',
+  SCHEDULE_RETRY: 'schedule.retry',
   SITE_VIEW: 'site.view',
   SITE_MANAGE: 'site.manage',
   LOG_LIST: 'log.list',
@@ -96,7 +97,10 @@ export const VISITOR_PERMISSION_CODES = [
   AdminPermissions.REFERRAL_WITHDRAWAL_LIST,
   AdminPermissions.FINANCE_REPORT,
   AdminPermissions.MEMBER_LEVEL_LIST,
-  AdminPermissions.AGENT_DISCOUNT_LIST,
+  // 这里曾多给访客一条 AGENT_DISCOUNT_LIST，后端 AdminPermissions::visitorPermissions() 没有它。
+  // 结果是访客能看到代理折扣菜单，点进去三条 GET（agent-groups / product-discount-groups /
+  // agent-group-discounts）一律 403。以后端为准删掉；普通管理员不受影响——
+  // 它的 AGENT_DISCOUNT_MANAGE 本就隐含 AGENT_DISCOUNT_LIST。
   AdminPermissions.CONTENT_LIST,
   AdminPermissions.STAFF_LIST,
   AdminPermissions.ROLE_LIST,
@@ -156,6 +160,7 @@ export function impliedPermissions(permission: string): string[] {
     case AdminPermissions.INTEGRATION_PLUGIN_TEST:
       return [AdminPermissions.INTEGRATION_PLUGIN_VIEW];
     case AdminPermissions.SCHEDULE_TRIGGER:
+    case AdminPermissions.SCHEDULE_RETRY:
       return [AdminPermissions.SCHEDULE_VIEW];
     case AdminPermissions.SITE_MANAGE:
       return [AdminPermissions.SITE_VIEW];

--- a/frontend-admin-v3/src/pages/users/detail/index.vue
+++ b/frontend-admin-v3/src/pages/users/detail/index.vue
@@ -1153,7 +1153,9 @@ const notices = reactive<PageState>({
 });
 
 const editRules: Record<string, FormRule[]> = {
-  password: [{ validator: (val) => !val || String(val).length >= 6, message: '密码至少需要 6 位', type: 'warning' }],
+  // 后端 UpdateUserRequest 是 ['nullable','string','min:8']。此前写 6 且是 warning——
+  // 既放行 6-7 位（必然 422），warning 也不阻断提交。改为与后端同口径的 error。
+  password: [{ validator: (val) => !val || String(val).length >= 8, message: '密码至少需要 8 位', type: 'error' }],
 };
 const rechargeRules: Record<string, FormRule[]> = {
   amount: [required('请输入金额')],

--- a/frontend-admin-v3/src/pages/users/index.vue
+++ b/frontend-admin-v3/src/pages/users/index.vue
@@ -210,7 +210,9 @@ const createForm = reactive({ email: '', nickname: '', phone: '', password: '' }
 const createRules: Record<string, FormRule[]> = {
   email: [required('请输入有效邮箱'), { email: true, message: '请输入有效邮箱', type: 'warning' }],
   phone: [required('请输入手机号')],
-  password: [required('请输入密码')],
+  // 后端 StoreUserRequest 是 ['required','string','min:8']；此前只判必填，
+  // 管理员输 3 位也能提交，直到 422 才知道。
+  password: [required('请输入密码'), { min: 8, message: '密码至少需要 8 位', type: 'error' }],
 };
 
 async function loadList() {

--- a/frontend-user-v4-console/src/composables/useGeeTestCaptcha.ts
+++ b/frontend-user-v4-console/src/composables/useGeeTestCaptcha.ts
@@ -94,7 +94,7 @@ async function getCaptchaConfig() {
       .catch(() => {
         // 失败绝不能留缓存。captchaConfigPromise 是模块级单例，一旦把 defaultConfig
         // （enabled: false）固化进去，本页此后永久不唤起验证码，而后端 requiresCaptcha
-        // 仍返回 true 并以 42210 / captcha_required 拒绝提交——用户提交必然失败，
+        // 仍返回 true 并以 42220 / captcha_required 拒绝提交——用户提交必然失败，
         // 且 reinit() 复用同一个已缓存 promise 也无法自恢复，只能整页刷新。
         // 清掉缓存后本次调用仍降级为 defaultConfig（不阻塞 UI），但下次会重新拉取。
         if (captchaConfigPromise === pending) {

--- a/frontend-user-v4-console/src/domains/account/useProfile.ts
+++ b/frontend-user-v4-console/src/domains/account/useProfile.ts
@@ -218,6 +218,11 @@ export function useProfile() {
       MessagePlugin.warning('请输入新密码');
       return;
     }
+    // 这里此前只判空。后端 ResetPasswordRequest 是 min:8，短密码会一路发出去再被 422 打回。
+    if (resetForm.password.length < 8) {
+      MessagePlugin.warning('密码长度不能少于 8 位');
+      return;
+    }
     if (resetForm.password !== resetForm.confirmPassword) {
       MessagePlugin.warning('两次密码输入不一致');
       return;

--- a/frontend-user-v4-console/src/pages/client-auth/forgot-password.vue
+++ b/frontend-user-v4-console/src/pages/client-auth/forgot-password.vue
@@ -49,7 +49,7 @@
             :type="showPassword ? 'text' : 'password'"
             clearable
             autocomplete="new-password"
-            placeholder="请输入至少 6 位新密码"
+            placeholder="请输入至少 8 位新密码"
           >
             <template #prefix-icon><lock-on-icon /></template>
             <template #suffix-icon>
@@ -178,7 +178,8 @@ const rules: Record<keyof ResetPasswordForm, FormRule[]> = {
   ],
   password: [
     { required: true, message: '请输入新密码', type: 'error', trigger: 'blur' },
-    { min: 6, message: '密码长度不能少于 6 位', type: 'error', trigger: 'blur' },
+    // 与后端 ResetPasswordRequest 的 min:8 对齐。
+    { min: 8, message: '密码长度不能少于 8 位', type: 'error', trigger: 'blur' },
   ],
   password_confirmation: [
     { required: true, message: '请再次输入新密码', type: 'error', trigger: 'blur' },
@@ -281,8 +282,8 @@ function validateForm() {
   }
   if (!form.password) {
     errors.password = '请输入新密码';
-  } else if (form.password.length < 6) {
-    errors.password = '密码长度不能少于 6 位';
+  } else if (form.password.length < 8) {
+    errors.password = '密码长度不能少于 8 位';
   }
   if (!form.password_confirmation) {
     errors.password_confirmation = '请再次输入新密码';

--- a/frontend-user-v4-console/src/pages/client-auth/register.vue
+++ b/frontend-user-v4-console/src/pages/client-auth/register.vue
@@ -77,7 +77,7 @@
             :type="showPassword ? 'text' : 'password'"
             clearable
             autocomplete="new-password"
-            placeholder="请输入至少 6 位密码"
+            placeholder="请输入至少 8 位密码"
           >
             <template #prefix-icon><lock-on-icon /></template>
             <template #suffix-icon>
@@ -216,7 +216,8 @@ const rules: Record<keyof RegisterForm, FormRule[]> = {
   referral_code: [{ max: 24, message: '推荐码不能超过 24 个字符', type: 'error', trigger: 'blur' }],
   password: [
     { required: true, message: '请输入登录密码', type: 'error', trigger: 'blur' },
-    { min: 6, message: '密码长度不能少于 6 位', type: 'error', trigger: 'blur' },
+    // 与后端 RegisterRequest 的 min:8 对齐；写 6 会让用户输 6-7 位时前端放行、后端 422。
+    { min: 8, message: '密码长度不能少于 8 位', type: 'error', trigger: 'blur' },
   ],
   password_confirmation: [
     { required: true, message: '请再次输入密码', type: 'error', trigger: 'blur' },
@@ -327,8 +328,8 @@ function validateForm() {
   }
   if (!form.password) {
     errors.password = '请输入登录密码';
-  } else if (form.password.length < 6) {
-    errors.password = '密码长度不能少于 6 位';
+  } else if (form.password.length < 8) {
+    errors.password = '密码长度不能少于 8 位';
   }
   if (!form.password_confirmation) {
     errors.password_confirmation = '请再次输入密码';

--- a/frontend-user-v4-console/src/pages/client/profile/index.vue
+++ b/frontend-user-v4-console/src/pages/client/profile/index.vue
@@ -151,7 +151,7 @@
           </div>
         </t-form-item>
         <t-form-item label="新密码"
-          ><t-input v-model="resetForm.password" type="password" placeholder="至少 6 位"
+          ><t-input v-model="resetForm.password" type="password" placeholder="至少 8 位"
         /></t-form-item>
         <t-form-item label="确认密码"><t-input v-model="resetForm.confirmPassword" type="password" /></t-form-item>
         <t-button variant="text" theme="primary" class="password-forgot" @click="togglePasswordMode"


### PR DESCRIPTION
## 变更内容

两个独立提交，互不依赖：**① schema 基线重导**（单文件）；**② 三端状态文案/校验口径对齐与商品目录缓存失效收敛**（#36 合入后按约定提交的下一批修复）。

---

## 提交一：重导 `mysql-schema.sql` 基线

基线上次导出于 `513c646`（2026-08-16），且该提交自身就带入了 11 条未入基线的迁移——漂移从导出当天就已存在，此后累计落后 **23 条迁移**：

- 空库导入基线得 **62** 张表，需再跑 23 条增量迁移才到 **72** 张；
- 整体缺 **10 张表**：`agent_groups`、`agent_group_discounts`、`product_discount_groups`、`api_keys`、`api_key_usage_logs`、`ticket_delivery_rules`、`ticket_delivery_rule_products`、`ticket_reply_deliveries`、`ticket_upstream_bindings`、`ticket_upstream_delivery_logs`，外加若干列（含 `integration_plugins.manifest_hash`）。

安装流程本身不受影响（`InstallService` 是「空库导基线 → 无条件跑增量迁移」两段式），但漂移持续扩大，且在 #36 评审中被指出（评审建议之一即独立重导）。#36 已合入且不含迁移，本基线对当前 main（`6ecc3a7`）依然精确。

**导出方式**：与线上同构环境（MySQL 8.0，`utf8mb4_unicode_ci`）上以「旧基线 + 全部 23 条迁移」构建纯净库，用仓库自带 `scripts/export_schema_baseline.php` 导出，取第二代（定点）结果——gen2 与 gen3 逐字节一致，与既有基线文件风格相同；旧基线中混杂的 36 行「仅 COLLATE」列亦随之归一。今后同构环境重导可复现逐字节一致的文件。

| 验证项 | 方法 | 结果 |
|---|---|---|
| 语义等价 | 「新基线独立成库」vs「旧基线+23 迁移」两库 `information_schema` 快照逐行 diff | 列（1003 行）/ 索引（550 行）/ 表排序规则（72 行）三份**完全一致** |
| 数据等价 | 两路径全量 `mysqldump` 对比 | INSERT 行**零差异**（涉写的 5 条迁移均只动存量数据，空库为 no-op） |
| 排序规则守卫 | grep 导出文件 | `utf8mb4_0900_ai_ci` **0** 次、`utf8mb4_unicode_ci` 458 处 |
| 迁移记录 | 新基线成库后 `migrate:status` | 197 条一一对应，**pending = 0**，`manifest_hash` 列随建表语句就位 |
| 导出定点 | 成库→再导→对比 | 逐字节一致 |
| 全量套件 | 新基线成库跑完整 PHPUnit | 失败集合与 main 基线完全一致，**新增 0** |

> 检查清单特殊说明：常规约定是「数据库变更走新增 migration、不改基线」；本提交恰是针对基线本身的维护性重导（#36 评审建议落地），未新增/修改任何迁移文件。

---

## 提交二：状态文案 / 校验口径 / 权限清单 / 缓存失效

### 实名状态 5 文案漂移
后端 `VERIFICATION_STATUS_LABELS` 写「已解绑」，前端两处写「已驳回」，看似两个业务事件实为一个：`VerificationService::unbind()` 是唯一写入点（仅管理员、前置条件已认证、落库驳回原因）。「解绑」是对数据的效果，「驳回」是管理员的动作；该标签只被 5 个 Admin/V2 Resource 输出、读者即操作员，且管理端整条流程与 `shared/statusConfig.js` 都叫「驳回」——后端对齐为「已驳回」。`unbind` 保留为 API 与权限标识符。

### 错误码 42210 撞车
验证码失败与 `ReferralService` 退款拦截共用 42210，语义完全不同；未出事只因前端判断的是 `captcha_required` 布尔字段。让码的是验证码侧：42210–42212 是 Referral 连续具名码段，42211/42212 的码号还写进了管理员可见文案。新增 `CaptchaPolicyService::VERIFY_FAILED_ERROR_CODE = 42220`，替换两处控制器裸字面量（前端确认无按码值分支）。

### 密码长度前后端不一致
后端「设置新密码」路径一律 `min:8`（登录/校验用的 `min:6` 是容纳存量老密码，保持不动），前端 7 处仍写 6 或不校验——用户输 6–7 位必然 422。全部对齐到 8（共 8 处，含评审补充发现的 `useProfile.changePassword` 分支——修改登录密码入口此前同样只判空）；管理端用户编辑的校验改按 trim 后长度，与 `handleSave` 的提交口径一致（评审发现）。

### 权限清单缺口（后端 61 vs 前端 60）
前端缺 `schedule.retry`（后端有路由与 implied 映射），且访客集多了一条 `agent_discount.list`——后端 `visitorPermissions()` 没有它，访客看得到菜单、三条 GET 全 403。以后端为准补齐/删除；改后 61/61 常量、25/25 访客集、23/23 implied 全对齐。

### 管理端 dev 模式编译修复（处理评审 E2E 建议时发现的阻断项）
`Content.vue` 的 `keep-alive` 内有注释节点，dev 编译保留注释会报「`<KeepAlive>` expects exactly one child component」——**整个管理端 dev 模式与全部既有 Playwright e2e 此前无法运行**（生产构建剥离注释所以 `build` 一直是绿的）。注释移出 keep-alive；修复后既有 `agent-discounts.spec.ts` 5 条实测恢复通过。并按评审建议新增 `users-create-password.spec.ts` 两条（7 位密码拦下且零请求 / 8 位放行并原样提交），沿用仓库 route-mock 约定。

### 商品目录缓存失效三份实现（唯一确认会让线上展示旧数据的缺陷）
`forgetSiteCatalogCache()` 有三份实现，各漏不同步骤。真正的失效机制是 **bump 拆分版本号**（官网目录页全部经 `ProductSiteService::rememberSitePayload()` 读取，键里嵌版本号），而：
- `InstanceSpecCatalogService` 恰恰不 bump——改完实例规格官网要等 600–900 秒 TTL；它清的 `catalog:site:instance_spec:v1` 全仓无任何写入方，是空操作；
- `CpuModelCatalogService` 漏掉管理端目录概览失效;
- trait 里的 `Cache::tags(['site:home','site:products'])->flush()` 也是空操作——全仓（含 `plugins/`）没有一处用 tags 写缓存；它想清的 `site:home:*` 是普通键，且该 payload 含商品数据、键上版本号却是文章发布版本——**改任何商品首页都会陈旧 600 秒**，影响全部 5 个目录服务。

收敛为 `SiteCatalogCacheInvalidator` 唯一入口（三处全部委托），`catalog:admin_summary:v1` / `catalog:site:v1` 收敛到 `CacheKey` 唯一定义点；`SiteHomeService::overviewCacheKey()` 把目录版本号编进首页缓存键（写入方与失效方共用同一构造器），让 tag flush 的意图真正生效。

`flush()` 整体注册为 `DB::afterCommit` 回调（评审发现）：多数调用方在 `DB::transaction()` 内触发失效，若提交前就 bump 版本号，并发请求会用新版本键缓存住提交前的旧目录，提交后再无第二次失效。afterCommit 语义已实测：无事务立即执行、提交后执行、回滚丢弃。

新增 `SiteCatalogCacheInvalidationTest`（7 条）：5 条失效断言（**负控已验证**：还原任一旧实现即失败于「目录拆分版本号未递增」）+ 2 条事务语义断言（提交前不失效、回滚后作废）。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [x] 其他（请说明）：schema 基线维护性重导

## 检查清单

- [x] 已阅读 CONTRIBUTING.md
- [x] 已运行相关 lint 与静态检查
- [x] 提交二不含数据库变更；提交一为基线维护性重导（见上方特殊说明），未新增/修改任何迁移文件
- [x] 未提交任何敏感信息（密钥、`.env`、真实域名等）

## 测试说明

全部在与线上同构的服务器环境实测（每轮全新空库），基点为当前 main `6ecc3a7`，head `523e287`：

| 检查项 | 结果 |
|---|---|
| 全量净库回归 | 纯净 main **78** 条失败 → 带本 PR **78 条完全同一集合**（1622 tests），引入回归 **0** |
| PHPStan | 纯净 main **16** errors → 带本 PR **16**，零新增 |
| Pint / php -l | 涉及的 14 个 PHP 文件全 PASS |
| 新增缓存失效测试 | 7/7 通过（负控与事务语义均实测） |
| Playwright e2e | 既有 `agent-discounts` 5 条恢复通过 + 新增 2 条通过 |
| `vue-tsc`（admin-v3 + user-v4-console） | RC=0 |
| eslint（各包配置）+ prettier | 全部改动文件无告警 |

基线重导部分的六组验证（语义等价 / 数据等价 / 排序规则 / 迁移记录 / 导出定点 / 全量套件）见上文表格；#36 合入后 main 无新增迁移，基线对 `6ecc3a7` 依然精确，且对象级 diff 确认：**表移除 0、列移除 0**（13 条索引行消失系上游已合并迁移早已删除、生产库逐一核实同样不存在）。
