### PR TITLE
fix: 压平vitepress构建分块消除framework与theme循环依赖

### DIFF
--- a/docs-web/.vitepress/config.ts
+++ b/docs-web/.vitepress/config.ts
@@ -1,7 +1,31 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
-import { defineConfig, type DefaultTheme } from "vitepress";
+import { defineConfig, type DefaultTheme, type Plugin } from "vitepress";
+
+// vitepress 1.6.4 内部把运行时拆为 framework/theme 两个 chunk 并在其 output
+// 展开顺序中覆盖用户 manualChunks；theme 分组包含被入口静态引用的全局注册
+// 组件（如增强阅读面板），与 framework 形成跨 chunk 循环，水合时序下
+// framework 读取到 theme 尚未赋值的导出（undefined.shallowRef 崩溃）。
+// vite 的 mergeConfig 会跳过 undefined 值，因此用"恒返回 undefined 的
+// 函数"覆盖内部分块，让运行时全部进入单一 entry chunk，消除循环。
+function flattenManualChunks(): Plugin {
+  return {
+    name: "docs-web:flatten-manual-chunks",
+    apply: "build",
+    config() {
+      return {
+        build: {
+          rollupOptions: {
+            output: {
+              manualChunks: () => undefined,
+            },
+          },
+        },
+      };
+    },
+  };
+}
 
 const docsRoot = resolve(import.meta.dirname, "../../docs");
 
@@ -278,6 +302,7 @@ export default defineConfig({
   srcDir: "../docs",
   vite: {
     publicDir: resolve(import.meta.dirname, "../public"),
+    plugins: [flattenManualChunks()],
     resolve: {
       alias: vueAlias,
     },


### PR DESCRIPTION
## 背景

#49 将 vue 运行时锁定到 3.5.41 后，文档站水合崩溃（`undefined.shallowRef`）仍复现——本地构建产物 + `vitepress preview` 实测同样崩溃，排除了构建环境差异与 vue 版本两个假设。

## 根因（产物级实证）

vitepress 1.6.4 内部 `manualChunks` 将运行时拆为 `framework`/`theme` 两个 chunk（npm 扁平与 pnpm 布局下均产生，产物 `assets/chunks/` 可见）。`theme` 分组收录"被入口静态引用的非排除模块"——经 `enhanceApp` 全局注册的增强阅读面板组件因此进入 theme chunk，与 framework 形成**跨 chunk 循环依赖**（构建期警告 `Circular chunk: framework -> theme -> framework`）：

- framework 求值早期执行外观状态初始化：`x.shallowRef(Ah)`
- `x` 为 `import { v as x } from "./theme.*.js"` 的跨块导入
- 循环时序下 theme 的对应导出尚未赋值 → `undefined.shallowRef` 崩溃
- dev 模式无分块，因此本地开发一直正常；线上与本地 `preview` 均复现

## 修复

`config.ts` 新增 `flattenManualChunks` 插件：利用 vite 插件 `config` 钩子在 vitepress 内部配置**之后**合并 `build.rollupOptions.output.manualChunks = () => undefined`（vite 的 `mergeConfig` 跳过 `undefined` 值，无法直接覆盖，函数可覆盖），使运行时全部进入单一 entry chunk，从结构上消除跨 chunk 循环。

产物形态：`app.*.js`（运行时+主题+面板）+ 动态 import 的搜索框/搜索索引等单向异步 chunk。体积代价为单 chunk 增大（约 500 kB），正确性优先。

## 验证

- `build:docs` 通过，产物中 `framework`/`theme` chunk 消失，`shallowRef` 完整存在于 entry chunk
- 首页引用的全部资产 HTTP 200，preview 实测侧栏折叠、顶部扩展按钮、深浅色切换恢复响应（浏览器控制台无报错）