### PR TITLE
perf(heartbeat): 削减心跳调度每分钟的冗余查询

### DIFF
--- a/backend/app/Services/Automation/Heartbeat/HeartbeatScheduler.php
+++ b/backend/app/Services/Automation/Heartbeat/HeartbeatScheduler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\Automation\Heartbeat;
 
 use App\Jobs\RunHeartbeatTaskJob;
-use App\Models\ScheduleTaskRun;
 use App\Models\ScheduleTick;
 use App\Services\Automation\Heartbeat\Contracts\ScheduledTask;
 use App\Services\Automation\Heartbeat\Data\TickContext;
@@ -60,7 +59,7 @@ class HeartbeatScheduler
             }
 
             foreach ($this->registry->enabledTasks() as $task) {
-                $this->dispatchTaskForTick($task, $tickModel, $tick, $queued, $skipped, $duplicates, $reclaimed, $dispatchFailed);
+                $this->dispatchTaskForTick($task, $tickModel, $tick, $queued, $skipped, $duplicates, $dispatchFailed);
             }
         } finally {
             $lock->release();
@@ -83,7 +82,6 @@ class HeartbeatScheduler
         array &$queued,
         array &$skipped,
         array &$duplicates,
-        int &$reclaimed,
         int &$dispatchFailed,
     ): void {
         try {
@@ -113,21 +111,21 @@ class HeartbeatScheduler
         }
 
         try {
-            // 只有超过任务执行、队列可见性和锁安全余量的记录才回收，避免误杀仍在运行的任务。
-            $reclaimed += $this->taskRuns->reclaimStaleRunsForTask($task->key(), $this->taskLeaseSeconds($task));
-
+            // 回收已在本槽开头对全部启用任务统一做过（见 tick()），此处不再重复：
+            // 两次调用之间只隔了前几个任务的派发，而回收租约至少 60 秒，
+            // 不可能在这个窗口里冒出新的超租约记录。
             if ($this->taskRuns->activeRunForTask($task->key()) !== null) {
                 $duplicates[] = $task->key();
 
                 return;
             }
 
-            $run = $this->taskRuns->markQueued($tickModel, $task, $matched);
+            $outcome = $this->taskRuns->markQueued($tickModel, $task, $matched);
+            $run = $outcome->dispatchable;
             if ($run === null) {
                 // 同槽位已终态处理（成功/失败）不算重复，计入跳过；仅仍活跃或派发失败才视为重复，
                 // 避免任务失败后的同槽剩余心跳刷出无意义的 duplicates 告警。
-                $existingStatus = $this->taskRuns->existingRunForTick($tickModel, $task->key())?->status;
-                if (in_array($existingStatus, [ScheduleTaskRun::STATUS_SUCCESS, ScheduleTaskRun::STATUS_FAILED], true)) {
+                if ($outcome->settledInThisSlot()) {
                     $skipped[] = $task->key();
 
                     return;

--- a/backend/app/Services/Automation/Heartbeat/QueuedRunOutcome.php
+++ b/backend/app/Services/Automation/Heartbeat/QueuedRunOutcome.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Automation\Heartbeat;
+
+use App\Models\ScheduleTaskRun;
+
+/**
+ * 本槽位登记运行记录的结果。
+ *
+ * 拆成两个字段是因为调用方要区分三种情况，而单个 ?ScheduleTaskRun 表达不了：
+ * - 需要派发（新建，或派发失败后重派）：$dispatchable 非 null；
+ * - 本槽已终态处理（success/failed）：不派发，也不算重复投递；
+ * - 本槽仍活跃或状态未知：算重复投递。
+ */
+final readonly class QueuedRunOutcome
+{
+    public function __construct(
+        public ?ScheduleTaskRun $dispatchable,
+        public ?string $existingStatus,
+    ) {}
+
+    /**
+     * 同槽已有记录是否已进入终态（成功或失败）。
+     *
+     * 终态不算「重复投递」：任务本槽已经跑过了，剩余心跳只是路过，
+     * 刷 duplicates 告警会把真正的重复投递淹掉。
+     */
+    public function settledInThisSlot(): bool
+    {
+        return in_array(
+            $this->existingStatus,
+            [ScheduleTaskRun::STATUS_SUCCESS, ScheduleTaskRun::STATUS_FAILED],
+            true,
+        );
+    }
+}

--- a/backend/app/Services/Automation/Heartbeat/ScheduleTaskRunRepository.php
+++ b/backend/app/Services/Automation/Heartbeat/ScheduleTaskRunRepository.php
@@ -18,7 +18,27 @@ use Illuminate\Support\Facades\Schema;
 
 class ScheduleTaskRunRepository
 {
-    public function markQueued(ScheduleTick $tick, ScheduledTask $task, TriggerRule $rule): ?ScheduleTaskRun
+    /**
+     * 表/列存在性的实例级缓存，只缓存 true。
+     *
+     * 只缓存 true 的理由：本仓「数据库只增不删」是铁律，表一旦建成不会再消失，
+     * 因此 true 是永久结论；而 false 是暂态——安装或迁移中途随时会翻转，把它缓存下来
+     * 会让同进程内后续调用永远读到过期结论（运行台账被静默停用）。
+     * 缓存挂在实例上而非静态：调度器与队列任务每次都从容器新建实例，作用域不跨请求。
+     */
+    private ?bool $tableReady = null;
+
+    private ?bool $retryLineageReady = null;
+
+    /**
+     * 登记本槽位的运行记录。
+     *
+     * 返回值携带「是否需要派发」与「同槽已有记录的状态」两件事：调用方原先在拿到 null
+     * 后还要再查一次 existingRunForTick 才能区分「本槽已终态处理」与「真正的重复投递」，
+     * 而那一行就是这里 firstOrCreate 刚读出来的同一行——(schedule_tick_id, task_key,
+     * source) 上有唯一索引，至多一行，两次查询必然同源。
+     */
+    public function markQueued(ScheduleTick $tick, ScheduledTask $task, TriggerRule $rule): QueuedRunOutcome
     {
         $run = ScheduleTaskRun::query()->firstOrCreate(
             [
@@ -36,7 +56,7 @@ class ScheduleTaskRunRepository
         );
 
         if ($run->wasRecentlyCreated) {
-            return $run;
+            return new QueuedRunOutcome($run, null);
         }
 
         // 派发阶段失败不等于任务执行失败；同一 15 分钟槽位的下一次心跳应复用该行重派。
@@ -67,23 +87,18 @@ class ScheduleTaskRunRepository
                     'updated_at' => $now,
                 ]);
 
-            return $updated === 1 ? $run->fresh() : null;
+            if ($updated === 1) {
+                return new QueuedRunOutcome($run->fresh(), ScheduleTaskRun::STATUS_DISPATCH_FAILED);
+            }
+
+            // CAS 落空说明另一路已经把这行重派走了；此时内存里的状态已过期，
+            // 必须重读一次才能给出与原实现一致的判定依据。这是罕见分支，多一次查询可接受。
+            return new QueuedRunOutcome(null, $run->fresh()?->status);
         }
 
-        return null;
-    }
-
-    /**
-     * 返回该槽位+任务已存在的运行记录（用于区分同槽位终态处理与真正的重复投递）。
-     */
-    public function existingRunForTick(ScheduleTick $tick, string $taskKey): ?ScheduleTaskRun
-    {
-        return ScheduleTaskRun::query()
-            ->where('schedule_tick_id', (int) $tick->id)
-            ->where('task_key', trim($taskKey))
-            ->where('source', 'heartbeat')
-            ->latest('id')
-            ->first();
+        // 本槽已有记录且无需重派：status 直接取自上面 firstOrCreate 读到的同一行，
+        // 无需再查库。
+        return new QueuedRunOutcome(null, $run->status);
     }
 
     /**
@@ -679,8 +694,12 @@ class ScheduleTaskRunRepository
 
     public function retryLineageReady(): bool
     {
+        if ($this->retryLineageReady === true) {
+            return true;
+        }
+
         try {
-            return $this->tableReady()
+            $ready = $this->tableReady()
                 && Schema::hasColumn('schedule_task_runs', 'parent_run_id')
                 && Schema::hasColumn('schedule_task_runs', 'attempt')
                 && Schema::hasColumn('schedule_task_runs', 'manual_retry_at')
@@ -688,14 +707,30 @@ class ScheduleTaskRunRepository
         } catch (\Throwable) {
             return false;
         }
+
+        if ($ready) {
+            $this->retryLineageReady = true;
+        }
+
+        return $ready;
     }
 
     public function tableReady(): bool
     {
+        if ($this->tableReady === true) {
+            return true;
+        }
+
         try {
-            return Schema::hasTable('schedule_task_runs');
+            $ready = Schema::hasTable('schedule_task_runs');
         } catch (\Throwable) {
             return false;
         }
+
+        if ($ready) {
+            $this->tableReady = true;
+        }
+
+        return $ready;
     }
 }


### PR DESCRIPTION
## 背景

心跳槽宽是 15 分钟（`TickSlot::SECONDS = 900`），但 crontab 每分钟跑一次 `schedule:run`。所以**每个槽里有 14 次心跳是「本槽任务已经跑完、理应无事可做」的**。

实测这样一次心跳仍然打 **106 条查询**：

| 类型 | 条数 | 来源 |
| --- | --- | --- |
| `information_schema` | 41 | `tableReady()` 每次都真查 |
| `UPDATE schedule_task_runs` | 29 | reclaim，**全部影响 0 行** |
| `SELECT schedule_task_runs` | 33 | activeRun + markQueued + existingRunForTick |
| 其它 | 3 | ticks 读写、jobs 计数 |

折算下来 **每天 142,464 条查询是纯浪费**（14 次/槽 × 96 槽 × 106 条）。本 PR 消除其中三处冗余，**不改变任何调度语义**。

## 改了什么

### ① `tableReady()` / `retryLineageReady()` 加实例级缓存，且只缓存 `true`

`ScheduleTaskRunRepository::tableReady()` 每次调用都真打一条 `information_schema`，而仓储里 **12 个方法**都在开头调它；`retryLineageReady()` 更是 `1 次 hasTable + 4 次 hasColumn = 5 条`。

**只缓存 `true` 是本项的关键安全设计：**

```php
if ($this->tableReady === true) return true;   // 只有 true 走缓存
$ready = Schema::hasTable('schedule_task_runs');
if ($ready) $this->tableReady = true;          // false 绝不写入
```

- `true` 是**永久结论**——本仓「绝不删表/列/索引」是铁律，表建成后不会消失；
- `false` 是**暂态**——安装或迁移中途随时翻转。缓存 false 会让同进程后续调用永远读到过期结论，把运行台账静默停用，这才是真正会阻碍功能的失败模式。

**作用域同样安全**：`ScheduleTaskRunRepository` 与 `HeartbeatScheduler` 都**没有绑定为单例**（`AppServiceProvider` 里只有 `HeartbeatTaskRegistry` 是），每次从容器解析都是新实例。`schedule:run` 每分钟一个全新进程、队列任务每个 job 一个新实例，**缓存从不跨进程或跨请求存活**，最长活一次心跳（不到 1 秒）。

### ② 删除 `dispatchTaskForTick` 里重复的 `reclaimStaleRunsForTask`

`tick()` 开头的自愈循环已经对**全部启用任务**回收过一遍，`dispatchTaskForTick` 里又对**同一个任务**再调一次。实测 `UPDATE 29 = 外层 18 + 内层 11`，删掉内层后正好剩 18。

**现有测试本身就是反证**：`test_heartbeat_reports_health_warning_when_stale_runs_are_reclaimed` 断言 `reclaimed === 1` —— 外层回收了那条陈旧记录（+1），内层再调时它已是 `failed`、回收 0 条。删掉后该断言仍是 1，实测通过。

**唯一会不一样的场景**（如实列出）：若同一次心跳内，从外层循环结束到轮到某个任务之间超过 **60 秒**（回收租约下限），期间新变陈旧的记录会晚一个心跳被回收。这需要前面的任务在派发时阻塞一分钟以上——只有 `QUEUE_CONNECTION=sync` 且任务极慢才可能；生产是 `database` 驱动，派发是瞬时的。后果也只是延迟一个心跳，不会漏掉。

### ③ 复用 `markQueued` 已加载的行，去掉 `existingRunForTick` 的二次查询

`markQueued` 的 `firstOrCreate` 已经把行读出来了，却在 `return null` 时丢弃；调用方紧接着用 `existingRunForTick` 查同一行拿 `status`。

**等价性是可证明的**：两者都按 `(schedule_tick_id, task_key, source)` 三列查询，而这三列上有唯一索引 `schedule_task_runs_tick_task_source_unique` —— 至多一行，必然同源。

改为返回显式 DTO `QueuedRunOutcome`（携带「是否需要派发」与「同槽已有记录状态」）。调用方要区分**需派发 / 本槽已终态 / 重复投递**三种情况，单个 `?ScheduleTaskRun` 表达不了；DTO 与既有 `Data/TickSummary` 等同风格。

`dispatch_failed` 重派分支单独处理：CAS 成功时返回 `$run->fresh()` 供派发；**CAS 落空时内存状态已过期，保留一次重读**，确保判定依据与原实现逐字一致（罕见分支，多一次查询换语义等价）。

爆炸半径也已核实：`markQueued` 与 `existingRunForTick` **各只有 1 个调用点**，都在 `HeartbeatScheduler` 内，测试不直接引用。

## 效率对比（同一棵树、同一轮实测）

| | 改前 | 改后 | 降幅 |
| --- | --- | --- | --- |
| **稳态心跳**（占 15 分钟里的 14 分钟） | **106 条** | **44 条** | **−58%** |
| ├ `information_schema` | 41 | **1** | −97.6% |
| ├ `UPDATE schedule_task_runs` | 29 | 18 | −38% |
| └ `SELECT schedule_task_runs` | 33 | 22 | −33% |
| 首次心跳（需真派发） | 124 | 74 | −40% |
| **每天浪费的查询** | **142,464** | **59,136** | **−58%** |
| 每天元数据查询 | 55,104 | **1,344** | **−97.6%** |

数字可对账：`UPDATE 29→18` 正是砍掉 11 次命中任务的重复 reclaim；`SELECT 33→22` 正是 11 次 `existingRunForTick`；`META 41→1` 是缓存生效后只剩首次那一条。

## 验证

**零迁移、零 DDL、零配置变更**；只动 3 个文件（+99/−28），其中 1 个是新增 DTO。

| 轨道 | Tests | Assertions | 失败集 |
| --- | --- | --- | --- |
| 基底 `68ceadd` @ MySQL 8.0 | 1664 | 84835 | 89 |
| 本 PR @ MySQL 8.0 | 1664 | **84835** | **89** |
| 本 PR @ MySQL 5.7.44 | 1664 | **84835** | **89** |

- **only-in-PR = 0**（未引入任何回归）、only-in-base = 0
- **双版本失败集逐条一致**：仅 5.7 失败 0、仅 8.0 失败 0
- **断言数三轮逐字相同（84835）**——不只是失败数一致，执行路径也一致
- `HeartbeatSchedulerTest` 24 条中，基底失败 1 条，本 PR 后为**同一条**（`test_laravel_schedule_only_registers_...`，属主线既有失败集），其余 **23 条全过**
- Pint PASS
- **PHPStan 受控 A/B**：先把测试库重置到固定状态、中途不做任何库变更，基底与本 PR **各测两次**，结果 `25 → 25`，**错误列表逐条相同**

> 关于 PHPStan 的一处说明：最初一轮测出「基底 24 / 本 PR 25」，差异行却是 `ZjmfFinanceTransport`（插件）与 `TicketDeliveryService`，都与本次改动无关。追查后确认是 larastan 的 `checkModelProperties: true` 会读实时库结构，而那两次测量时数据库被测试跑成了不同状态。改用固定库状态的受控 A/B 后增量为 0，且基底自身两次测量结果相同、可重复。

## 未包含（另行处理）

本次扫描还发现两条**正确性**问题，属于改行为而非改性能，未夹带进本 PR：

1. `HeartbeatScheduler::pendingJobsCount()` 硬编码读 `queue.connections.database.*`，与实际队列驱动无关。当前生产 `QUEUE_CONNECTION=database` 所以有效；一旦切 redis，队列积压告警会**恒为 0 且完全静默**。
2. 槽位锁 TTL = 900s = 整个槽宽，而临界区实际是亚秒级。进程若在 `get()` 与 `release()` 之间被杀（OOM、部署重启），锁会残留到本槽结束，**该槽所有任务都不派发**。生产日志里「槽位锁被占用」出现 0 次，说明未真发生过，但 TTL 比需要的大三个数量级。
