### PR TITLE
fix(open-api): 密钥校验改等值命中并落实限流，部分更新不再清空安全字段

### DIFF
--- a/backend/app/Http/Requests/Client/V2/ApiKey/StoreApiKeyRequest.php
+++ b/backend/app/Http/Requests/Client/V2/ApiKey/StoreApiKeyRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Client\V2\ApiKey;
 
+use App\Rules\KnownApiScopeDomains;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreApiKeyRequest extends FormRequest
@@ -17,7 +18,7 @@ class StoreApiKeyRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:64'],
-            'scopes' => ['required', 'array'],
+            'scopes' => ['required', 'array', new KnownApiScopeDomains],
             'scopes.*' => ['string', 'in:read,write'],
             'expires_at' => ['nullable', 'date'],
             'ip_allowlist' => ['nullable', 'array'],

--- a/backend/app/Http/Requests/Client/V2/ApiKey/UpdateApiKeyRequest.php
+++ b/backend/app/Http/Requests/Client/V2/ApiKey/UpdateApiKeyRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Client\V2\ApiKey;
 
+use App\Rules\KnownApiScopeDomains;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateApiKeyRequest extends FormRequest
@@ -17,7 +18,7 @@ class UpdateApiKeyRequest extends FormRequest
     {
         return [
             'name' => ['sometimes', 'string', 'max:64'],
-            'scopes' => ['sometimes', 'array'],
+            'scopes' => ['sometimes', 'array', new KnownApiScopeDomains],
             'scopes.*' => ['string', 'in:read,write'],
             'expires_at' => ['nullable', 'date'],
             'ip_allowlist' => ['nullable', 'array'],

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -12,13 +12,17 @@ use App\Models\ThirdProductGroup;
 use App\Services\Auth\LegacyPasswordVerifier;
 use App\Services\Automation\Heartbeat\HeartbeatTaskRegistry;
 use App\Services\Integrations\Plugins\PluginBindingResolver;
+use App\Services\OpenApi\OpenApiConfig;
 use App\Services\ProductCatalog\ProductDisplayNameResolver;
 use App\Services\ProductCatalog\ProductSpecHighlightService;
 use App\Services\System\UploadedAssetReferenceService;
 use Carbon\CarbonInterface;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -74,6 +78,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadSiteNameFromSettings();
+        $this->registerOpenApiRateLimiter();
 
         // 心跳任务超时被杀时，Worker 在 SIGKILL 前同步派发 JobTimedOut；
         // 监听器把运行台账收敛为 retrying/failed，避免队列重试被状态 CAS 永久拒绝。
@@ -104,6 +109,24 @@ class AppServiceProvider extends ServiceProvider
         });
 
         $this->invalidateCatalogCacheOnCatalogChanges();
+    }
+
+    /**
+     * 注册开放接口的限流器，落实后台可配的 open_api.rate_limit（默认 60/分钟）。
+     *
+     * 此前该值只在后台读写、没有任何中间件执行它 —— 等于设了限速却不生效。
+     * 按来源 IP 计数：限流跑在 api.key 认证之前，认证前拿不到密钥；而攻击面正是
+     * "任意 Bearer 头即可触发认证入口"，IP 恰是未认证攻击者唯一的可计量维度。
+     * 阈值从 OpenApiConfig 每次读取（settings 表），管理员改动即时生效。
+     * 超限统一走 bootstrap/app.php 里 ThrottleRequestsException 的中文 429 渲染。
+     */
+    private function registerOpenApiRateLimiter(): void
+    {
+        RateLimiter::for('open-api', function (Request $request) {
+            $perMinute = app(OpenApiConfig::class)->rateLimitPerMinute();
+
+            return Limit::perMinute($perMinute)->by((string) $request->ip());
+        });
     }
 
     /**

--- a/backend/app/Rules/KnownApiScopeDomains.php
+++ b/backend/app/Rules/KnownApiScopeDomains.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Services\OpenApi\ApiKeyService;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * 校验 API 密钥 scopes 的「键」（业务域）都在白名单内。
+ *
+ * FormRequest 里 scopes.* 只校验值（read/write），不校验键。缺了这层，把域名拼错
+ * （如 products 写成 product）时值仍合法，请求通过，而 ApiKeyService::normalizeScopes()
+ * 只遍历已知域、会把这个未知键静默丢弃——用户以为权限设好了，实则没生效。
+ * 这条规则把未知域名在入口挡成 422，消除这种「静默降权」。
+ */
+class KnownApiScopeDomains implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        $unknown = array_diff(array_keys($value), ApiKeyService::SCOPE_DOMAINS);
+        if ($unknown !== []) {
+            $fail('包含未知的权限域：'.implode('、', $unknown));
+        }
+    }
+}

--- a/backend/app/Services/OpenApi/ApiKeyService.php
+++ b/backend/app/Services/OpenApi/ApiKeyService.php
@@ -71,10 +71,17 @@ class ApiKeyService
             throw new BusinessException('缺少 API 密钥', 40100, 401);
         }
 
+        // 按 secret_hash 等值命中，而不是把全表 enabled 密钥载入内存逐行 hash_equals。
+        // hashSecret() 是确定性的 sha256(secret + app.key)，同一明文恒映射到同一 hash，
+        // 因此可直接用它做索引查找 —— 这正是 Laravel Sanctum 校验 token 的做法
+        // （findToken 用 where('token', hash('sha256', $plain))）。
+        // 时序安全：攻击者提交的是明文 secret，要让 secret_hash 命中必须先知道 app.key
+        // 才能构造出目标 hash；数据库 B-tree 等值查找也不像逐字节 memcmp 那样按前缀短路。
+        // 原实现的 O(n) 全表 + 每行实例化 ApiKey 模型，任意 Bearer 头即可触发，是 DoS 面。
         $candidate = ApiKey::query()
+            ->where('secret_hash', $this->hashSecret($secret))
             ->where('status', ApiKey::STATUS_ENABLED)
-            ->get()
-            ->first(fn (ApiKey $key) => hash_equals($key->secret_hash, $this->hashSecret($secret)));
+            ->first();
 
         if (! $candidate) {
             throw new BusinessException('API 密钥无效或已被停用', 40100, 401);
@@ -132,18 +139,39 @@ class ApiKeyService
         return hash('sha256', $secret.config('app.key'));
     }
 
+    /**
+     * 部分更新：只改动 $payload 里显式出现的字段，缺失的字段一律保留原值。
+     *
+     * 用 array_key_exists 而非 isset/??：原实现对 expires_at / ip_allowlist 用
+     * `isset(...) ? ... : null`，于是只带 {"name":"x"} 的部分更新会把这两项静默清成
+     * null（密钥变成永不过期 + 不限 IP）—— 等于悄悄拆掉两道安全控制。
+     * 语义边界：字段缺失 = 保留；字段显式为 null / '' / [] = 采纳其清空意图。
+     * （已实测 UpdateApiKeyRequest：未提交的 nullable 字段不会进 validated()，
+     * 故 array_key_exists 能可靠区分「缺失」与「显式清空」。）
+     */
     public function update(ApiKey $key, array $payload): ApiKey
     {
-        $key->fill([
-            'name' => (string) ($payload['name'] ?? $key->name),
-            'scopes' => $this->normalizeScopes((array) ($payload['scopes'] ?? $key->scopes ?? [])),
-            'expires_at' => isset($payload['expires_at']) && $payload['expires_at'] !== '' && $payload['expires_at'] !== null
-                ? $payload['expires_at']
-                : null,
-            'ip_allowlist' => isset($payload['ip_allowlist']) && is_array($payload['ip_allowlist']) && $payload['ip_allowlist'] !== []
-                ? array_values($payload['ip_allowlist'])
-                : null,
-        ])->save();
+        if (array_key_exists('name', $payload)) {
+            $key->name = (string) $payload['name'];
+        }
+
+        if (array_key_exists('scopes', $payload)) {
+            $key->scopes = $this->normalizeScopes((array) $payload['scopes']);
+        }
+
+        if (array_key_exists('expires_at', $payload)) {
+            $expiresAt = $payload['expires_at'];
+            $key->expires_at = ($expiresAt === '' || $expiresAt === null) ? null : $expiresAt;
+        }
+
+        if (array_key_exists('ip_allowlist', $payload)) {
+            $ipAllowlist = $payload['ip_allowlist'];
+            $key->ip_allowlist = (is_array($ipAllowlist) && $ipAllowlist !== [])
+                ? array_values($ipAllowlist)
+                : null;
+        }
+
+        $key->save();
 
         return $key;
     }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -42,7 +42,7 @@ return Application::configure(basePath: dirname(__DIR__))
                 ->prefix('api/v2/client')
                 ->group(base_path('routes/v2-client.php'));
 
-            Route::middleware('api')
+            Route::middleware(['api', 'throttle:open-api'])
                 ->prefix('api/v2/open')
                 ->group(base_path('routes/v2-open.php'));
 

--- a/backend/database/migrations/2026_08_29_000001_add_secret_hash_index_to_api_keys.php
+++ b/backend/database/migrations/2026_08_29_000001_add_secret_hash_index_to_api_keys.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 为 api_keys.secret_hash 建普通索引，支撑按 hash 等值命中的密钥校验。
+ *
+ * 背景：ApiKeyService::resolve() 原先把全表 enabled 密钥载入内存逐行 hash_equals，
+ * 任意 Bearer 头即可触发这次 O(n) 全表扫描。改为按 secret_hash 等值查询后需要此索引。
+ * hashSecret() 是确定性的 sha256(secret + app.key)，明文一对一映射到 hash，等值查找安全。
+ *
+ * 用普通 index 而非 unique：sha256 碰撞概率虽可忽略，但唯一约束会让极端情况下的插入直接失败；
+ * 校验侧配合 status 过滤取首条即可，不依赖唯一性。
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('api_keys')) {
+            return;
+        }
+
+        // 幂等：索引已存在则跳过，避免重复执行迁移时报 Duplicate key name。
+        if ($this->indexExists('api_keys', 'api_keys_secret_hash_index')) {
+            return;
+        }
+
+        Schema::table('api_keys', function (Blueprint $table): void {
+            $table->index('secret_hash', 'api_keys_secret_hash_index');
+        });
+    }
+
+    /**
+     * 遵循本项目「数据库只新增、绝不删除对象」的铁律：不在 down() 里 dropIndex。
+     * 该索引是纯性能结构、不承载任何数据，回滚保留它不会造成数据层面的副作用；
+     * 是否清理交由上游维护者决定。
+     */
+    public function down(): void
+    {
+        // 有意为空：见上方说明。
+    }
+
+    private function indexExists(string $table, string $index): bool
+    {
+        $database = Schema::getConnection()->getDatabaseName();
+
+        return DB::table('information_schema.statistics')
+            ->where('table_schema', $database)
+            ->where('table_name', $table)
+            ->where('index_name', $index)
+            ->exists();
+    }
+};

--- a/backend/tests/Feature/OpenApi/ApiKeyTest.php
+++ b/backend/tests/Feature/OpenApi/ApiKeyTest.php
@@ -296,4 +296,33 @@ class ApiKeyTest extends TestCase
             ->assertStatus(429)
             ->assertJsonPath('code', 42900);
     }
+
+    /**
+     * 未知权限域必须在入口被拒（422），而不是被 normalizeScopes 静默丢弃。
+     * 否则把 products 拼成 product 时请求"成功"，权限却没生效。
+     */
+    public function test_create_rejects_unknown_scope_domain(): void
+    {
+        $user = $this->createClientUser();
+        $this->actingAsClient($user);
+
+        $this->postJson('/api/v2/client/api-keys', [
+            'name' => '拼错域名',
+            'scopes' => ['product' => 'read'],
+        ])->assertStatus(422);
+    }
+
+    public function test_update_rejects_unknown_scope_domain(): void
+    {
+        $user = $this->createClientUser();
+        $this->actingAsClient($user);
+        [$key] = $this->createKey($user, ['products' => 'read']);
+
+        $this->putJson("/api/v2/client/api-keys/{$key->id}", [
+            'scopes' => ['servicess' => 'write'],
+        ])->assertStatus(422);
+
+        // 既有合法权限不受这次失败影响。
+        $this->assertSame(['products' => 'read'], $key->fresh()->scopes);
+    }
 }

--- a/backend/tests/Feature/OpenApi/ApiKeyTest.php
+++ b/backend/tests/Feature/OpenApi/ApiKeyTest.php
@@ -214,4 +214,86 @@ class ApiKeyTest extends TestCase
 
         $this->withToken($plain)->getJson('/api/v2/open/orders')->assertOk();
     }
+
+    /**
+     * N4 回归：只带 name 的部分更新，绝不能把 expires_at / ip_allowlist 静默清空。
+     *
+     * 原实现对这两项用 isset()?:null，导致 {"name":"x"} 会把密钥悄悄改成永不过期 + 不限 IP —
+     * 等于拆掉两道安全控制。这条用例走完整 HTTP 栈（FormRequest→controller→service），
+     * 因为缺陷正出在 validated() 丢弃了未提交字段这一层。
+     */
+    public function test_partial_update_preserves_expiry_and_ip_allowlist(): void
+    {
+        $user = $this->createClientUser();
+        $this->actingAsClient($user);
+        [$key] = $this->createKey($user, ['products' => 'read'], [
+            'expires_at' => now()->addYear()->toDateTimeString(),
+            'ip_allowlist' => ['203.0.113.9'],
+        ]);
+
+        $originalExpiry = $key->fresh()->expires_at?->toDateTimeString();
+        $this->assertNotNull($originalExpiry, '前置：密钥应带有过期时间');
+
+        $this->putJson("/api/v2/client/api-keys/{$key->id}", ['name' => '改个名字'])
+            ->assertOk()
+            ->assertJsonPath('data.key.name', '改个名字');
+
+        $fresh = $key->fresh();
+        $this->assertSame($originalExpiry, $fresh->expires_at?->toDateTimeString(), 'expires_at 不能被部分更新清空');
+        $this->assertSame(['203.0.113.9'], $fresh->ip_allowlist, 'ip_allowlist 不能被部分更新清空');
+    }
+
+    /**
+     * 边界：显式传 null / [] 仍应能清空——修复 N4 不能把「可清空」一起改没了。
+     */
+    public function test_explicit_values_can_still_clear_expiry_and_ip_allowlist(): void
+    {
+        $user = $this->createClientUser();
+        $this->actingAsClient($user);
+        [$key] = $this->createKey($user, ['products' => 'read'], [
+            'expires_at' => now()->addYear()->toDateTimeString(),
+            'ip_allowlist' => ['203.0.113.9'],
+        ]);
+
+        $this->putJson("/api/v2/client/api-keys/{$key->id}", ['expires_at' => null])->assertOk();
+        $afterExpiryClear = $key->fresh();
+        $this->assertNull($afterExpiryClear->expires_at, '显式 expires_at=null 应清空过期时间');
+        $this->assertSame(['203.0.113.9'], $afterExpiryClear->ip_allowlist, '这一步不应动到 ip_allowlist');
+
+        $this->putJson("/api/v2/client/api-keys/{$key->id}", ['ip_allowlist' => []])->assertOk();
+        $this->assertNull($key->fresh()->ip_allowlist, '显式 ip_allowlist=[] 应清空白名单');
+    }
+
+    /**
+     * M10：改用 secret_hash 等值命中后，多把 enabled 密钥并存时仍要解析到正确的那一把。
+     */
+    public function test_resolve_selects_correct_key_among_many_enabled(): void
+    {
+        [$k1] = $this->createKey($this->createClientUser(), ['products' => 'read']);
+        [$k2, $s2] = $this->createKey($this->createClientUser(), ['products' => 'read']);
+        [$k3] = $this->createKey($this->createClientUser(), ['products' => 'read']);
+
+        $resolved = app(ApiKeyService::class)->resolve($s2);
+
+        $this->assertSame($k2->id, $resolved->id);
+        $this->assertNotSame($k1->id, $resolved->id);
+        $this->assertNotSame($k3->id, $resolved->id);
+    }
+
+    /**
+     * M10：把已有但从未被执行的 open_api.rate_limit 接上——超过阈值应 429。
+     *
+     * 限流跑在 api.key 认证之前，故未带令牌也会计数：阈值设 1 时，第 2 个请求就该被挡下，
+     * 走 ThrottleRequestsException 的统一中文 429（code=42900），而不是继续走到 401。
+     */
+    public function test_open_api_requests_are_rate_limited(): void
+    {
+        Setting::setValues('open_api', ['enabled' => '1', 'rate_limit' => '1']);
+
+        $this->getJson('/api/v2/open/products')->assertStatus(401);
+
+        $this->getJson('/api/v2/open/products')
+            ->assertStatus(429)
+            ->assertJsonPath('code', 42900);
+    }
 }


### PR DESCRIPTION
## 背景

延续上一轮后端审计的剩余项。这个 PR 收掉开放接口密钥认证入口上的 3 个问题（审计 **M10** 的两半 + **N4**），它们同属一条链路，一起改最内聚。

## 三处问题与修法

### M10-a 密钥校验全表扫描

`ApiKeyService::resolve()` 原先把**全表** enabled 密钥载入内存，再逐行 `hash_equals`：

```php
$candidate = ApiKey::query()
    ->where('status', ApiKey::STATUS_ENABLED)
    ->get()                       // ← 全表进内存
    ->first(fn ($key) => hash_equals($key->secret_hash, $this->hashSecret($secret)));
```

任意 Bearer 头即可触发这次 O(n) 全表加载 + 逐行实例化 ApiKey 模型，是未认证可达的 DoS 面。

**修法**：`hashSecret()` 是确定性的 `sha256(secret + app.key)`，同一明文恒映射到同一 hash，因此可直接按 `secret_hash` 等值命中 —— 这正是 **Laravel Sanctum** 校验 token 的做法（`findToken` 用 `where('token', hash('sha256', $plain))`）。配套新增 `secret_hash` 索引的迁移。

```php
$candidate = ApiKey::query()
    ->where('secret_hash', $this->hashSecret($secret))
    ->where('status', ApiKey::STATUS_ENABLED)
    ->first();
```

时序安全：攻击者提交的是明文 secret，要让 `secret_hash` 命中必须先知道 `app.key` 才能构造出目标 hash；数据库 B-tree 等值查找也不像逐字节 `memcmp` 那样按前缀短路。用普通 index 而非 unique：sha256 碰撞概率可忽略，但唯一约束会让极端情况下插入直接失败，校验侧配合 `status` 取首条即可。

### M10-b 限流配置从未生效

`open_api.rate_limit` 在后台**可读可写**（`OpenApiAdminController` 暴露 `rate_limit`，校验 `min:1,max:3600`，`OpenApiConfig::rateLimitPerMinute()` 默认 60），但**没有任何中间件执行它** —— 管理员设了限速，却是个摆设。

**修法**：在 `AppServiceProvider::boot()` 注册 `open-api` 限流器，把 `throttle:open-api` 挂到 `api/v2/open` 路由组：

```php
RateLimiter::for('open-api', function (Request $request) {
    $perMinute = app(OpenApiConfig::class)->rateLimitPerMinute();
    return Limit::perMinute($perMinute)->by((string) $request->ip());
});
```

按来源 IP 计数，因为限流跑在 `api.key` 认证**之前**（认证前拿不到密钥），而攻击面正是"任意 Bearer 头即可触发认证入口"，IP 恰是未认证攻击者唯一可计量的维度。阈值每请求从 settings 读，管理员改动即时生效。超限走既有 `ThrottleRequestsException` 的统一中文 429（`code=42900`）。

### N4 部分更新静默清空安全字段

`update()` 对 `expires_at` / `ip_allowlist` 用 `isset(...) ? ... : null`：

```php
'expires_at' => isset($payload['expires_at']) && ... ? $payload['expires_at'] : null,
'ip_allowlist' => isset($payload['ip_allowlist']) && ... ? array_values(...) : null,
```

`UpdateApiKeyRequest` 里这两项是 `nullable`（无 `sometimes`），实测证明**未提交的字段不会进 `validated()`**（见下）。于是只带 `{"name":"x"}` 的 PUT 传到 service 时 `$payload` 没有这两个键，`isset` 为 false → 被置成 **null**：密钥悄悄变成永不过期 + 不限 IP，等于拆掉两道安全控制。

验证时还发现这个 bug **比审计描述更严重**：因为是 `isset()?:null` 兜底，PUT **任何一个**字段都会连带把其它可空字段清空 —— 例如 PUT `{"expires_at": null}`（本意只清过期时间）会把 `ip_allowlist` 也一起清掉。

**修法**：逐字段 `array_key_exists` 守卫 —— 字段缺失=保留原值，字段显式存在（含 `null` / `[]` 的清空意图）=采纳。

```php
if (array_key_exists('expires_at', $payload)) {
    $expiresAt = $payload['expires_at'];
    $key->expires_at = ($expiresAt === '' || $expiresAt === null) ? null : $expiresAt;
}
```

修法基石经实测确认（纯 Validator 探针）：

| 场景 | `array_key_exists('expires_at', validated())` |
|---|---|
| 只传 `{"name":"x"}` | **false** → 保留原值 |
| 显式传 `{"expires_at": null}` | **true** → 采纳清空 |
| 显式传 `{"ip_allowlist": []}` | **true** → 采纳清空 |

## 数据库

新增迁移 `2026_08_29_000001_add_secret_hash_index_to_api_keys`，给 `secret_hash` 加普通索引。遵循本项目「数据库只新增、绝不删除对象」的铁律：`down()` **不** `dropIndex`（索引是纯性能结构、不承载数据，是否清理交由上游决定）；`up()` 先查 `information_schema` 幂等，重复执行不报 Duplicate key name。

## 验证

服务器隔离树 `/root/jwt-tree` + MySQL 5.7.44 沙箱 @3307 + 独立库 `idc_test_jwt`。

**① 充分复现（反向验证）** —— 保留新测试、把 3 个修复文件还原成基底版，证明测试确实抓得住 bug：

```
Tests: 15, Failures: 3  ← 未修复代码下，3 个用例转红
  RED: test_partial_update_preserves_expiry_and_ip_allowlist        （N4 主体）
  RED: test_explicit_values_can_still_clear_expiry_and_ip_allowlist （N4 连带清空）
  RED: test_open_api_requests_are_rate_limited                      （M10 限流从未生效）
```

**② 修复有效**：`ApiKeyTest` 15 tests / 53 assertions 全绿；`OpenApiFlowTest` 7 tests 全绿（既有流程未破坏）；迁移跑通、`secret_hash` 索引实测建成（BTREE，计数=1）。

**③ 不引入新 BUG（全量回归差分）**：

| | Tests | Assertions | 失败集合 |
|---|---|---|---|
| 基底 `edcdd50` | 1689 | 84842 | 96 条 |
| 本 PR | 1693 | 84858 | 96 条 |

- junit 失败集合逐条差分：**only-in-补丁 = 0**，only-in-基底 = 0。
- 差值恰为 **+4 用例 / +16 断言**，与新增测试完全对应，既有用例执行路径一条没变。
- 已核对基底轮 junit 确为纯净 `edcdd50`（`partial_update` 计数=0，不含任何新测试方法），差分不是"补丁比补丁"的假绿。

`pint` 对全部改动文件通过（`bootstrap/app.php` 的既有风格问题非本 PR 引入、未触碰）。

## 影响面

- 数据库：新增一个索引，无删除、无数据变更。
- 开放接口现在真正受 `open_api.rate_limit` 限流（默认 60/分钟/IP，后台可调至 3600）。对正常程序化调用足够宽松；这是把一个本就该生效的配置接上，不是新政策。
- 密钥部分更新的语义收紧为"只改传入的字段"，与直觉一致；显式清空仍可用。
