### PR TITLE
fix: 锁定vue运行时到3.5.41修复循环chunk初始化崩溃

### DIFF
--- a/docs-web/package-lock.json
+++ b/docs-web/package-lock.json
@@ -11,9 +11,9 @@
       "devDependencies": {
         "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.18.2",
         "@nolebase/vitepress-plugin-highlight-targeted-heading": "^2.18.2",
-        "@vue/server-renderer": "^3.5.41",
+        "@vue/server-renderer": "3.5.41",
         "vitepress": "^1.6.4",
-        "vue": "^3.5.41"
+        "vue": "3.5.41"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1447,58 +1447,83 @@
         "vue": "^3.2.25"
       }
     },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
-      "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.8",
-        "@vue/shared": "3.5.42",
-        "entities": "^7.0.1",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
-      "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.42",
-        "@vue/shared": "3.5.42"
-      }
-    },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
-      "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.8",
-        "@vue/compiler-core": "3.5.42",
-        "@vue/compiler-dom": "3.5.42",
-        "@vue/compiler-ssr": "3.5.42",
-        "@vue/shared": "3.5.42",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
-      "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
+    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.42",
-        "@vue/shared": "3.5.42"
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1537,56 +1562,56 @@
         "rfdc": "^1.4.1"
       }
     },
-    "node_modules/@vue/reactivity": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/reactivity/-/reactivity-3.5.42.tgz",
-      "integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.5.42"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
-      "integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.42",
-        "@vue/shared": "3.5.42"
-      }
-    },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
-      "integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+      "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.42",
-        "@vue/runtime-core": "3.5.42",
-        "@vue/shared": "3.5.42",
+        "@vue/reactivity": "3.5.41",
+        "@vue/runtime-core": "3.5.41",
+        "@vue/shared": "3.5.41",
         "csstype": "^3.2.3"
       }
     },
-    "node_modules/@vue/server-renderer": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
-      "integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
+    "node_modules/@vue/runtime-dom/node_modules/@vue/reactivity": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.42",
-        "@vue/runtime-dom": "3.5.42",
-        "@vue/shared": "3.5.42"
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/runtime-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+      "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+      "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/@vue/shared/-/shared-3.5.42.tgz",
-      "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2904,17 +2929,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.42.tgz",
-      "integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.41.tgz",
+      "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.42",
-        "@vue/compiler-sfc": "3.5.42",
-        "@vue/runtime-dom": "3.5.42",
-        "@vue/server-renderer": "3.5.42",
-        "@vue/shared": "3.5.42"
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-sfc": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/server-renderer": "3.5.41",
+        "@vue/shared": "3.5.41"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2923,6 +2948,31 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/zwitch": {

--- a/docs-web/package.json
+++ b/docs-web/package.json
@@ -12,8 +12,20 @@
   "devDependencies": {
     "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.18.2",
     "@nolebase/vitepress-plugin-highlight-targeted-heading": "^2.18.2",
-    "@vue/server-renderer": "^3.5.41",
+    "@vue/server-renderer": "3.5.41",
     "vitepress": "^1.6.4",
-    "vue": "^3.5.41"
+    "vue": "3.5.41"
+  },
+  "overrides": {
+    "vue": "3.5.41",
+    "@vue/runtime-core": "3.5.41",
+    "@vue/runtime-dom": "3.5.41",
+    "@vue/reactivity": "3.5.41",
+    "@vue/shared": "3.5.41",
+    "@vue/server-renderer": "3.5.41",
+    "@vue/compiler-core": "3.5.41",
+    "@vue/compiler-dom": "3.5.41",
+    "@vue/compiler-sfc": "3.5.41",
+    "@vue/compiler-ssr": "3.5.41"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,13 +64,13 @@ importers:
         specifier: ^2.18.2
         version: 2.18.2(vitepress@1.6.4(@algolia/client-search@5.57.0)(@types/node@26.2.0)(async-validator@4.2.5)(axios@1.19.0)(change-case@5.4.4)(less@4.9.0)(lightningcss@1.33.0)(nprogress@0.2.0)(postcss@8.5.26)(sass@1.103.0)(search-insights@2.17.3)(sortablejs@1.15.7)(stylus@0.57.0)(typescript@5.9.3))
       '@vue/server-renderer':
-        specifier: ^3.5.41
+        specifier: 3.5.41
         version: 3.5.41
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.57.0)(@types/node@26.2.0)(async-validator@4.2.5)(axios@1.19.0)(change-case@5.4.4)(less@4.9.0)(lightningcss@1.33.0)(nprogress@0.2.0)(postcss@8.5.26)(sass@1.103.0)(search-insights@2.17.3)(sortablejs@1.15.7)(stylus@0.57.0)(typescript@5.9.3)
       vue:
-        specifier: ^3.5.41
+        specifier: 3.5.41
         version: 3.5.41(typescript@5.9.3)
 
   frontend-admin-v3:
@@ -11015,9 +11015,9 @@ snapshots:
 
   wrap-ansi@7.0.0:
     dependencies:
-      ansi-styles: 4.0.0
-      string-width: 4.1.0
-      strip-ansi: 6.0.0
+      ansi-styles: 4.1.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@8.1.0:
     dependencies:


### PR DESCRIPTION
## 背景

#48 锁定了构建依赖组合，但线上 docs.turaidc.com 仍复现：

\`\`\`
framework.BWLZAFUU.js:21 Uncaught TypeError: Cannot read properties of undefined (reading 'shallowRef')
\`\`\`

侧栏交互、顶部扩展按钮与深浅色切换均无响应（水合中断）。

## 根因（版本指纹实证）

| 环境 | framework chunk 内嵌 vue | 结果 |
| --- | --- | --- |
| 线上两次部署 | **3.5.42** | 崩溃（不同构建 hash、同一代码列 21:32420 稳定复现） |
| 本地 workspace | **3.5.41** | 正常 |

vue 3.5.42 在 vitepress 1.6.4 固有的 `framework ↔ theme` 循环 chunk 结构（npm 扁平布局下 `Circular chunk: framework -> theme -> framework` 警告）中触发模块初始化回归，响应性命名空间求值为 undefined。本地（vue 3.5.41）同结构产物正常。

## 修复

- `docs-web/package.json`：`vue` 与 `@vue/server-renderer` 直接依赖精确锁定 `3.5.41`，并加 `overrides` 将 `@vue/runtime-core`、`@vue/reactivity`、`@vue/shared` 等运行时全家统一压到 `3.5.41`（避免 reactivity 双实例）
- `docs-web/package-lock.json` / 根 `pnpm-lock.yaml`：同步刷新

## 验证

- npm ci（模拟 EdgeOne）+ pnpm workspace 两种环境 `build:docs` 通过
- 产物 `framework.*.js` 内嵌版本指纹为 `"3.5.41"`，chunk 引用完整性全部通过