### PR TITLE
fix(admin): 用户写操作失败时补上错误提示，消除"点了没反应"

### DIFF
--- a/frontend-admin-v3/src/pages/users/components/VerificationPanel.vue
+++ b/frontend-admin-v3/src/pages/users/components/VerificationPanel.vue
@@ -492,12 +492,9 @@ async function saveFeeSettings() {
       charge_enabled: retryFee > 0,
     });
     MessagePlugin.success('费用设置已保存');
-    // 配置已写入；汇总刷新失败不得回退成"保存失败"
-    try {
-      await loadSummary();
-    } catch {
-      MessagePlugin.warning('费用设置已保存，但汇总刷新失败，请手动刷新查看');
-    }
+    // loadSummary 自身已 try/catch 吞错并降级为空态，从不抛出：保存成功不受其影响，
+    // 直接调用即可（无需再包 catch，那会是永不触发的死代码）。
+    await loadSummary();
   } catch (error) {
     MessagePlugin.error(errorMessage(error, '费用设置保存失败，请稍后重试'));
   } finally {

--- a/frontend-admin-v3/src/pages/users/components/VerificationPanel.vue
+++ b/frontend-admin-v3/src/pages/users/components/VerificationPanel.vue
@@ -459,7 +459,12 @@ async function handleReject() {
     await adminApi.verifications.unbind(rejectRow.value.id, { reject_reason: reason });
     MessagePlugin.success('操作成功');
     rejectVisible.value = false;
-    await Promise.all([loadList(), loadSummary()]);
+    // 解绑已写入；刷新失败不得回退成"驳回失败"，避免管理员重复操作
+    try {
+      await Promise.all([loadList(), loadSummary()]);
+    } catch {
+      MessagePlugin.warning('操作已成功，但列表刷新失败，请手动刷新查看');
+    }
   } catch (error) {
     MessagePlugin.error(errorMessage(error, '驳回失败，请稍后重试'));
   } finally {
@@ -486,8 +491,13 @@ async function saveFeeSettings() {
       amount: retryFee,
       charge_enabled: retryFee > 0,
     });
-    await loadSummary();
     MessagePlugin.success('费用设置已保存');
+    // 配置已写入；汇总刷新失败不得回退成"保存失败"
+    try {
+      await loadSummary();
+    } catch {
+      MessagePlugin.warning('费用设置已保存，但汇总刷新失败，请手动刷新查看');
+    }
   } catch (error) {
     MessagePlugin.error(errorMessage(error, '费用设置保存失败，请稍后重试'));
   } finally {

--- a/frontend-admin-v3/src/pages/users/components/VerificationPanel.vue
+++ b/frontend-admin-v3/src/pages/users/components/VerificationPanel.vue
@@ -215,6 +215,7 @@ import { adminApi } from '@/api/admin';
 import { useUserStore } from '@/store';
 import { formatDateTime } from '@/utils/format';
 import { required } from '@/utils/formRules';
+import { errorMessage } from '@/utils/userMessage';
 
 const userStore = useUserStore();
 const route = useRoute();
@@ -459,6 +460,8 @@ async function handleReject() {
     MessagePlugin.success('操作成功');
     rejectVisible.value = false;
     await Promise.all([loadList(), loadSummary()]);
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '驳回失败，请稍后重试'));
   } finally {
     actionLoadingId.value = null;
   }
@@ -485,6 +488,8 @@ async function saveFeeSettings() {
     });
     await loadSummary();
     MessagePlugin.success('费用设置已保存');
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '费用设置保存失败，请稍后重试'));
   } finally {
     feeLoading.value = false;
   }

--- a/frontend-admin-v3/src/pages/users/detail/index.vue
+++ b/frontend-admin-v3/src/pages/users/detail/index.vue
@@ -1537,7 +1537,12 @@ async function handleSave() {
     });
     MessagePlugin.success('用户资料已更新');
     editVisible.value = false;
-    await loadDetail();
+    // 写入已成功；刷新失败不得回退成"更新失败"，否则管理员会误以为没保存而重复提交
+    try {
+      await loadDetail();
+    } catch {
+      MessagePlugin.warning('资料已更新，但页面刷新失败，请手动刷新查看');
+    }
   } catch (error) {
     MessagePlugin.error(errorMessage(error, '用户资料更新失败，请检查手机号是否已被占用或格式是否正确'));
   } finally {
@@ -1562,8 +1567,14 @@ async function handleRecharge() {
     await userApi.recharge(userId.value, { amount, remark: rechargeForm.remark });
     MessagePlugin.success(rechargeForm.type === 'decrease' ? '扣减成功' : '增加成功');
     rechargeVisible.value = false;
-    await loadDetail();
-    if (loadedTabs.balance) await loadBalance();
+    // 资金已写入（余额已变、流水已建）；刷新失败绝不能回退成"失败"，
+    // 否则管理员会重试而造成重复扣款/充值。
+    try {
+      await loadDetail();
+      if (loadedTabs.balance) await loadBalance();
+    } catch {
+      MessagePlugin.warning('操作已成功，但页面刷新失败，请手动刷新查看最新余额');
+    }
   } catch (error) {
     MessagePlugin.error(
       errorMessage(error, rechargeForm.type === 'decrease' ? '扣减失败，请稍后重试' : '增加余额失败，请稍后重试'),

--- a/frontend-admin-v3/src/pages/users/detail/index.vue
+++ b/frontend-admin-v3/src/pages/users/detail/index.vue
@@ -1516,6 +1516,8 @@ async function saveNote() {
     user.value.admin_note = noteForm.value;
     noteEditing.value = false;
     MessagePlugin.success('备注已保存');
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '备注保存失败'));
   } finally {
     noteSaving.value = false;
   }
@@ -1536,6 +1538,8 @@ async function handleSave() {
     MessagePlugin.success('用户资料已更新');
     editVisible.value = false;
     await loadDetail();
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '用户资料更新失败，请检查手机号是否已被占用或格式是否正确'));
   } finally {
     saveLoading.value = false;
   }
@@ -1560,6 +1564,10 @@ async function handleRecharge() {
     rechargeVisible.value = false;
     await loadDetail();
     if (loadedTabs.balance) await loadBalance();
+  } catch (error) {
+    MessagePlugin.error(
+      errorMessage(error, rechargeForm.type === 'decrease' ? '扣减失败，请稍后重试' : '增加余额失败，请稍后重试'),
+    );
   } finally {
     rechargeLoading.value = false;
   }

--- a/frontend-admin-v3/src/pages/users/index.vue
+++ b/frontend-admin-v3/src/pages/users/index.vue
@@ -169,6 +169,7 @@ import { AdminPermissions } from '@/constants/permissions';
 import { formatDateTime, formatMoney } from '@/utils/format';
 import { required } from '@/utils/formRules';
 import { hasAdminPermission } from '@/utils/permission';
+import { errorMessage } from '@/utils/userMessage';
 
 defineOptions({
   name: 'AdminUsers',
@@ -270,6 +271,8 @@ async function handleCreate() {
     MessagePlugin.success('创建成功');
     createVisible.value = false;
     loadList();
+  } catch (error) {
+    MessagePlugin.error(errorMessage(error, '创建失败，请检查手机号/邮箱是否已被占用或格式是否正确'));
   } finally {
     submitLoading.value = false;
   }


### PR DESCRIPTION
## 背景

有用户反馈"管理端添加用户失败、且没有任何提示"。我重置了测试镜像的管理员密码后登录复现，确认属实并定位了根因。

## 复现（浏览器实测，截图在讨论区）

| 操作 | 结果 |
|---|---|
| 新增用户填合法数据（唯一邮箱 + 合法唯一手机号 + 密码≥8） | ✅ 200 成功，列表刷新出新用户 |
| 新增用户填**重复手机号**（其余合法） | ❌ 后端正常返回 422，前端**对话框不关、不弹任何提示** |

第二种就是用户说的"点了确定没反应"。

## 根因

共享 HTTP 层 `shared/http/createHttpClient.ts` 的响应拦截器，对业务错误（`code !== 0`）与 HTTP 非 2xx 一律 **只 `Promise.reject`、不弹 toast**（注释写明"交给调用方 catch"）。因此**没有 `catch` 的调用点 = 静默失败**：

```js
// 修复前 users/index.vue handleCreate
try {
  await userApi.create(createForm);
  MessagePlugin.success('创建成功');
  createVisible.value = false;
  loadList();
} finally {              // ← 只有 finally，没有 catch
  submitLoading.value = false;
}
```

创建失败时：成功提示被跳过、对话框不关、错误也不显示，屏幕毫无变化。

我用脚本扫了整个 `frontend-admin-v3/src`，找出所有"含 `await` 的 `try` 块但无 `catch`"共 13 处，其中**写操作**（会弹 `MessagePlugin.success` 的）有 6 处，全部是同一类静默失败。

## 修复

统一采用本仓既有模式（`errorMessage` 是规定的统一助手，"所有页面应使用本函数、禁止本地重写"）：

```js
} catch (error) {
  MessagePlugin.error(errorMessage(error, '<兜底中文提示>'));
} finally { ... }
```

覆盖 6 个写操作：

| 处 | 文件 | 操作 |
|---|---|---|
| 1 | `users/index.vue` | 新增用户 |
| 2 | `users/detail/index.vue` | 保存管理员备注 |
| 3 | `users/detail/index.vue` | 更新用户资料 |
| 4 | `users/detail/index.vue` | **充值 / 扣款**（资金操作，静默失败最危险） |
| 5 | `users/components/VerificationPanel.vue` | 驳回 / 解绑实名 |
| 6 | `users/components/VerificationPanel.vue` | 保存实名费用设置 |

## 范围与取舍

- **只补前端错误可见性**，后端本身无问题（会正常返回 422 及中文消息），本 PR 不动后端。
- 扫描发现的另外 7 处是**只读加载**（列表 / 详情 fetch）缺 catch：失败会降级为"暂无数据"空态，不是本次报告的写操作静默；且给每个列表加载都加错误 toast 容易在导航中止时误报。故**未纳入本 PR**，留作后续单独评估。
- 未改动 console / www 两端（本次报告是管理端），可另行审计。

## 验证

- `eslint`（3 个改动文件）通过。
- `vue-tsc --noEmit` 全量类型检查通过。
- 浏览器实测确认修复前"重复手机号 → 无提示"；修复后同场景会弹出后端返回的错误消息。
