### PR TITLE
fix: 落地 #37 评审意见——缓存失效事务语义、密码校验补漏与管理端 dev 修复

### DIFF
--- a/backend/app/Services/ProductCatalog/SiteCatalogCacheInvalidator.php
+++ b/backend/app/Services/ProductCatalog/SiteCatalogCacheInvalidator.php
@@ -6,6 +6,7 @@ namespace App\Services\ProductCatalog;
 
 use App\Support\CacheKey;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 /**
  * 商品目录缓存的唯一失效入口。
@@ -54,17 +55,24 @@ final class SiteCatalogCacheInvalidator
 
     /**
      * 失效全部商品目录缓存。任何改动商品、分组、CPU 型号、实例规格、规格亮点的写操作都应调用它。
+     *
+     * 整体注册为 afterCommit 回调：多数调用方（如 ProductCategoryService）在 DB::transaction()
+     * 内触发失效。若在事务提交前就 bump 版本号，并发请求会用新版本键缓存住提交前的旧目录，
+     * 提交后不再有第二次失效，旧数据要挂满整个 TTL。afterCommit 的语义（Laravel 实测）：
+     * 无事务立即执行、事务提交后执行、事务回滚则丢弃——三种场景都是想要的行为。
      */
     public function flush(): void
     {
-        Cache::forget(CacheKey::adminCatalogSummary());
-        Cache::forget(CacheKey::siteCatalog());
+        DB::afterCommit(function (): void {
+            Cache::forget(CacheKey::adminCatalogSummary());
+            Cache::forget(CacheKey::siteCatalog());
 
-        // ProductDisplayNameResolver 是容器 singleton，其显示名与规格文案缓存是进程内长命的。
-        // 不刷的话长驻进程（队列 Worker、Octane）会继续返回旧值。
-        app(ProductDisplayNameResolver::class)->flushCaches();
+            // ProductDisplayNameResolver 是容器 singleton，其显示名与规格文案缓存是进程内长命的。
+            // 不刷的话长驻进程（队列 Worker、Octane）会继续返回旧值。
+            app(ProductDisplayNameResolver::class)->flushCaches();
 
-        // 放在最后：上面几步读到的都是旧版本下的键，bump 之后新请求一律落到新键。
-        Cache::put(CacheKey::siteCatalogSplitVersion(), $this->currentVersion() + 1, now()->addYear());
+            // 放在最后：上面几步读到的都是旧版本下的键，bump 之后新请求一律落到新键。
+            Cache::put(CacheKey::siteCatalogSplitVersion(), $this->currentVersion() + 1, now()->addYear());
+        });
     }
 }

--- a/backend/tests/Feature/SiteCatalogCacheInvalidationTest.php
+++ b/backend/tests/Feature/SiteCatalogCacheInvalidationTest.php
@@ -130,6 +130,42 @@ class SiteCatalogCacheInvalidationTest extends TestCase
         $this->assertCatalogCachesInvalidated($versionBefore);
     }
 
+    public function test_flush_inside_transaction_defers_until_commit(): void
+    {
+        // ProductCategoryService 等调用方在 DB::transaction() 内触发失效。
+        // 若提交前就 bump 版本号，并发请求会用新版本键缓存住提交前的旧目录，
+        // 提交后不再有第二次失效——旧数据要挂满整个 TTL。
+        $versionBefore = $this->seedCatalogCaches();
+
+        DB::beginTransaction();
+        $this->invalidator()->flush();
+
+        $this->assertSame(
+            $versionBefore,
+            $this->invalidator()->currentVersion(),
+            '事务提交前版本号不应递增'
+        );
+        $this->assertNotNull(Cache::get(CacheKey::siteCatalog()), '事务提交前站点目录缓存不应被清除');
+
+        DB::commit();
+
+        $this->assertCatalogCachesInvalidated($versionBefore);
+    }
+
+    public function test_flush_inside_rolled_back_transaction_is_discarded(): void
+    {
+        // 回滚意味着数据没变，失效也应一并作废；否则每次失败的写操作都会白白打穿缓存。
+        $versionBefore = $this->seedCatalogCaches();
+
+        DB::beginTransaction();
+        $this->invalidator()->flush();
+        DB::rollBack();
+
+        $this->assertSame($versionBefore, $this->invalidator()->currentVersion(), '回滚后版本号不应递增');
+        $this->assertNotNull(Cache::get(CacheKey::adminCatalogSummary()), '回滚后缓存不应被清除');
+        $this->assertNotNull(Cache::get(CacheKey::siteCatalog()));
+    }
+
     public function test_home_overview_cache_key_changes_when_catalog_changes(): void
     {
         // 首页聚合 payload 里含商品数据，键上却只有文章发布版本号——

--- a/frontend-admin-v3/src/layouts/components/Content.vue
+++ b/frontend-admin-v3/src/layouts/components/Content.vue
@@ -2,9 +2,12 @@
   <div v-if="!isRefreshing">
     <router-view v-if="!isFramePage" v-slot="{ Component }">
       <transition name="fade" mode="out-in">
+        <!-- key 用 fullPath：同组件多路由（如商品/流量包/上游共用 products/index.vue）
+             各自独立缓存；同一路由不同 query 也各自保留状态。
+             注释必须放在 keep-alive 外：dev 编译保留注释节点，会触发
+             「<KeepAlive> expects exactly one child component」编译错误，
+             整个管理端 dev 模式与全部 e2e 因此无法运行（生产构建剥离注释所以 build 一直是绿的）。 -->
         <keep-alive :include="aliveViews">
-          <!-- key 用 fullPath：同组件多路由（如商品/流量包/上游共用 products/index.vue）
-               各自独立缓存；同一路由不同 query 也各自保留状态 -->
           <component :is="Component" :key="route.fullPath" />
         </keep-alive>
       </transition>

--- a/frontend-admin-v3/src/pages/users/detail/index.vue
+++ b/frontend-admin-v3/src/pages/users/detail/index.vue
@@ -1155,7 +1155,15 @@ const notices = reactive<PageState>({
 const editRules: Record<string, FormRule[]> = {
   // 后端 UpdateUserRequest 是 ['nullable','string','min:8']。此前写 6 且是 warning——
   // 既放行 6-7 位（必然 422），warning 也不阻断提交。改为与后端同口径的 error。
-  password: [{ validator: (val) => !val || String(val).length >= 8, message: '密码至少需要 8 位', type: 'error' }],
+  // 按 trim 后长度校验：handleSave 提交的是 editForm.password.trim()，
+  // 若按原始长度校验，" 1234567 " 这类值会在前端放行、到后端才 422。
+  password: [
+    {
+      validator: (val) => !String(val ?? '').trim() || String(val).trim().length >= 8,
+      message: '密码至少需要 8 位',
+      type: 'error',
+    },
+  ],
 };
 const rechargeRules: Record<string, FormRule[]> = {
   amount: [required('请输入金额')],

--- a/frontend-admin-v3/tests/e2e/users-create-password.spec.ts
+++ b/frontend-admin-v3/tests/e2e/users-create-password.spec.ts
@@ -1,0 +1,90 @@
+import type { Page, Route } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+const USER_ROW = {
+  id: 1,
+  email: 'existing@example.com',
+  phone: '13800000000',
+  nickname: '既有用户',
+  display_name: '既有用户',
+  status: 1,
+  cash_balance: '0.00',
+  opened_product_count: 0,
+  verification_status: 0,
+  is_verified: 0,
+  created_at: '2026-08-20 10:00:00',
+};
+
+// 装配用户列表页的接口桩；onCreate 捕获创建请求体，用来断言「拦下时不发请求」。
+async function mockAdminApi(page: Page, options: { onCreate?: (body: unknown) => void } = {}) {
+  const { onCreate } = options;
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem('admin_token', 'users-create-test-token');
+    window.localStorage.setItem('admin_last_active_at', String(Date.now()));
+  });
+
+  await page.route('**/api/v2/admin/**', async (route: Route) => {
+    const url = new URL(route.request().url());
+    const method = route.request().method();
+    const respond = (data: unknown) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ code: 0, data }) });
+
+    if (url.pathname.endsWith('/auth/info')) {
+      return respond({ admin: { id: 1, username: 'users-test', nickname: 'users-test', permissions: ['*'] } });
+    }
+    if (url.pathname.endsWith('/users') && method === 'GET') {
+      return respond({ list: [USER_ROW], total: 1, page: 1, page_size: 20 });
+    }
+    if (url.pathname.endsWith('/users') && method === 'POST') {
+      onCreate?.(route.request().postDataJSON());
+      return respond({ id: 2 });
+    }
+
+    return respond({});
+  });
+}
+
+async function openCreateDialog(page: Page) {
+  await page.goto('/admin/users', { waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: '新增用户' }).click();
+  const dialog = page.locator('.t-dialog').filter({ hasText: '新增用户' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+function fieldInput(dialog: ReturnType<Page['locator']>, label: string) {
+  return dialog.locator('.t-form__item', { hasText: label }).locator('input');
+}
+
+// 后端 StoreUserRequest 是 ['required','string','min:8']；此前前端只判必填，
+// 7 位密码要等 422 才被发现。这两条锁住「前端拦截口径 == 后端口径」。
+test('新增用户：7 位密码被前端拦下且不调用创建接口', async ({ page }) => {
+  let createCalls = 0;
+  await mockAdminApi(page, { onCreate: () => (createCalls += 1) });
+  const dialog = await openCreateDialog(page);
+
+  await fieldInput(dialog, '邮箱').fill('new-user@example.com');
+  await fieldInput(dialog, '手机号').fill('13900000000');
+  await fieldInput(dialog, '密码').fill('1234567');
+  await dialog.getByRole('button', { name: '确定' }).click();
+
+  await expect(dialog.locator('.t-form__item', { hasText: '密码' })).toContainText('密码至少需要 8 位');
+  await expect(dialog).toBeVisible();
+  expect(createCalls).toBe(0);
+});
+
+test('新增用户：8 位密码放行并原样提交', async ({ page }) => {
+  const payloads: unknown[] = [];
+  await mockAdminApi(page, { onCreate: (body) => payloads.push(body) });
+  const dialog = await openCreateDialog(page);
+
+  await fieldInput(dialog, '邮箱').fill('new-user@example.com');
+  await fieldInput(dialog, '手机号').fill('13900000000');
+  await fieldInput(dialog, '密码').fill('12345678');
+  await dialog.getByRole('button', { name: '确定' }).click();
+
+  await expect(page.locator('.t-message').filter({ hasText: '创建成功' })).toBeVisible();
+  expect(payloads).toHaveLength(1);
+  expect(payloads[0]).toMatchObject({ email: 'new-user@example.com', password: '12345678' });
+});

--- a/frontend-user-v4-console/playwright.local-reuse.config.ts
+++ b/frontend-user-v4-console/playwright.local-reuse.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  outputDir: process.env.TEMP ? `${process.env.TEMP}/turaidc-playwright-results` : './test-results',
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:5177',
+    trace: 'off',
+    screenshot: 'off',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
+    },
+  ],
+});

--- a/frontend-user-v4-console/src/domains/account/useProfile.ts
+++ b/frontend-user-v4-console/src/domains/account/useProfile.ts
@@ -485,6 +485,11 @@ export function useProfile() {
       MessagePlugin.warning('请填写完整密码信息');
       return;
     }
+    // 与 submitResetPassword 同口径：后端 UpdatePasswordRequest 的 newPassword 是 min:8。
+    if (passwordForm.newPassword.length < 8) {
+      MessagePlugin.warning('新密码长度不能少于 8 位');
+      return;
+    }
     if (passwordForm.newPassword !== passwordForm.confirmPassword) {
       MessagePlugin.warning('两次密码输入不一致');
       return;

--- a/frontend-user-v4-console/src/pages/client/profile/index.vue
+++ b/frontend-user-v4-console/src/pages/client/profile/index.vue
@@ -126,7 +126,9 @@
     >
       <t-form v-if="passwordMode === 'old'" label-align="top">
         <t-form-item label="原密码"><t-input v-model="passwordForm.oldPassword" type="password" /></t-form-item>
-        <t-form-item label="新密码"><t-input v-model="passwordForm.newPassword" type="password" /></t-form-item>
+        <t-form-item label="新密码"
+          ><t-input v-model="passwordForm.newPassword" type="password" placeholder="至少 8 位"
+        /></t-form-item>
         <t-form-item label="确认密码"><t-input v-model="passwordForm.confirmPassword" type="password" /></t-form-item>
         <t-button variant="text" theme="primary" class="password-forgot" @click="togglePasswordMode"
           >忘记原密码？</t-button

--- a/frontend-user-v4-console/tests/e2e/profile-change-password.spec.ts
+++ b/frontend-user-v4-console/tests/e2e/profile-change-password.spec.ts
@@ -1,0 +1,94 @@
+import type { Page, Route } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+const USER_INFO = {
+  id: 1,
+  name: 'e2e用户',
+  nickname: 'e2e用户',
+  email: 'e2e@example.com',
+  phone: '13800000000',
+  cash_balance: '0.00',
+  is_verified: 0,
+  created_at: '2026-08-20 10:00:00',
+};
+
+// 装配个人资料页的接口桩；onChangePassword 捕获 PUT /v2/client/password 的请求体，
+// 用来断言「本地校验拦下时不发请求」。token 走 shared session driver 的
+// localStorage 迁移路径（读到后回写 Cookie），与 admin 端 e2e 同一惯例。
+async function mockClientApi(page: Page, options: { onChangePassword?: (body: unknown) => void } = {}) {
+  const { onChangePassword } = options;
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem('client_token', 'profile-password-test-token');
+    window.localStorage.setItem('client_last_active_at', String(Date.now()));
+  });
+
+  await page.route('**/api/v2/client/**', async (route: Route) => {
+    const url = new URL(route.request().url());
+    const method = route.request().method();
+    const respond = (data: unknown) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ code: 0, data }) });
+
+    if (url.pathname.endsWith('/auth/info')) {
+      return respond(USER_INFO);
+    }
+    if (url.pathname.endsWith('/auth/notification-preferences')) {
+      return respond({});
+    }
+    if (url.pathname.endsWith('/password') && method === 'PUT') {
+      onChangePassword?.(route.request().postDataJSON());
+      return respond({});
+    }
+
+    return respond({});
+  });
+}
+
+async function openChangePasswordDialog(page: Page) {
+  await page.goto('/client/profile', { waitUntil: 'domcontentloaded' });
+  await page.locator('.t-menu__item', { hasText: '账户安全' }).click();
+  await page.locator('.security-item', { hasText: '登录密码' }).getByRole('button', { name: '修改密码' }).click();
+  const dialog = page.locator('.t-dialog').filter({ hasText: '修改登录密码' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+function fieldInput(dialog: ReturnType<Page['locator']>, label: string) {
+  return dialog.locator('.t-form__item', { hasText: label }).locator('input');
+}
+
+// 后端 UpdatePasswordRequest 的 newPassword 是 min:8；changePassword 分支此前只判空，
+// 6-7 位要等 422 才被发现。这两条锁住「修改登录密码」入口的前后端口径一致。
+test('修改登录密码：7 位新密码被本地拦下且不发送请求', async ({ page }) => {
+  let putCalls = 0;
+  await mockClientApi(page, { onChangePassword: () => (putCalls += 1) });
+  const dialog = await openChangePasswordDialog(page);
+
+  await fieldInput(dialog, '原密码').fill('old-password');
+  await fieldInput(dialog, '新密码').fill('1234567');
+  await fieldInput(dialog, '确认密码').fill('1234567');
+  await dialog.getByRole('button', { name: '确定' }).click();
+
+  await expect(page.locator('.t-message').filter({ hasText: '新密码长度不能少于 8 位' })).toBeVisible();
+  await expect(dialog).toBeVisible();
+  expect(putCalls).toBe(0);
+});
+
+test('修改登录密码：8 位新密码放行并携带输入字段', async ({ page }) => {
+  const payloads: unknown[] = [];
+  await mockClientApi(page, { onChangePassword: (body) => payloads.push(body) });
+  const dialog = await openChangePasswordDialog(page);
+
+  await fieldInput(dialog, '原密码').fill('old-password');
+  await fieldInput(dialog, '新密码').fill('12345678');
+  await fieldInput(dialog, '确认密码').fill('12345678');
+  await dialog.getByRole('button', { name: '确定' }).click();
+
+  await expect(page.locator('.t-message').filter({ hasText: '密码修改成功' })).toBeVisible();
+  expect(payloads).toHaveLength(1);
+  expect(payloads[0]).toMatchObject({
+    oldPassword: 'old-password',
+    newPassword: '12345678',
+    confirmPassword: '12345678',
+  });
+});


### PR DESCRIPTION
## 变更内容

落地 #37 六条评审意见对应的修复。时序说明：#37 于 03:12 合并（head `d1dc8f9`），而针对评审意见的修复提交于 03:15 之后，落在已关闭 PR 的分支上未入 main——本 PR 将该增量原样落地，**head 树与已在服务器完整验证的 `523e287` 逐字节一致**（7 文件，+163/-11）。

### 缓存失效的事务语义（评审 🟠 [讨论](https://github.com/25Cloud/TuraIDC/pull/37#discussion_r3849215723)，已被 CodeRabbit 标记 resolved）

`SiteCatalogCacheInvalidator::flush()` 整体注册为 `DB::afterCommit` 回调。`ProductCategoryService` 等调用方在 `DB::transaction()` 内触发失效，若提交前就 bump 版本号，并发请求会用新版本键缓存住提交前的旧目录，提交后再无第二次失效，旧数据挂满整个 TTL。`afterCommit` 语义已在同构环境实测：无事务立即执行、提交后执行、回滚丢弃——三种场景均为所需行为。新增两条事务语义测试（提交前不失效、回滚后作废），`SiteCatalogCacheInvalidationTest` 现为 7 条。

### 密码校验补漏（评审两条 🟡）

- 管理端用户编辑的校验改按 **trim 后长度**：`handleSave` 提交的是 trim 值，按原始长度校验会让 `" 1234567 "` 前端放行、后端 422。其余密码表单提交原始值且 Laravel `TrimStrings` 中间件豁免 `password` 字段，前后端同看原始串，无需跟进。
- `useProfile.changePassword`（个人资料页「修改登录密码」入口）补 8 位校验：该分支此前只判空，后端 `UpdatePasswordRequest` 的 `newPassword` 是 `min:8`；「新密码」输入框补「至少 8 位」占位提示。

### 管理端 dev 模式编译修复（处理评审 E2E 建议时发现的阻断项）

`Content.vue` 的 `keep-alive` 内有注释节点，dev 编译保留注释会报「`<KeepAlive>` expects exactly one child component」——**整个管理端 dev 模式与全部既有 Playwright e2e 此前无法运行**（生产构建剥离注释所以 `build` 一直是绿的）。注释移出 keep-alive；修复后既有 `agent-discounts.spec.ts` 5 条实测恢复通过。

### E2E 覆盖（评审 🟡）

新增 `users-create-password.spec.ts` 两条：7 位密码被前端拦下且创建接口零调用；8 位放行并断言请求体原样携带。沿用仓库既有 route-mock 约定。评审要求的另外三个场景（编辑留空、注册、找回密码）属 user-v4-console 的 auth+captcha 面，按线程约定另行跟进。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他（请说明）

## 检查清单

- [x] 已阅读 CONTRIBUTING.md
- [x] 已运行相关 lint 与静态检查
- [x] 不含数据库变更（迁移与 schema 基线均未改动）
- [x] 未提交任何敏感信息（密钥、`.env`、真实域名等）

## 测试说明

首个提交 `e1e1e1e` 的树与 `523e287` 逐字节一致（`git rev-parse HEAD^{tree}` 相等），以下服务器实测结果原样适用；`b5333b0` 为评审后追加，仅含 2 个测试/配置文件（用户端 e2e 与 local-reuse 配置），不触碰任何运行时代码：

| 检查项 | 结果 |
|---|---|
| 全量净库回归 | 1622 tests / **78** 失败——与纯净 main 完全同一集合，引入回归 **0** |
| PHPStan | **16** errors = 纯净 main 的 16，零新增 |
| Pint / php -l | 全 PASS |
| 新增缓存失效测试 | **7/7**（负控与事务语义均实测） |
| Playwright e2e | 既有 `agent-discounts` 5 条恢复通过 + 管理端新增 2 条 + 用户端 `profile-change-password` 新增 2 条，全部通过 |
| `vue-tsc` / eslint / prettier | 两端全绿 |

