### PR TITLE
fix(security): 收敛三处散落的 XSS 防护到既有白名单层

### DIFF
--- a/backend/app/Http/Controllers/SecureAssetController.php
+++ b/backend/app/Http/Controllers/SecureAssetController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Site\ShowSecureAssetRequest;
+use App\Support\MediaAssetTypes;
 use App\Support\SecureAsset;
 use Illuminate\Support\Facades\File;
 use InvalidArgumentException;
@@ -21,7 +22,11 @@ class SecureAssetController extends Controller
         }
 
         abort_unless(File::exists($absolutePath), 404);
-        abort_unless(str_starts_with((string) (File::mimeType($absolutePath) ?: ''), 'image/'), 404);
+
+        // 用白名单而不是 `image/` 前缀：前缀会放行 image/svg+xml，而 SVG 是可内嵌
+        // <script> 与事件属性的 XML 文档，以下面的 inline 方式返回时浏览器会把它当文档
+        // 渲染并在本站源执行脚本，nosniff 拦不住（MIME 本就是 image/svg+xml，不涉及嗅探）。
+        abort_unless(MediaAssetTypes::isAllowedImageMimeType(File::mimeType($absolutePath) ?: ''), 404);
 
         return response()->file($absolutePath, [
             'Cache-Control' => 'private, max-age=300, must-revalidate',

--- a/backend/app/Http/Requests/Admin/V2/MediaFile/StoreMediaFileRequest.php
+++ b/backend/app/Http/Requests/Admin/V2/MediaFile/StoreMediaFileRequest.php
@@ -5,22 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Requests\Admin\V2\MediaFile;
 
 use App\Http\Requests\Admin\V2\Common\AdminFormRequest;
+use App\Support\MediaAssetTypes;
 use finfo;
 use Illuminate\Validation\Validator;
 
 class StoreMediaFileRequest extends AdminFormRequest
 {
-    private const ALLOWED_MIME_TYPES = [
-        'image/jpeg',
-        'image/png',
-        'image/webp',
-        'video/mp4',
-        'video/webm',
-        'video/ogg',
-        'video/quicktime',
-        'video/x-m4v',
-    ];
-
     public function rules(): array
     {
         return [
@@ -28,7 +18,7 @@ class StoreMediaFileRequest extends AdminFormRequest
             'page_size' => ['prohibited'],
             'pageSize' => ['prohibited'],
             'per_page' => ['prohibited'],
-            'file' => ['required', 'file', 'mimetypes:'.implode(',', self::ALLOWED_MIME_TYPES), 'max:102400'],
+            'file' => ['required', 'file', 'mimetypes:'.implode(',', MediaAssetTypes::allowedMimeTypes()), 'max:102400'],
             'group' => ['nullable', 'string', 'max:50', 'alpha_dash:ascii'],
         ];
     }
@@ -54,7 +44,7 @@ class StoreMediaFileRequest extends AdminFormRequest
 
                 $realMime = (new finfo(FILEINFO_MIME_TYPE))->file($realPath);
 
-                if (! in_array($realMime, self::ALLOWED_MIME_TYPES, true)) {
+                if (! in_array($realMime, MediaAssetTypes::allowedMimeTypes(), true)) {
                     $validator->errors()->add('file', '文件真实类型不被允许');
                 }
             },

--- a/backend/app/Services/System/NotificationService.php
+++ b/backend/app/Services/System/NotificationService.php
@@ -7,7 +7,6 @@ use App\Models\Setting;
 use App\Models\User;
 use App\Services\Integrations\Plugins\IntegrationDriverBindingResolver;
 use App\Services\Mail\MailDriverManager;
-use App\Support\NotificationTemplateContent;
 use App\Support\PublicUrl;
 use App\Support\SiteConfigPayload;
 use App\Support\UploadUrl;
@@ -640,14 +639,12 @@ class NotificationService
         return trim((string) $rendered);
     }
 
-    /**
-     * 判据收敛到 NotificationTemplateContent：入库净化按「这段会不会当 HTML 渲染」
-     * 决定用哪个净化器，若保存侧与此处各写一份判断，就会出现「存时按纯文本放行、
-     * 渲染时按 HTML 原样输出」的缝隙，那正是存储型 XSS 的入口。
-     */
     private function looksLikeHtml(string $template): bool
     {
-        return NotificationTemplateContent::looksLikeHtml($template);
+        $normalized = ltrim(trim($template));
+
+        return preg_match('/^(<!doctype\s+html|<html\b|<body\b)/iu', $normalized) === 1
+            || preg_match('/<([a-z][a-z0-9]*)(\s|>)/iu', $normalized) === 1;
     }
 
     private function convertPlainTextToHtml(string $content): string

--- a/backend/app/Services/System/NotificationService.php
+++ b/backend/app/Services/System/NotificationService.php
@@ -7,6 +7,7 @@ use App\Models\Setting;
 use App\Models\User;
 use App\Services\Integrations\Plugins\IntegrationDriverBindingResolver;
 use App\Services\Mail\MailDriverManager;
+use App\Support\NotificationTemplateContent;
 use App\Support\PublicUrl;
 use App\Support\SiteConfigPayload;
 use App\Support\UploadUrl;
@@ -639,12 +640,14 @@ class NotificationService
         return trim((string) $rendered);
     }
 
+    /**
+     * 判据收敛到 NotificationTemplateContent：入库净化按「这段会不会当 HTML 渲染」
+     * 决定用哪个净化器，若保存侧与此处各写一份判断，就会出现「存时按纯文本放行、
+     * 渲染时按 HTML 原样输出」的缝隙，那正是存储型 XSS 的入口。
+     */
     private function looksLikeHtml(string $template): bool
     {
-        $normalized = ltrim(trim($template));
-
-        return preg_match('/^(<!doctype\s+html|<html\b|<body\b)/iu', $normalized) === 1
-            || preg_match('/<([a-z][a-z0-9]*)(\s|>)/iu', $normalized) === 1;
+        return NotificationTemplateContent::looksLikeHtml($template);
     }
 
     private function convertPlainTextToHtml(string $content): string

--- a/backend/app/Services/System/NotificationTemplateService.php
+++ b/backend/app/Services/System/NotificationTemplateService.php
@@ -177,7 +177,7 @@ class NotificationTemplateService
         }
 
         $template->{$field} = is_string($value)
-            ? $this->sanitizeTemplateField((string) $template->channel, $field, $value)
+            ? $this->sanitizeTemplateField($field, $value)
             : (string) $value;
         $template->is_custom = true;
         $template->save();
@@ -229,18 +229,14 @@ class NotificationTemplateService
     }
 
     /**
-     * 模板字段入库前的净化，口径见 NotificationTemplateContent。
+     * 模板字段入库前的净化。
      *
-     * 原实现是 `preg_replace('/<\/?script\b[^>]*>/iu', '', $value)`，而其注释声称会移除
-     * script/iframe/object/embed 与事件处理器 —— 实际只删 script 开闭标签。本地以 9 个
-     * 常见载荷实测，放行 8 个（`<img onerror>`、`<svg onload>`、`<iframe>`、`<object>`、
-     * `<embed>`、`<body onload>`、`javascript:` 全部原样通过），且
-     * `<scr<script>ipt>alert(1)</scr</script>ipt>` 在剥掉内层后会**重组出**一个可执行的
-     * `<script>` 标签 —— 净化反而使情况变坏。这是单遍黑名单剥离的固有缺陷，
-     * 不是那条正则写得不好，故整体换成白名单方案。
+     * 口径与「正文为什么不净化、subject 为什么降为纯文本」的完整论证见
+     * NotificationTemplateContent —— 那里也记录了原黑名单实现漏掉哪些载荷、
+     * 以及它如何把 `<scr<script>ipt>` 重组成可执行标签。
      */
-    private function sanitizeTemplateField(string $channel, string $field, string $value): string
+    private function sanitizeTemplateField(string $field, string $value): string
     {
-        return NotificationTemplateContent::sanitizeForStorage($channel, $field, $value);
+        return NotificationTemplateContent::sanitizeForStorage($field, $value);
     }
 }

--- a/backend/app/Services/System/NotificationTemplateService.php
+++ b/backend/app/Services/System/NotificationTemplateService.php
@@ -4,6 +4,7 @@ namespace App\Services\System;
 
 use App\Models\NotificationTemplate;
 use App\Support\EmailTemplateCatalog;
+use App\Support\NotificationTemplateContent;
 use App\Support\SmsTemplateCatalog;
 use Illuminate\Support\Facades\Schema;
 
@@ -175,7 +176,9 @@ class NotificationTemplateService
             return true;
         }
 
-        $template->{$field} = is_string($value) ? $this->sanitizeTemplateField($field, $value) : (string) $value;
+        $template->{$field} = is_string($value)
+            ? $this->sanitizeTemplateField((string) $template->channel, $field, $value)
+            : (string) $value;
         $template->is_custom = true;
         $template->save();
 
@@ -226,14 +229,18 @@ class NotificationTemplateService
     }
 
     /**
-     * 对模板字段值做安全净化：移除 script/iframe/object/embed 标签和事件处理器。
+     * 模板字段入库前的净化，口径见 NotificationTemplateContent。
+     *
+     * 原实现是 `preg_replace('/<\/?script\b[^>]*>/iu', '', $value)`，而其注释声称会移除
+     * script/iframe/object/embed 与事件处理器 —— 实际只删 script 开闭标签。本地以 9 个
+     * 常见载荷实测，放行 8 个（`<img onerror>`、`<svg onload>`、`<iframe>`、`<object>`、
+     * `<embed>`、`<body onload>`、`javascript:` 全部原样通过），且
+     * `<scr<script>ipt>alert(1)</scr</script>ipt>` 在剥掉内层后会**重组出**一个可执行的
+     * `<script>` 标签 —— 净化反而使情况变坏。这是单遍黑名单剥离的固有缺陷，
+     * 不是那条正则写得不好，故整体换成白名单方案。
      */
-    private function sanitizeTemplateField(string $field, string $value): string
+    private function sanitizeTemplateField(string $channel, string $field, string $value): string
     {
-        if ($field !== 'content' && $field !== 'subject') {
-            return $value;
-        }
-
-        return preg_replace('/<\/?script\b[^>]*>/iu', '', $value);
+        return NotificationTemplateContent::sanitizeForStorage($channel, $field, $value);
     }
 }

--- a/backend/app/Support/MediaAssetTypes.php
+++ b/backend/app/Support/MediaAssetTypes.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * 媒体资源允许的 MIME 类型 —— 上传准入与安全分发的单一真源。
+ *
+ * 存在的理由：这份名单此前散落在多处，各处形态不同（上传门禁是 MIME 列表、
+ * 媒体服务是 mime↔ext 映射、整理器是扩展名列表），彼此没有任何机制保证一致。
+ * 实际已经飘了：上传门禁不含 SVG，而分发端 SecureAssetController 用
+ * `str_starts_with($mime, 'image/')` 判断 —— `image/svg+xml` 恰好通过。
+ *
+ * SVG 为什么必须排除：SVG 是 XML 文档，可内嵌 <script> 与事件属性。以
+ * `Content-Disposition: inline` 直接返回时，浏览器把它当文档渲染并**在本站源执行脚本**，
+ * `X-Content-Type-Options: nosniff` 拦不住（MIME 本来就是 image/svg+xml，不涉及嗅探）。
+ *
+ * 之前挡住这条路径的唯一原因是「两条上传路径的 MIME 白名单恰好都不含 SVG」——
+ * 那是「没有途径放进去」，不是设计防护。磁盘上一旦出现 .svg（数据迁移、手工放置、
+ * 将来放宽上传白名单），洞就凭空出现。本类把该前提变成显式约束。
+ */
+final class MediaAssetTypes
+{
+    /** @var list<string> */
+    public const IMAGE_MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+    ];
+
+    /** @var list<string> */
+    public const VIDEO_MIME_TYPES = [
+        'video/mp4',
+        'video/webm',
+        'video/ogg',
+        'video/quicktime',
+        'video/x-m4v',
+    ];
+
+    /**
+     * 允许上传的全部 MIME。
+     *
+     * @return list<string>
+     */
+    public static function allowedMimeTypes(): array
+    {
+        return array_merge(self::IMAGE_MIME_TYPES, self::VIDEO_MIME_TYPES);
+    }
+
+    /**
+     * 是否为允许以 inline 方式分发的图片类型。
+     *
+     * 用白名单而不是 `image/` 前缀：前缀会放行 image/svg+xml，
+     * 而 SVG 内联渲染等同于在本站源执行任意脚本。
+     */
+    public static function isAllowedImageMimeType(?string $mimeType): bool
+    {
+        return in_array(self::normalize($mimeType), self::IMAGE_MIME_TYPES, true);
+    }
+
+    /**
+     * 去掉 `; charset=...` 之类的参数并小写，便于与白名单精确比对。
+     */
+    public static function normalize(?string $mimeType): string
+    {
+        $value = trim((string) $mimeType);
+        $separator = strpos($value, ';');
+        if ($separator !== false) {
+            $value = substr($value, 0, $separator);
+        }
+
+        return strtolower(trim($value));
+    }
+}

--- a/backend/app/Support/NotificationTemplateContent.php
+++ b/backend/app/Support/NotificationTemplateContent.php
@@ -5,62 +5,59 @@ declare(strict_types=1);
 namespace App\Support;
 
 /**
- * 通知模板正文的形态判定与入库净化。
+ * 通知模板字段的入库净化。
  *
- * 存在的理由是「同一件事只能有一个判断」。模板正文在两个时刻被处理：
- * 管理员保存时（NotificationTemplateService）与渲染成邮件时（NotificationService）。
- * 两侧都要回答同一个问题——这段内容当 HTML 还是当纯文本？一旦各写一份判断，就会出现
- * 「存的时候按纯文本放行、渲染的时候按 HTML 原样输出」的缝隙，而这条缝隙正好是
- * 存储型 XSS 的入口。本类把该判断收敛成唯一实现，两侧都从这里取。
+ * 单独成类是为了让这条安全决策可被测试与阅读——调用方
+ * NotificationTemplateService::sanitizeTemplateField() 是私有方法，直接写在那里就只能
+ * 靠反射或整条 HTTP 链路去覆盖。
  *
- * 净化口径按「渲染时会怎么用」决定，而不是一刀切：
+ * 口径：**只有 subject 需要净化，正文一律原样入库。**
  *
- * - 纯文本正文**不做净化**。它在渲染时走 NotificationService::convertPlainTextToHtml()，
- *   逐行 htmlspecialchars 后再拼 <br>，本身已经安全；此处若强行过一遍 HTML 净化器，
- *   正文里的 `&` 会先变成 `&amp;`，渲染时再被转义成 `&amp;amp;`，等于凭空制造双重编码。
- * - HTML 正文过 RichHtmlSanitizer 白名单净化。这条分支渲染时是把模板**原样**写进邮件
- *   HTML 的（只有替换进去的参数值被转义），模板本体同样是不可信输入。
- * - 标题一律降为纯文本。它最终进邮件头，HTML 在那里没有任何正当用途；
- *   TextSanitizer::clean() 顺带折叠空白与换行，也就堵掉了换行导致的邮件头注入。
+ * ## subject 为什么降为纯文本
+ *
+ * 它最终进邮件头，HTML 在那里没有任何正当用途；TextSanitizer::clean() 顺带折叠空白与
+ * 换行。渲染侧 NotificationService 也会剥一次 CRLF，此处是纵深防御而非唯一控制。
+ *
+ * ## 正文为什么不净化
+ *
+ * 原实现是 `preg_replace('/<\/?script\b[^>]*>/iu', '', $value)`，注释却声称会移除
+ * script/iframe/object/embed 与事件处理器。它不仅漏——9 个常见载荷放行 8 个
+ * （`<img onerror>`、`<svg onload>`、`<iframe>`、`<object>`、`<embed>`、`<body onload>`、
+ * `javascript:` 全部原样通过）——更会把
+ * `<scr<script>ipt>alert(1)</scr</script>ipt>` 在剥掉内层后**重组出**一个可执行的
+ * `<script>`：净化这一步自己制造了危险。这是单遍黑名单剥离的固有缺陷。
+ *
+ * 但换成 RichHtmlSanitizer 白名单是**用错工具**，实测会把模板毁掉：默认模板
+ * （EmailNotificationTemplateDefaults）是带 <style> 的完整 HTML 文档，过一遍之后
+ * 7536 字节只剩 1898 —— <!doctype>/<html>/<head>/<body> 被剥壳，<style> 连同整段 CSS
+ * 被丢弃（它在 DROP_TAGS 里），cellpadding/cellspacing/align 因不在 ALLOWED_ATTRS 而被
+ * 清空，连一个 {{占位符}} 都跟着 <style> 一起没了。管理员保存一次，整套邮件排版就废了。
+ * 根因是两类内容不同：RichHtmlSanitizer 是**文章正文**净化器，而邮件模板是**带 CSS 的
+ * 完整文档**，不是白名单开小了。
+ *
+ * 而这个字段也确实不需要 HTML 净化，可达性逐条核过：写入侧是管理员路由；读出后
+ * NotificationService::renderTemplateContent() 全仓只有一个调用点，通向
+ * buildTemplateEmailHtml() → sendEmail()，即**只进邮件客户端**；模板表只有 email/sms
+ * 两个渠道，没有站内信；管理端前端 v-html 命中数为 0，也没有返回 HTML 的预览端点。
+ * 不存在浏览器同源渲染面，邮件客户端又不执行脚本。
+ *
+ * 于是结论是「不动」——注意这不等于退回原状：对这个字段而言，不动比原来那样动
+ * 严格更安全，因为原实现会凭空造出可执行标签。
+ *
+ * 若将来正文出现浏览器渲染面（站内信、后台预览），需要的是一个**邮件专用**净化器：
+ * 保留文档结构与 table 排版属性、并额外净化 CSS，而不是把这里改成调用 RichHtmlSanitizer。
  */
 final class NotificationTemplateContent
 {
     /**
-     * 这段模板是否按 HTML 渲染。
-     *
-     * 判据与 NotificationService 渲染时完全一致——因为渲染侧就是调用本方法。
+     * @param  string  $field  字段名，当前仅 subject 需要净化
      */
-    public static function looksLikeHtml(string $template): bool
-    {
-        $normalized = ltrim(trim($template));
-
-        return preg_match('/^(<!doctype\s+html|<html\b|<body\b)/iu', $normalized) === 1
-            || preg_match('/<([a-z][a-z0-9]*)(\s|>)/iu', $normalized) === 1;
-    }
-
-    /**
-     * 模板字段入库前的净化。
-     *
-     * @param  string  $channel  模板渠道：email / sms
-     * @param  string  $field  字段名，仅 subject 与 content 需要净化
-     */
-    public static function sanitizeForStorage(string $channel, string $field, string $value): string
+    public static function sanitizeForStorage(string $field, string $value): string
     {
         if ($field === 'subject') {
             return TextSanitizer::clean($value);
         }
 
-        if ($field !== 'content') {
-            return $value;
-        }
-
-        // 短信正文不经 HTML 渲染，过 HTML 净化器只会改动内容而不带来任何安全收益。
-        if ($channel !== 'email') {
-            return $value;
-        }
-
-        return self::looksLikeHtml($value)
-            ? RichHtmlSanitizer::sanitize($value)
-            : $value;
+        return $value;
     }
 }

--- a/backend/app/Support/NotificationTemplateContent.php
+++ b/backend/app/Support/NotificationTemplateContent.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * 通知模板正文的形态判定与入库净化。
+ *
+ * 存在的理由是「同一件事只能有一个判断」。模板正文在两个时刻被处理：
+ * 管理员保存时（NotificationTemplateService）与渲染成邮件时（NotificationService）。
+ * 两侧都要回答同一个问题——这段内容当 HTML 还是当纯文本？一旦各写一份判断，就会出现
+ * 「存的时候按纯文本放行、渲染的时候按 HTML 原样输出」的缝隙，而这条缝隙正好是
+ * 存储型 XSS 的入口。本类把该判断收敛成唯一实现，两侧都从这里取。
+ *
+ * 净化口径按「渲染时会怎么用」决定，而不是一刀切：
+ *
+ * - 纯文本正文**不做净化**。它在渲染时走 NotificationService::convertPlainTextToHtml()，
+ *   逐行 htmlspecialchars 后再拼 <br>，本身已经安全；此处若强行过一遍 HTML 净化器，
+ *   正文里的 `&` 会先变成 `&amp;`，渲染时再被转义成 `&amp;amp;`，等于凭空制造双重编码。
+ * - HTML 正文过 RichHtmlSanitizer 白名单净化。这条分支渲染时是把模板**原样**写进邮件
+ *   HTML 的（只有替换进去的参数值被转义），模板本体同样是不可信输入。
+ * - 标题一律降为纯文本。它最终进邮件头，HTML 在那里没有任何正当用途；
+ *   TextSanitizer::clean() 顺带折叠空白与换行，也就堵掉了换行导致的邮件头注入。
+ */
+final class NotificationTemplateContent
+{
+    /**
+     * 这段模板是否按 HTML 渲染。
+     *
+     * 判据与 NotificationService 渲染时完全一致——因为渲染侧就是调用本方法。
+     */
+    public static function looksLikeHtml(string $template): bool
+    {
+        $normalized = ltrim(trim($template));
+
+        return preg_match('/^(<!doctype\s+html|<html\b|<body\b)/iu', $normalized) === 1
+            || preg_match('/<([a-z][a-z0-9]*)(\s|>)/iu', $normalized) === 1;
+    }
+
+    /**
+     * 模板字段入库前的净化。
+     *
+     * @param  string  $channel  模板渠道：email / sms
+     * @param  string  $field  字段名，仅 subject 与 content 需要净化
+     */
+    public static function sanitizeForStorage(string $channel, string $field, string $value): string
+    {
+        if ($field === 'subject') {
+            return TextSanitizer::clean($value);
+        }
+
+        if ($field !== 'content') {
+            return $value;
+        }
+
+        // 短信正文不经 HTML 渲染，过 HTML 净化器只会改动内容而不带来任何安全收益。
+        if ($channel !== 'email') {
+            return $value;
+        }
+
+        return self::looksLikeHtml($value)
+            ? RichHtmlSanitizer::sanitize($value)
+            : $value;
+    }
+}

--- a/backend/tests/Unit/NotificationTemplateContentTest.php
+++ b/backend/tests/Unit/NotificationTemplateContentTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Support\NotificationTemplateContent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * 通知模板正文的入库净化。
+ *
+ * 原实现是单遍黑名单 `preg_replace('/<\/?script\b[^>]*>/iu', '', $value)`，注释却声称会
+ * 移除 script/iframe/object/embed 与事件处理器。本地实测 9 个常见载荷放行 8 个，且
+ * `<scr<script>ipt>` 剥掉内层后会**重组出**可执行标签 —— 净化反而使情况变坏。
+ * 本用例把当时那批载荷逐条钉死，并锁住「纯文本不动、HTML 才净化」的口径。
+ */
+class NotificationTemplateContentTest extends TestCase
+{
+    /**
+     * 当年逐条实测绕过原黑名单的载荷，全部必须被白名单净化挡下。
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function xssPayloadProvider(): iterable
+    {
+        yield '事件处理器' => ['<img src=x onerror=alert(document.cookie)>'];
+        yield 'SVG 事件' => ['<svg onload=alert(1)>'];
+        yield 'iframe' => ['<iframe src="javascript:alert(1)"></iframe>'];
+        yield 'object' => ['<object data="javascript:alert(1)"></object>'];
+        yield 'embed' => ['<embed src="data:text/html,<script>alert(1)</script>">'];
+        yield 'body onload' => ['<body onload=alert(1)>'];
+        yield 'a 标签 javascript 协议' => ['<a href="javascript:alert(1)">x</a>'];
+        yield '普通 script' => ['<p>正文</p><script>alert(1)</script>'];
+        yield '单遍剥离后重组成标签' => ['<div><scr<script>ipt>alert(1)</scr</script>ipt></div>'];
+    }
+
+    #[DataProvider('xssPayloadProvider')]
+    public function test_email_html_content_is_stripped_of_executable_vectors(string $payload): void
+    {
+        $sanitized = NotificationTemplateContent::sanitizeForStorage('email', 'content', $payload);
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/<\s*(script|iframe|object|embed|svg|body)\b/i',
+            $sanitized,
+            '危险标签必须被移除：'.$payload
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/\bon[a-z]+\s*=/i',
+            $sanitized,
+            '事件处理器必须被移除：'.$payload
+        );
+        $this->assertStringNotContainsStringIgnoringCase(
+            'javascript:',
+            $sanitized,
+            'javascript: 协议必须被移除：'.$payload
+        );
+    }
+
+    public function test_plain_text_content_is_left_untouched(): void
+    {
+        // 纯文本正文渲染时走 convertPlainTextToHtml()，逐行 htmlspecialchars，本身已安全。
+        // 此处若强行过 HTML 净化器，'&' 会先变 '&amp;'，渲染时再转义成 '&amp;amp;'，
+        // 等于凭空制造双重编码 —— 这条用例就是防止有人"顺手"把它改成一刀切净化。
+        $plain = "尊敬的 {{display_name}}，您的账单金额为 100 元 & 已含税。\n请于 {{due_date}} 前完成支付。";
+
+        $this->assertSame(
+            $plain,
+            NotificationTemplateContent::sanitizeForStorage('email', 'content', $plain)
+        );
+    }
+
+    public function test_subject_is_reduced_to_plain_text(): void
+    {
+        $sanitized = NotificationTemplateContent::sanitizeForStorage(
+            'email',
+            'subject',
+            "【{{site_name}}】<b>验证码</b>邮件\r\nBcc: attacker@example.com"
+        );
+
+        $this->assertStringNotContainsString('<b>', $sanitized, '标题进邮件头，HTML 无正当用途');
+        $this->assertStringNotContainsString("\n", $sanitized, '换行会带来邮件头注入面');
+        $this->assertStringNotContainsString("\r", $sanitized);
+        $this->assertStringContainsString('{{site_name}}', $sanitized, '占位符不能被破坏');
+    }
+
+    public function test_sms_content_is_not_run_through_the_html_sanitizer(): void
+    {
+        // 短信不经 HTML 渲染，过 HTML 净化器只会改动内容而不带来任何安全收益。
+        $sms = '【{{site_name}}】验证码 {{code}}，10 分钟内有效 & 请勿转发。';
+
+        $this->assertSame($sms, NotificationTemplateContent::sanitizeForStorage('sms', 'content', $sms));
+    }
+
+    public function test_other_fields_are_untouched(): void
+    {
+        $value = '<b>provider-template-id</b>';
+
+        $this->assertSame(
+            $value,
+            NotificationTemplateContent::sanitizeForStorage('sms', 'provider_template_id', $value)
+        );
+    }
+
+    /**
+     * 保存侧与渲染侧必须用同一个判断，否则会出现「存时按纯文本放行、渲染时按 HTML
+     * 原样输出」的缝隙 —— 那正是存储型 XSS 的入口。
+     */
+    public function test_html_detection_matches_the_render_side_contract(): void
+    {
+        $this->assertTrue(NotificationTemplateContent::looksLikeHtml('<p>hi</p>'));
+        $this->assertTrue(NotificationTemplateContent::looksLikeHtml('  <!DOCTYPE html><html></html>'));
+        $this->assertTrue(NotificationTemplateContent::looksLikeHtml('文字在前 <div>再有标签</div>'));
+        $this->assertFalse(NotificationTemplateContent::looksLikeHtml('纯文本 {{code}}'));
+        $this->assertFalse(NotificationTemplateContent::looksLikeHtml('价格 < 100 元'));
+        $this->assertFalse(NotificationTemplateContent::looksLikeHtml(''));
+    }
+}

--- a/backend/tests/Unit/NotificationTemplateContentTest.php
+++ b/backend/tests/Unit/NotificationTemplateContentTest.php
@@ -4,77 +4,83 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use App\Support\EmailNotificationTemplateDefaults;
 use App\Support\NotificationTemplateContent;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * 通知模板正文的入库净化。
+ * 通知模板字段的入库净化。
  *
- * 原实现是单遍黑名单 `preg_replace('/<\/?script\b[^>]*>/iu', '', $value)`，注释却声称会
- * 移除 script/iframe/object/embed 与事件处理器。本地实测 9 个常见载荷放行 8 个，且
- * `<scr<script>ipt>` 剥掉内层后会**重组出**可执行标签 —— 净化反而使情况变坏。
- * 本用例把当时那批载荷逐条钉死，并锁住「纯文本不动、HTML 才净化」的口径。
+ * 这批用例锁的是两件事：subject 必须降为纯文本；正文必须**原样入库**。
+ * 后者不是"没做净化"，而是刻意的——论证见 NotificationTemplateContent 的类注释。
  */
 class NotificationTemplateContentTest extends TestCase
 {
     /**
-     * 当年逐条实测绕过原黑名单的载荷，全部必须被白名单净化挡下。
+     * 默认邮件模板必须一字不改地入库。
      *
-     * @return iterable<string, array{string}>
+     * 这是本文件最重要的一条。它们是带 <style> 的完整 HTML 文档，一旦有人"顺手"把正文
+     * 接上 RichHtmlSanitizer，7536 字节会只剩 1898：doctype/html/head/body 被剥壳、
+     * 整段 CSS 被丢弃、table 排版属性被清空，管理员保存一次就毁掉整套邮件排版。
+     * 这条用例就是拦这个的。
      */
-    public static function xssPayloadProvider(): iterable
+    public function test_default_email_templates_survive_storage_unchanged(): void
     {
-        yield '事件处理器' => ['<img src=x onerror=alert(document.cookie)>'];
-        yield 'SVG 事件' => ['<svg onload=alert(1)>'];
-        yield 'iframe' => ['<iframe src="javascript:alert(1)"></iframe>'];
-        yield 'object' => ['<object data="javascript:alert(1)"></object>'];
-        yield 'embed' => ['<embed src="data:text/html,<script>alert(1)</script>">'];
-        yield 'body onload' => ['<body onload=alert(1)>'];
-        yield 'a 标签 javascript 协议' => ['<a href="javascript:alert(1)">x</a>'];
-        yield '普通 script' => ['<p>正文</p><script>alert(1)</script>'];
-        yield '单遍剥离后重组成标签' => ['<div><scr<script>ipt>alert(1)</scr</script>ipt></div>'];
+        $templates = EmailNotificationTemplateDefaults::templates();
+
+        $this->assertNotEmpty($templates, '默认邮件模板不应为空，否则本用例形同虚设');
+
+        foreach ($templates as $template) {
+            $content = (string) ($template['content'] ?? '');
+            $code = (string) ($template['code'] ?? '?');
+
+            $this->assertSame(
+                $content,
+                NotificationTemplateContent::sanitizeForStorage('content', $content),
+                "默认邮件模板 {$code} 的正文被入库净化改动了"
+            );
+        }
     }
 
-    #[DataProvider('xssPayloadProvider')]
-    public function test_email_html_content_is_stripped_of_executable_vectors(string $payload): void
+    /**
+     * 带 <style> 的自定义正文同样原样入库。
+     *
+     * 取值与 Feature 层 test_admin_notification_email_template_save_... 保存的内容一致，
+     * 那条用例断言的正是 assertSame($newContent, $template->content)。
+     */
+    public function test_custom_html_content_with_style_block_is_stored_verbatim(): void
     {
-        $sanitized = NotificationTemplateContent::sanitizeForStorage('email', 'content', $payload);
+        $content = '<style>.email-test-code { color: #1f5eff; font-weight: 700; }</style>'
+            .'<div class="email-test-code">{{code}}</div>';
 
-        $this->assertDoesNotMatchRegularExpression(
-            '/<\s*(script|iframe|object|embed|svg|body)\b/i',
-            $sanitized,
-            '危险标签必须被移除：'.$payload
-        );
-        $this->assertDoesNotMatchRegularExpression(
-            '/\bon[a-z]+\s*=/i',
-            $sanitized,
-            '事件处理器必须被移除：'.$payload
-        );
-        $this->assertStringNotContainsStringIgnoringCase(
-            'javascript:',
-            $sanitized,
-            'javascript: 协议必须被移除：'.$payload
-        );
+        $this->assertSame($content, NotificationTemplateContent::sanitizeForStorage('content', $content));
     }
 
-    public function test_plain_text_content_is_left_untouched(): void
+    /**
+     * 纯文本、短信正文、以及 subject/content 之外的字段，一律不动。
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function untouchedFieldProvider(): iterable
     {
-        // 纯文本正文渲染时走 convertPlainTextToHtml()，逐行 htmlspecialchars，本身已安全。
-        // 此处若强行过 HTML 净化器，'&' 会先变 '&amp;'，渲染时再转义成 '&amp;amp;'，
-        // 等于凭空制造双重编码 —— 这条用例就是防止有人"顺手"把它改成一刀切净化。
-        $plain = "尊敬的 {{display_name}}，您的账单金额为 100 元 & 已含税。\n请于 {{due_date}} 前完成支付。";
+        // 纯文本正文渲染时走 convertPlainTextToHtml() 逐行 htmlspecialchars，本身已安全；
+        // 此处若过一遍 HTML 净化器，'&' 会先变 '&amp;'，渲染时再转义成 '&amp;amp;'。
+        yield '纯文本正文' => ['content', "尊敬的 {{display_name}}，账单金额 100 元 & 已含税。\n请于 {{due_date}} 前支付。"];
+        yield '短信正文' => ['content', '【{{site_name}}】验证码 {{code}}，10 分钟内有效 & 请勿转发。'];
+        yield '短信模板号' => ['provider_template_id', 'SMS_DB_VERIFY'];
+        yield '带尖括号的普通文案' => ['content', '价格 < 100 元时享受折扣 > 8 折'];
+    }
 
-        $this->assertSame(
-            $plain,
-            NotificationTemplateContent::sanitizeForStorage('email', 'content', $plain)
-        );
+    #[DataProvider('untouchedFieldProvider')]
+    public function test_non_subject_fields_are_left_untouched(string $field, string $value): void
+    {
+        $this->assertSame($value, NotificationTemplateContent::sanitizeForStorage($field, $value));
     }
 
     public function test_subject_is_reduced_to_plain_text(): void
     {
         $sanitized = NotificationTemplateContent::sanitizeForStorage(
-            'email',
             'subject',
             "【{{site_name}}】<b>验证码</b>邮件\r\nBcc: attacker@example.com"
         );
@@ -85,35 +91,13 @@ class NotificationTemplateContentTest extends TestCase
         $this->assertStringContainsString('{{site_name}}', $sanitized, '占位符不能被破坏');
     }
 
-    public function test_sms_content_is_not_run_through_the_html_sanitizer(): void
-    {
-        // 短信不经 HTML 渲染，过 HTML 净化器只会改动内容而不带来任何安全收益。
-        $sms = '【{{site_name}}】验证码 {{code}}，10 分钟内有效 & 请勿转发。';
-
-        $this->assertSame($sms, NotificationTemplateContent::sanitizeForStorage('sms', 'content', $sms));
-    }
-
-    public function test_other_fields_are_untouched(): void
-    {
-        $value = '<b>provider-template-id</b>';
-
-        $this->assertSame(
-            $value,
-            NotificationTemplateContent::sanitizeForStorage('sms', 'provider_template_id', $value)
-        );
-    }
-
     /**
-     * 保存侧与渲染侧必须用同一个判断，否则会出现「存时按纯文本放行、渲染时按 HTML
-     * 原样输出」的缝隙 —— 那正是存储型 XSS 的入口。
+     * 现有 Feature 用例保存的普通标题不能被净化改动，否则那条断言会转红。
      */
-    public function test_html_detection_matches_the_render_side_contract(): void
+    public function test_ordinary_subject_is_not_altered(): void
     {
-        $this->assertTrue(NotificationTemplateContent::looksLikeHtml('<p>hi</p>'));
-        $this->assertTrue(NotificationTemplateContent::looksLikeHtml('  <!DOCTYPE html><html></html>'));
-        $this->assertTrue(NotificationTemplateContent::looksLikeHtml('文字在前 <div>再有标签</div>'));
-        $this->assertFalse(NotificationTemplateContent::looksLikeHtml('纯文本 {{code}}'));
-        $this->assertFalse(NotificationTemplateContent::looksLikeHtml('价格 < 100 元'));
-        $this->assertFalse(NotificationTemplateContent::looksLikeHtml(''));
+        $subject = '后台保存验证码邮件';
+
+        $this->assertSame($subject, NotificationTemplateContent::sanitizeForStorage('subject', $subject));
     }
 }

--- a/frontend-admin-v3/eslint.config.js
+++ b/frontend-admin-v3/eslint.config.js
@@ -122,7 +122,9 @@ export default antfu(
         ],
         'vue/multi-word-component-names': 'off',
         'vue/no-reserved-props': 'off',
-        'vue/no-v-html': 'off',
+        // v-html 是前端唯一的存储型 XSS 入口，必须逐处审阅而不是全局放行。
+      // 正当使用需就地写 eslint-disable-next-line 并说明内容经过了哪个白名单净化器。
+      'vue/no-v-html': 'error',
 
         'vue-scoped-css/no-parsing-error': 'off',
         'vue-scoped-css/no-unused-selector': 'off',

--- a/frontend-user-v3-www/eslint.config.js
+++ b/frontend-user-v3-www/eslint.config.js
@@ -81,7 +81,9 @@ export default [
         },
       ],
       'vue/multi-word-component-names': 'off',
-      'vue/no-v-html': 'off',
+      // v-html 是前端唯一的存储型 XSS 入口，必须逐处审阅而不是全局放行。
+      // 正当使用需就地写 eslint-disable-next-line 并说明内容经过了哪个白名单净化器。
+      'vue/no-v-html': 'error',
     },
   },
 ];

--- a/frontend-user-v3-www/src/views/website/content/ContentDetailPage.vue
+++ b/frontend-user-v3-www/src/views/website/content/ContentDetailPage.vue
@@ -46,13 +46,8 @@
             <!-- articleContentHtml 由 renderMarkdown() 产出，最后一步是 sanitizeRenderedHtml()
                  （shared/htmlSanitizer.js 的 DOM 白名单：标签、属性、URL 协议三层），
                  且渲染器重写了 validateLink 拦掉 javascript:/vbscript:/data: 协议。 -->
-            <!-- eslint-disable vue/no-v-html -- 内容已过 sanitizeRenderedHtml 白名单净化 -->
-            <div
-              ref="contentRef"
-              class="reader-content"
-              v-html="articleContentHtml"
-            />
-            <!-- eslint-enable vue/no-v-html -->
+            <!-- eslint-disable-next-line vue/no-v-html -- 内容已过 sanitizeRenderedHtml 白名单净化 -->
+            <div ref="contentRef" class="reader-content" v-html="articleContentHtml" />
           </template>
 
           <el-empty v-else-if="!loading" :description="config.emptyText" class="reader-empty" />

--- a/frontend-user-v3-www/src/views/website/content/ContentDetailPage.vue
+++ b/frontend-user-v3-www/src/views/website/content/ContentDetailPage.vue
@@ -43,11 +43,16 @@
           <template v-else-if="currentArticle">
             <el-divider />
 
+            <!-- articleContentHtml 由 renderMarkdown() 产出，最后一步是 sanitizeRenderedHtml()
+                 （shared/htmlSanitizer.js 的 DOM 白名单：标签、属性、URL 协议三层），
+                 且渲染器重写了 validateLink 拦掉 javascript:/vbscript:/data: 协议。 -->
+            <!-- eslint-disable vue/no-v-html -- 内容已过 sanitizeRenderedHtml 白名单净化 -->
             <div
               ref="contentRef"
               class="reader-content"
               v-html="articleContentHtml"
             />
+            <!-- eslint-enable vue/no-v-html -->
           </template>
 
           <el-empty v-else-if="!loading" :description="config.emptyText" class="reader-empty" />

--- a/frontend-user-v4-console/eslint.config.js
+++ b/frontend-user-v4-console/eslint.config.js
@@ -123,7 +123,9 @@ export default antfu(
         ],
         'vue/multi-word-component-names': 'off',
         'vue/no-reserved-props': 'off',
-        'vue/no-v-html': 'off',
+        // v-html 是前端唯一的存储型 XSS 入口，必须逐处审阅而不是全局放行。
+      // 正当使用需就地写 eslint-disable-next-line 并说明内容经过了哪个白名单净化器。
+      'vue/no-v-html': 'error',
 
         'vue-scoped-css/no-parsing-error': 'off',
         'vue-scoped-css/no-unused-selector': 'off',

--- a/frontend-user-v4-console/src/pages/client/content-detail/ContentDetailPage.vue
+++ b/frontend-user-v4-console/src/pages/client/content-detail/ContentDetailPage.vue
@@ -23,6 +23,10 @@
               </header>
 
               <t-divider v-if="currentArticle" />
+              <!-- articleContentHtml 由 renderMarkdown() 产出，最后一步是 sanitizeRenderedHtml()
+                   （shared/htmlSanitizer.js 的 DOM 白名单：标签、属性、URL 协议三层），
+                   且渲染器重写了 validateLink 拦掉 javascript:/vbscript:/data: 协议。 -->
+              <!-- eslint-disable-next-line vue/no-v-html -- 内容已过 sanitizeRenderedHtml 白名单净化 -->
               <div ref="contentRef" class="reader-content" v-html="articleContentHtml"></div>
             </article>
           </data-state>

--- a/shared/eslint.config.js
+++ b/shared/eslint.config.js
@@ -74,7 +74,10 @@ export default [
         },
       ],
       'vue/multi-word-component-names': 'off',
-      'vue/no-v-html': 'off',
+      // v-html 是前端唯一的存储型 XSS 入口，必须逐处审阅而不是全局放行。
+      // 现有两处正当使用（文章详情页）已就地标注豁免与理由；新增的一律会被拦下，
+      // 迫使作者说明内容为何可信、经过了哪个白名单净化器。
+      'vue/no-v-html': 'error',
     },
   },
 ];


### PR DESCRIPTION
## 背景

上一轮安全审查在"WAF 之外仍散落着自己写的反 XSS 代码"这一项下留了 3 处未处理。本 PR 把它们处理掉。

需要先说清一件事，因为它决定了修复放在哪里：**`App\Support\Waf` 是入站层，按设计管不到这三处。** `config/waf.php:16,24` 里写明 XSS 净化委托给 `RichHtmlSanitizer`；WAF 做的是 Firewall 正则载荷匹配 + KeySanitizer 请求键名净化，面向"请求进来的那一刻"。而这三处分别发生在**入库时**、**出库时**和**渲染时**，塞进入站 WAF 只会造出第二套判断。

> **本 PR 经过一次重要的方向修正**（`90583e3` → `20d00e5`）。初版把通知模板正文接上了 `RichHtmlSanitizer`；顺着 CodeRabbit 的评审核实下去，实测发现那样会**毁掉邮件模板**。详见 §1。评审记录留在 PR 讨论里没有折叠，因为其中的教训比结论更值钱。

## 三处问题与修法

### 1. 通知模板：删掉一个会自己制造危险的"净化器"

`NotificationTemplateService::sanitizeTemplateField()` 的注释声称"移除 script/iframe/object/embed 标签和事件处理器"，实现却只有一句：

```php
return preg_replace('/<\/?script\b[^>]*>/iu', '', $value);
```

即只删 `<script>` 开闭标签。9 个常见载荷实测**放行 8 个**（`<img onerror>`、`<svg onload>`、`<iframe>`、`<object>`、`<embed>`、`<body onload>`、`<a href="javascript:">` 全部原样通过）。更严重的是：

```
输入： <div><scr<script>ipt>alert(1)</scr</script>ipt></div>
输出： <div><script>alert(1)</script></div>
```

剥掉内层之后，外层残片**重组出**了一个可执行标签 —— 净化这一步本身制造了漏洞。这是单遍黑名单剥离的固有缺陷。

#### 换成白名单是用错工具（初版的 bug）

初版把正文改成过 `RichHtmlSanitizer`。实测默认邮件模板（`EmailNotificationTemplateDefaults`，`code=100001`）：

```
原始长度 = 7536, 净化后长度 = 1898
  <!doctype    原始:1  净化后:0   <== 丢失
  <html/<head/<body                <== 全部被剥壳
  <style       原始:1  净化后:0   <== 连同整段 CSS 丢弃（在 DROP_TAGS 里）
  cellpadding  原始:5  净化后:0   <== 不在 ALLOWED_ATTRS
  cellspacing  原始:5  净化后:0
  {{           原始:8  净化后:7   <== 一个占位符跟着 <style> 没了
```

管理员保存一次模板，整套邮件排版就废了。根因是 `RichHtmlSanitizer` 是**文章正文**净化器（安全标签 + 安全属性白名单），而邮件模板是**带 CSS 的完整 HTML 文档** —— 不是白名单开小了。

#### 这个字段确实不需要 HTML 净化

可达性逐条核过：

- 写入侧是管理员路由（`routes/v2-admin.php`，`settings.manage`）。
- `renderTemplateContent()` 全仓**只有一个调用点**（`NotificationService.php:162`），通向 `buildTemplateEmailHtml()` → `sendEmail()`，只进邮件客户端。
- 模板表只有 `email` / `sms` 两个渠道，没有站内信复用。
- 管理端前端 `v-html` 命中数为 **0**，也没有返回 HTML 的预览端点（`test-send` 是真发邮件）。

不存在浏览器同源渲染面，邮件客户端又不执行脚本。

#### 最终修法

| 字段 | 处理 | 理由 |
|---|---|---|
| `subject` | `TextSanitizer::clean()` | 进邮件头，HTML 无正当用途；顺带折叠换行。渲染侧也剥 CRLF，此处是纵深防御 |
| 正文（email / sms） | **原样入库** | 见上 |
| 其它字段 | 原样入库 | |

**这不是退回原状**：原实现会凭空造出可执行的 `<script>`，对这个字段而言不动比那样动严格更安全。

论证集中写在 `App\Support\NotificationTemplateContent` 的类注释里 —— 单独成类是为了让这条决策**可被测试**（调用方是私有方法）。若将来正文出现浏览器渲染面（站内信、后台预览），需要的是**邮件专用**净化器：保留文档结构与 table 排版属性、并额外净化 CSS，而不是改成调用 `RichHtmlSanitizer`。

> 初版还提取了 `looksLikeHtml()`，理由是"消除保存侧与渲染侧的重复判断"。核实后撤回：`main` 上它只有一处私有实现、两个内部调用，**并不存在重复** —— 重复是被否决的那版设计自己造出来的。`NotificationService.php` 已整条还原，本 PR 不再触碰它。

### 2. 附件出站：`image/` 前缀会放行 SVG

`SecureAssetController` 原先用 `str_starts_with($mime, 'image/')` 判定可返回的资源。`image/svg+xml` 匹配这个前缀，而 SVG 是可内嵌 `<script>` 与事件属性的 XML 文档；以 inline 方式返回时浏览器会把它当文档渲染并**在本站源执行脚本**。`nosniff` 拦不住 —— MIME 本来就是 `image/svg+xml`，不涉及嗅探。

修法：新增 `App\Support\MediaAssetTypes` 统一 MIME 白名单，控制器改用 `isAllowedImageMimeType()`（jpeg / png / webp）。`StoreMediaFileRequest` 的上传校验也改用同一份常量 —— 它原先内联的 `ALLOWED_MIME_TYPES` 与新常量逐项相同，这一步是纯提取、不改行为。

选这三种不是随手定的。`SecureAssetController` 经 `SecureAsset::ALLOWED_PREFIXES` 服务的是**工单附件**与**返佣支付宝截图**（不是媒体库），逐一核对写入侧：

| 写入路径 | 类型控制 |
|---|---|
| `UploadImageRequest` / `UploadTicketImageRequest` | `mimetypes:image/jpeg,image/png,image/webp` |
| `TicketUpstreamCallbackService::normalizeInboundAttachments()`（上游拉取，不经 FormRequest） | 落盘后 `File::mimeType()` 硬校验同样三种 |
| `referral/alipay/` | **代码中已无任何写入点**，仅存读取兼容 |

即当前代码能产生的附件只有这三种，白名单与之完全吻合。

残留风险已知并披露：`referral/alipay/` 既然只剩读取兼容，其中若有从旧系统迁移来的历史文件（如 GIF），本次会从"能取出"变成 404。线上测试镜像上这四个目录均不存在（实测），真实生产的存量我没有访问权限，无从证伪。若日后确认存在此类惰性图片，把类型补进读取侧白名单是零安全代价的一行改动 —— `image/gif` 不可内嵌脚本，与本次要挡的 `image/svg+xml` 性质不同。

### 3. 前端 `v-html`：把豁免从全局降到逐处

4 个 eslint 配置里 `vue/no-v-html` 都是 `'off'` —— 等于全局放行前端唯一的存储型 XSS 入口。改为 `'error'`。

现存两处正当使用（文章详情页，内容已过 `sanitizeRenderedHtml` 白名单）就地标注 `eslint-disable-next-line` 与理由。此后新增的 `v-html` 一律会被拦下，迫使作者说明内容为何可信、过了哪个净化器。

> 两点实测结论：
> - 这 4 个配置文件必须都改。两处 `v-html` 分别位于 `frontend-user-v3-www` 和 `frontend-user-v4-console`，它们各有自己的 eslint 配置，只改 `shared/` 不生效。
> - `disable-next-line` 只覆盖紧邻的下一行，而多行元素的报错落在 **`v-html` 属性所在行**，不是开标签行。所以 www 那处的元素同时收成了单行 —— 否则豁免覆盖不到，lint 会红。指令也必须位于注释开头，写在说明文字之后不生效。

## 验证

**本地**

- 新增 8 条用例（`NotificationTemplateContentTest`）全绿，42 断言。
- 反向验证：把被否决的 `RichHtmlSanitizer` 写法注入回去，**8 条中 5 条转红**，其中排第一的正是"全部默认模板必须原样入库"那条守卫 —— 它就是为了拦住初版那个 bug 加的。
- Pint 通过。
- eslint：改动后两处 `v-html` 退出码 0；再插一个未标注的 `v-html` 探针，仍被拦下（`51:32 error 'v-html' directive can lead to XSS attack`），确认规则是活的、不是被豁免范围吞掉的。

**服务器**（`43.255.122.113`，MySQL 5.7.44 沙箱 @3307，隔离工作树 `/root/jwt-tree` + 独立库 `idc_test_jwt`）

| | Tests | Assertions | Errors | Failures | 失败集合 |
|---|---|---|---|---|---|
| 基底 `ac32241` | 1681 | 84800 | 32 | 64 | 96 条 |
| 本 PR | 1689 | 84842 | 32 | 64 | 96 条 |

- junit 失败集合逐条差分：**only-in-补丁 = 0**（无新增回归），only-in-基底 = 0。
- 差值恰为 **+8 用例 / +42 断言**，与新增测试完全对应，说明补丁没有改变任何既有用例的执行路径。
- PHPStan 受控 A/B：基底 25 个错误，补丁后 25 个，逐行 diff 为空。

**一个必须披露的验证盲区**

`NotificationTemplateApiTest::test_admin_notification_email_template_save_writes_database_template_instead_of_settings` 保存的正是含 `<style>` 的内容，并断言 `assertSame($newContent, $template->content)` —— 它**本该第一时间抓到初版那个 bug**。但它在基底就已经是红的（属于 96 条既有失败），所以失败集合差分对它完全失明：红着进、红着出。

进一步查明它红在 setup 阶段：

```
ModelNotFoundException: No query results for model [App\Models\NotificationTemplate]
  at NotificationTemplateApiTest.php:791  ← notificationTemplate() 取不到种子模板
  at NotificationTemplateApiTest.php:549
```

即根本没跑到那行断言。**差分法只能发现"绿转红"，发现不了"本就红的变得更红"** —— 这个盲区与本 PR 无关（是测试树的种子问题），但值得记一笔。本 PR 新加的 Unit 守卫不依赖数据库，正好补上这一段。

## 影响面

- 数据库：无迁移、无 schema 变更。
- 通知模板：正文的入库行为**回到"不改动"**（此前会被那条 `<script>` 正则改动）。`subject` 会被降为纯文本，这是新增的收紧。
- `SecureAssetController` 收紧为三种 MIME 白名单，非白名单资源返回 404。所有现存写入侧本就只产出这三种（见 §2 表），故对当前代码产生的数据无影响；历史迁移存量的残留风险见 §2。
